### PR TITLE
Refactor MOS event bus for overlays and HUD

### DIFF
--- a/src/agent/tool-impl.ts
+++ b/src/agent/tool-impl.ts
@@ -39,15 +39,15 @@ export const ToolImpl = {
 
   async start_focus({ minutes = 25, hypnosis }: { minutes?: number; hypnosis?: 'focus' | 'calm' | 'confidence' | null }) {
     if (hypnosis) {
-      document.dispatchEvent(new CustomEvent('mos:startHypnosis'));
+      window.dispatchEvent(new CustomEvent('mos', { detail: { type: 'startHypnosis' } }));
     }
-    document.dispatchEvent(new CustomEvent('mos:startFocus'));
+    window.dispatchEvent(new CustomEvent('mos', { detail: { type: 'startFocus' } }));
     toast({ title: `Focus started`, description: `${minutes} minutes${hypnosis ? ` · with ${hypnosis}` : ''}` });
     return { ok: true };
   },
 
   async start_hypnosis({ mode, duration }: { mode: 'focus' | 'calm' | 'confidence' | 'reset'; duration?: number }) {
-    document.dispatchEvent(new CustomEvent('mos:startHypnosis'));
+    window.dispatchEvent(new CustomEvent('mos', { detail: { type: 'startHypnosis' } }));
     toast({ title: `Hypnosis: ${mode}`, description: duration ? `${duration}s` : undefined });
     return { ok: true };
   },

--- a/src/components/agent/AgentPanel.tsx
+++ b/src/components/agent/AgentPanel.tsx
@@ -57,7 +57,12 @@ export default function AgentPanel() {
             >
               Hold to Talk
             </Button>
-            <Button variant="secondary" onClick={() => document.dispatchEvent(new CustomEvent('mos:openAgent'))}>Open</Button>
+            <Button
+              variant="secondary"
+              onClick={() => window.dispatchEvent(new CustomEvent('mos', { detail: { type: 'openAgent' } }))}
+            >
+              Open
+            </Button>
           </div>
         </div>
       </section>

--- a/src/components/hud/GameHUD.tsx
+++ b/src/components/hud/GameHUD.tsx
@@ -4,22 +4,13 @@ import { useGameStore } from "@/game/store";
 import { quickSlots } from "@/game/hud/hud.data";
 import { EvolvingSphere } from "@/components/effects/EvolvingSphere";
 import { Mic, ChevronDown, ChevronUp } from "lucide-react";
-import { useViewNav } from "@/state/view";
-import { Link, useNavigate } from "react-router-dom";
-import { views } from "@/views/registry";
+
+function fire(type: string, payload?: any) {
+  window.dispatchEvent(new CustomEvent('mos', { detail: { type, payload } }));
+}
 
 export function GameHUD() {
   const stats = useGameStore((s) => s.stats);
-  const open = useViewNav();
-  const navigate = useNavigate();
-  const actionToView: Record<string, any> = {
-    startFocus: 'focus',
-    startHypnosis: 'hypno',
-    voiceNote: 'voice',
-    addNote: 'notes',
-    openAnalyze: 'analyze',
-    openMap: 'portal',
-  };
 
   // Mobile collapse state
   const [isMobile, setIsMobile] = useState(() => window.innerWidth <= 768);
@@ -50,12 +41,12 @@ export function GameHUD() {
       const n = Number(e.key);
       if (n >= 1 && n <= 6) {
         const slot = quickSlots[n - 1];
-        if (slot) open(actionToView[slot.action]);
+        if (slot) fire(slot.action);
       }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [open]);
+  }, []);
 
   return (
     <div
@@ -84,42 +75,35 @@ export function GameHUD() {
 
           {/* Actions (scroll on small, wrap/justify on desktop) */}
           <ul className="hud-actions flex gap-2 ml-auto overflow-x-auto flex-nowrap scroll-smooth snap-x snap-mandatory md:overflow-visible md:flex-wrap md:justify-end md:ml-auto">
-            {quickSlots.map((a) => {
-              const viewId = actionToView[a.action];
-              return (
-                <li key={a.id} className="snap-start">
-                  <Link
-                    to={(viewId && views.find((v) => v.id === viewId)?.path) || '/app'}
-                    className="action-chip"
-                    aria-label={a.label}
-                    title={a.label}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      if (!viewId) return;
-                      const path = views.find((v) => v.id === viewId)?.path;
-                      if (path) navigate(path);
-                    }}
-                  >
-                    {a.icon ? (
-                      <i className={cn("hud-glyph", a.icon)} />
-                    ) : (
-                      <span className="text-sm font-medium">{a.key}</span>
-                    )}
-                    <span className="hidden sm:inline text-sm">{a.label}</span>
-                  </Link>
-                </li>
-              );
-            })}
+            {quickSlots.map((a) => (
+              <li key={a.id} className="snap-start">
+                <button
+                  type="button"
+                  className="action-chip"
+                  aria-label={a.label}
+                  title={a.label}
+                  onClick={() => fire(a.action)}
+                >
+                  {a.icon ? (
+                    <i className={cn('hud-glyph', a.icon)} />
+                  ) : (
+                    <span className="text-sm font-medium">{a.key}</span>
+                  )}
+                  <span className="hidden sm:inline text-sm">{a.label}</span>
+                </button>
+              </li>
+            ))}
             <li className="snap-start">
-              <Link
-                to={views.find((v) => v.id === 'agent')?.path || '/app/agent'}
+              <button
+                type="button"
                 className="action-chip mic"
                 aria-label="Open Aurora Agent"
                 title="Aurora Agent"
+                onClick={() => fire('openAgent')}
               >
                 <Mic className="w-4 h-4" />
                 <span className="hidden sm:inline text-sm">Agent</span>
-              </Link>
+              </button>
             </li>
           </ul>
         </div>

--- a/src/components/mindworld/MindWorldDashboard.tsx
+++ b/src/components/mindworld/MindWorldDashboard.tsx
@@ -27,9 +27,13 @@ export default function MindWorldDashboard() {
 
   // Toggle joystick via global event and persist
   useEffect(() => {
-    const onToggle = () => setJoyEnabled((v) => !v);
-    document.addEventListener('mos:toggleJoystick' as any, onToggle as any);
-    return () => document.removeEventListener('mos:toggleJoystick' as any, onToggle as any);
+    const onMos = (e: any) => {
+      if (e.detail?.type === 'toggleJoystick') {
+        setJoyEnabled((v) => !v);
+      }
+    };
+    window.addEventListener('mos', onMos as any);
+    return () => window.removeEventListener('mos', onMos as any);
   }, [setJoyEnabled]);
 
   // Keyboard controls (desktop)
@@ -62,28 +66,17 @@ export default function MindWorldDashboard() {
   // Listen to global HUD quick actions and open overlays accordingly + quests/XP
   useEffect(() => {
     const set = (id: OverlayId | null) => setOverlay(id);
-    const onFocus = () => { set('focus'); completeQuest('pick-focus'); awardXP(REWARDS.completeQuest); };
-    const onHypno = () => { set('mentor'); completeQuest('start-hypno'); awardXP(REWARDS.completeQuest); };
-    const onVoice = () => { set('library'); completeQuest('record-voice'); awardXP(REWARDS.completeQuest); };
-    const onNote = () => { set('library'); completeQuest('add-note'); awardXP(REWARDS.completeQuest); };
-    const onAnalyze = () => { set('analyze'); completeQuest('open-analyze'); awardXP(REWARDS.completeQuest); };
-    const onMap = () => { document.dispatchEvent(new CustomEvent('open-fast-travel')); };
-
-    document.addEventListener('mos:startFocus' as any, onFocus as any);
-    document.addEventListener('mos:startHypnosis' as any, onHypno as any);
-    document.addEventListener('mos:voiceNote' as any, onVoice as any);
-    document.addEventListener('mos:addNote' as any, onNote as any);
-    document.addEventListener('mos:openAnalyze' as any, onAnalyze as any);
-    document.addEventListener('mos:openMap' as any, onMap as any);
-
-    return () => {
-      document.removeEventListener('mos:startFocus' as any, onFocus as any);
-      document.removeEventListener('mos:startHypnosis' as any, onHypno as any);
-      document.removeEventListener('mos:voiceNote' as any, onVoice as any);
-      document.removeEventListener('mos:addNote' as any, onNote as any);
-      document.removeEventListener('mos:openAnalyze' as any, onAnalyze as any);
-      document.removeEventListener('mos:openMap' as any, onMap as any);
+    const onMos = (e: any) => {
+      const t = e.detail?.type;
+      if (t === 'startFocus') { set('focus'); completeQuest('pick-focus'); awardXP(REWARDS.completeQuest); }
+      if (t === 'startHypnosis') { set('mentor'); completeQuest('start-hypno'); awardXP(REWARDS.completeQuest); }
+      if (t === 'voiceNote') { set('library'); completeQuest('record-voice'); awardXP(REWARDS.completeQuest); }
+      if (t === 'addNote') { set('library'); completeQuest('add-note'); awardXP(REWARDS.completeQuest); }
+      if (t === 'openAnalyze') { set('analyze'); completeQuest('open-analyze'); awardXP(REWARDS.completeQuest); }
+      if (t === 'openMap') { document.dispatchEvent(new CustomEvent('open-fast-travel')); }
     };
+    window.addEventListener('mos', onMos as any);
+    return () => window.removeEventListener('mos', onMos as any);
   }, [awardXP, completeQuest]);
 
   // Close overlay with Escape key

--- a/src/components/overlays/FastTravel.tsx
+++ b/src/components/overlays/FastTravel.tsx
@@ -1,11 +1,15 @@
 import { useEffect, useState } from "react";
 
+const fire = (type: string, payload?: any) => {
+  window.dispatchEvent(new CustomEvent('mos', { detail: { type, payload } }));
+};
+
 const ZONES = [
-  { key: 'focus', label: 'Training Grounds', event: 'mos:startFocus' },
+  { key: 'focus', label: 'Training Grounds', type: 'startFocus' },
   { key: 'hypno', label: 'Hypno Temple', event: 'open-hypno-panel' },
-  { key: 'voice', label: 'Sound Studio', event: 'mos:voiceNote' },
-  { key: 'notes', label: 'Idea Forest', event: 'mos:addNote' },
-  { key: 'analyze', label: 'Arena', event: 'mos:openAnalyze' },
+  { key: 'voice', label: 'Sound Studio', type: 'voiceNote' },
+  { key: 'notes', label: 'Idea Forest', type: 'addNote' },
+  { key: 'analyze', label: 'Arena', type: 'openAnalyze' },
 ];
 
 export default function FastTravel() {
@@ -19,9 +23,10 @@ export default function FastTravel() {
 
   if (!open) return null;
 
-  const onSelect = (eventName: string) => {
+  const onSelect = (z: { type?: string; event?: string }) => {
     setOpen(false);
-    document.dispatchEvent(new CustomEvent(eventName));
+    if (z.type) fire(z.type);
+    else if (z.event) window.dispatchEvent(new CustomEvent(z.event));
   };
 
   return (
@@ -34,18 +39,18 @@ export default function FastTravel() {
         <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mt-4">
           {ZONES.map(z => (
             <button key={z.key}
-              onClick={() => onSelect(z.event)}
+              onClick={() => onSelect(z)}
               className="rounded-xl p-3 bg-white/10 hover:bg-white/15 text-left transition-colors"
             >
               <div className="font-medium">{z.label}</div>
               <div className="text-xs text-muted-foreground">{z.key}</div>
             </button>
           ))}
-          <button className="rounded-xl p-3 bg-white/10 hover:bg-white/15 text-left" onClick={() => onSelect('mos:openMap')}>
+          <button className="rounded-xl p-3 bg-white/10 hover:bg-white/15 text-left" onClick={() => onSelect({ type: 'openMap' })}>
             <div className="font-medium">Control</div>
             <div className="text-xs text-muted-foreground">Roadmaps & Tasks</div>
           </button>
-          <button className="rounded-xl p-3 bg-white/10 hover:bg-white/15 text-left" onClick={() => onSelect('mos:voiceNote')}>
+          <button className="rounded-xl p-3 bg-white/10 hover:bg-white/15 text-left" onClick={() => onSelect({ type: 'voiceNote' })}>
             <div className="font-medium">Archive</div>
             <div className="text-xs text-muted-foreground">Notes & Audio</div>
           </button>

--- a/src/game/hud/HUDBar.tsx
+++ b/src/game/hud/HUDBar.tsx
@@ -41,7 +41,7 @@ export default function HUDBar() {
                 <button className="hud-icon bag hover-scale smooth hover:brightness-110 active:scale-95" aria-label="Bag"/>
                 <button className="hud-icon map hover-scale smooth hover:brightness-110 active:scale-95" aria-label="Map" onClick={()=>run('openMap' as any)}/>
                 <button className="hud-icon chat hover-scale smooth hover:brightness-110 active:scale-95" aria-label="Chat"/>
-                <button className="hud-icon stick hover-scale smooth hover:brightness-110 active:scale-95" aria-label="Joystick" onClick={() => document.dispatchEvent(new CustomEvent('mos:toggleJoystick'))}/>
+                <button className="hud-icon stick hover-scale smooth hover:brightness-110 active:scale-95" aria-label="Joystick" onClick={() => window.dispatchEvent(new CustomEvent('mos', { detail: { type: 'toggleJoystick' } }))}/>
               </div>
 
               {/* Quick Slots: full width on small (second line), inline on large */}

--- a/src/game/hud/useHUDActions.ts
+++ b/src/game/hud/useHUDActions.ts
@@ -3,15 +3,15 @@ import type { QuickActionKey } from './hud.data'
 export function useHUDActions() {
   const run = (a: QuickActionKey) => {
     const eventMap: Record<QuickActionKey, string> = {
-      startFocus: 'mos:startFocus',
-      startHypnosis: 'mos:startHypnosis',
-      voiceNote: 'mos:voiceNote',
-      addNote: 'mos:addNote',
-      openAnalyze: 'mos:openAnalyze',
-      openMap: 'mos:openMap',
+      startFocus: 'startFocus',
+      startHypnosis: 'startHypnosis',
+      voiceNote: 'voiceNote',
+      addNote: 'addNote',
+      openAnalyze: 'openAnalyze',
+      openMap: 'openMap',
     };
     const name = eventMap[a];
-    document.dispatchEvent(new CustomEvent(name));
+    window.dispatchEvent(new CustomEvent('mos', { detail: { type: name } }));
   }
   return { run }
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -448,20 +448,18 @@ useEffect(() => {
   };
   const onMap = () => { window.dispatchEvent(new CustomEvent('open-fast-travel')); };
 
-  document.addEventListener('mos:startFocus' as any, onFocus as any);
-  document.addEventListener('mos:startHypnosis' as any, onHypno as any);
-  document.addEventListener('mos:voiceNote' as any, onVoice as any);
-  document.addEventListener('mos:addNote' as any, onNote as any);
-  document.addEventListener('mos:openAnalyze' as any, onAnalyze as any);
-  document.addEventListener('mos:openMap' as any, onMap as any);
-
+  const onMos = (e: any) => {
+    const t = e.detail?.type;
+    if (t === 'startFocus') onFocus();
+    if (t === 'startHypnosis') onHypno();
+    if (t === 'voiceNote') onVoice();
+    if (t === 'addNote') onNote();
+    if (t === 'openAnalyze') onAnalyze();
+    if (t === 'openMap') onMap();
+  };
+  window.addEventListener('mos', onMos as any);
   return () => {
-    document.removeEventListener('mos:startFocus' as any, onFocus as any);
-    document.removeEventListener('mos:startHypnosis' as any, onHypno as any);
-    document.removeEventListener('mos:voiceNote' as any, onVoice as any);
-    document.removeEventListener('mos:addNote' as any, onNote as any);
-    document.removeEventListener('mos:openAnalyze' as any, onAnalyze as any);
-    document.removeEventListener('mos:openMap' as any, onMap as any);
+    window.removeEventListener('mos', onMos as any);
   };
 }, [gotoPanel, completeQuest, awardXP, incStreak]);
 

--- a/src/routes/browser/BrowserShell.tsx
+++ b/src/routes/browser/BrowserShell.tsx
@@ -32,21 +32,15 @@ export default function BrowserShell() {
 
   // Handle quick actions from HUD
   useEffect(() => {
-    const map: Record<string, OverlayId> = {
-      "mos:startFocus": "focus",
-      "mos:startHypnosis": "mentor",
-      "mos:openAnalyze": "analyze",
-      "mos:openMap": "library",
-      "mos:openAgent": "agent",
-    } as const;
-    const handler = (e: Event) => {
-      const id = map[(e as CustomEvent).type];
-      if (id) setOverlay(id);
+    const onMos = (e: any) => {
+      const t = e.detail?.type;
+      if (t === 'startFocus') setOverlay('focus');
+      if (t === 'startHypnosis') setOverlay('mentor');
+      if (t === 'openAnalyze') setOverlay('analyze');
+      if (t === 'openAgent') setOverlay('agent');
     };
-    Object.keys(map).forEach((name) => document.addEventListener(name, handler as any));
-    return () => {
-      Object.keys(map).forEach((name) => document.removeEventListener(name, handler as any));
-    };
+    window.addEventListener('mos', onMos as any);
+    return () => window.removeEventListener('mos', onMos as any);
   }, []);
 
   // esc to close overlays


### PR DESCRIPTION
## Summary
- unify overlay event handling behind a single `mos` custom event
- add `fire()` helper to HUD and migrate quick-slot and agent actions to it
- replace legacy `mos:*` listeners and direct navigation with new event bus across app

## Testing
- `npm run lint` *(fails: Unexpected any, no-empty, no-require-imports)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68981019f7888326a6e09351583ff8df