### PR TITLE
feat: standardize z-index and HUD variables

### DIFF
--- a/src/components/live/FloatingAssistant.tsx
+++ b/src/components/live/FloatingAssistant.tsx
@@ -88,7 +88,7 @@ export function FloatingAssistant({ task, onUpdated }: { task: Task | null; onUp
       <button
         aria-label="Open assistant chat"
         onClick={() => setOpen(true)}
-        className="fixed z-[100] w-14 h-14 rounded-full glass-panel elev grid place-items-center hover-scale smooth"
+        className="fixed z-[var(--z-toast)] w-14 h-14 rounded-full glass-panel elev grid place-items-center hover-scale smooth"
         style={{
           right: 'calc(env(safe-area-inset-right) + 12px)',
           bottom: 'calc(env(safe-area-inset-bottom) + var(--hud-h, 96px) + var(--hud-gap, 12px) + 12px)'
@@ -98,7 +98,7 @@ export function FloatingAssistant({ task, onUpdated }: { task: Task | null; onUp
       </button>
 
       <Drawer open={open} onOpenChange={setOpen} shouldScaleBackground>
-        <DrawerContent className="p-0 z-[100]" style={{ paddingBottom: 'calc(env(safe-area-inset-bottom) + var(--hud-h, 96px) + var(--hud-gap, 12px))' }}>
+        <DrawerContent className="p-0 z-[var(--z-modal)]" style={{ paddingBottom: 'calc(env(safe-area-inset-bottom) + var(--hud-h, 96px) + var(--hud-gap, 12px))' }}>
           <DrawerHeader className="p-3 border-b">
             <div className="flex items-center justify-between">
               <DrawerTitle>Assistant</DrawerTitle>

--- a/src/components/mindworld/HubScene.tsx
+++ b/src/components/mindworld/HubScene.tsx
@@ -50,7 +50,7 @@ export default function HubScene({ children }: PropsWithChildren) {
       <div className="absolute inset-0 world-particles pointer-events-none" aria-hidden />
 
       {/* Content overlay */}
-      <div className="relative z-10 w-full h-full" style={{ paddingBottom: 'var(--hud-height)' }}>{children}</div>
+      <div className="relative z-[var(--z-content)] w-full h-full" style={{ paddingBottom: 'var(--hud-h)' }}>{children}</div>
     </div>
   );
 }

--- a/src/game/hud/HUDBar.tsx
+++ b/src/game/hud/HUDBar.tsx
@@ -21,9 +21,9 @@ export default function HUDBar() {
   }, [run])
 
   return (
-    <div className="pointer-events-auto fixed inset-x-0 bottom-0 z-40">
+    <div className="pointer-events-auto fixed inset-x-0 bottom-0 z-[var(--z-hud)]">
       {/* HUD shelf with divider line */}
-      <div className="w-full" style={{ height: 'var(--hud-height)' }}>
+      <div className="w-full" style={{ height: 'var(--hud-h)' }}>
         <div className="absolute top-0 left-0 right-0 h-px bg-border/80" role="separator" aria-hidden />
         <div className="absolute inset-x-0 bottom-2 flex justify-center pb-safe">
           <div className="hud-shell max-w-[1200px] w-[96%]">

--- a/src/index.css
+++ b/src/index.css
@@ -66,6 +66,18 @@ All colors MUST be HSL.
 
     /* Motion */
     --transition-smooth: all 300ms cubic-bezier(0.22, 1, 0.36, 1);
+
+    /* Layering */
+    --z-bg: 0;
+    --z-content: 10;
+    --z-hud: 40;
+    --z-modal: 60;
+    --z-toast: 100;
+
+    /* HUD */
+    --hud-h: 128px;            /* desktop HUD height */
+    --hud-h-mobile: 164px;     /* mobile/two-line HUD height */
+    --hud-gap: 12px;           /* gap above HUD (the “white line” gutter) */
   }
 
   .light {
@@ -165,6 +177,14 @@ All colors MUST be HSL.
   .story-link:hover::after {
     transform: scaleX(1);
     transform-origin: bottom left;
+  }
+
+  .min-h-svh {
+    min-height: 100svh;
+  }
+
+  .os-bg {
+    background-color: hsl(var(--background));
   }
 }
 
@@ -366,9 +386,6 @@ All colors MUST be HSL.
 
 /* HUD tokens and utilities */
 :root{
-  --hud-h: 128px;          /* desktop HUD height */
-  --hud-h-sm: 164px;       /* mobile/two-line HUD height */
-  --hud-gap: 12px;         /* gap above HUD (the “white line” gutter) */
   --hud-radius: 22px;
   --hud-glow: 0 0% 100% / 0.35;
   --hud-border: 0 0% 100% / 0.14;
@@ -416,7 +433,7 @@ All colors MUST be HSL.
 
 /* responsive tokens */
 @media (max-width: 768px){
-  :root { --hud-h: var(--hud-h-sm); }
+  :root { --hud-h: var(--hud-h-mobile); }
 }
 
 /* Quick slot glyphs */

--- a/src/styles/vars.css
+++ b/src/styles/vars.css
@@ -5,6 +5,4 @@
   --fab-size: 56px;    /* new task */
   --gap: 12px;
   --compass-bottom: 12px;
-  /* Reserved height for the bottom HUD shelf */
-  --hud-height: 112px;
 }


### PR DESCRIPTION
## Summary
- add z-index tokens and HUD sizing variables to `:root`
- define `.min-h-svh` and `.os-bg` utility classes
- drop legacy HUD variable names in favor of `--hud-h` and `--hud-h-mobile`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 197 errors, 19 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689802884a108326950ef39fce766a4c