### PR TITLE
feat: add mobile hud collapse

### DIFF
--- a/src/components/hud/GameHUD.tsx
+++ b/src/components/hud/GameHUD.tsx
@@ -22,18 +22,8 @@ export function GameHUD() {
   };
 
   // Mobile collapse state
-  const [isMobile, setIsMobile] = useState(() => window.innerWidth <= 768);
-  const [expanded, setExpanded] = useState(() => !(window.innerWidth <= 768));
-
-  useEffect(() => {
-    const onResize = () => setIsMobile(window.innerWidth <= 768);
-    window.addEventListener('resize', onResize);
-    return () => window.removeEventListener('resize', onResize);
-  }, []);
-
-  useEffect(() => {
-    setExpanded(!isMobile);
-  }, [isMobile]);
+  const isMobile = window.innerWidth <= 768;
+  const [expanded, setExpanded] = useState(() => !isMobile);
 
   useEffect(() => {
     const h = expanded ? (isMobile ? 148 : 132) : (isMobile ? 92 : 88);


### PR DESCRIPTION
## Summary
- simplify mobile HUD logic by deriving `isMobile` from `window.innerWidth`
- default HUD to collapsed on small screens and allow toggling via a mobile-only button
- update `--hud-h` CSS variable based on mobile and expanded state

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint errors)

------
https://chatgpt.com/codex/tasks/task_e_68980f9bc53c8326a259f804a4555706