### PR TITLE
Ensure top-level screens use relative min-h-svh backgrounds

### DIFF
--- a/src/game/path/GameHome.tsx
+++ b/src/game/path/GameHome.tsx
@@ -10,10 +10,9 @@ export default function GameHome({
   onNavSelect?: (key: 'home' | 'map' | 'live' | 'rank' | 'aurora') => void;
 }) {
   return (
-    <div className="min-h-screen bg-[hsl(var(--path-bg))] text-white relative overflow-hidden">
-      
+    <div className="relative min-h-svh text-white overflow-hidden">
+      <div className="os-bg bg-[hsl(var(--path-bg))]" />
       <LessonPath onNodeClick={onNodeClick} />
-      
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -184,6 +184,9 @@ All colors MUST be HSL.
   }
 
   .os-bg {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
     background-color: hsl(var(--background));
   }
 }

--- a/src/nodes/AnalyzeRunner.tsx
+++ b/src/nodes/AnalyzeRunner.tsx
@@ -14,7 +14,8 @@ export default function AnalyzeRunner({ node, onExit }: Props) {
   }, [notes]);
 
   return (
-    <main className="min-h-screen px-4 pt-10 pb-28 max-w-[760px] mx-auto">
+    <main className="relative min-h-svh px-4 pt-10 pb-28 max-w-[760px] mx-auto">
+      <div className="os-bg" />
       <h1 className="text-2xl font-semibold mb-2">{node.label}</h1>
       <p className="opacity-80 mb-6">Lightweight AI analysis (stub)</p>
 

--- a/src/nodes/BrowserRunner.tsx
+++ b/src/nodes/BrowserRunner.tsx
@@ -20,7 +20,8 @@ export default function BrowserRunner({ node, onExit }: Props) {
   }, [url]);
 
   return (
-    <main className="min-h-screen px-4 pt-6 pb-28">
+    <main className="relative min-h-svh px-4 pt-6 pb-28">
+      <div className="os-bg" />
       <div className="flex items-center gap-2 mb-3">
         <input
           className="w-full rounded-md bg-white/5 border border-white/10 px-3 py-2 outline-none"

--- a/src/nodes/CoachRunner.tsx
+++ b/src/nodes/CoachRunner.tsx
@@ -26,7 +26,8 @@ export default function CoachRunner({ node, onExit }: Props) {
   const stop = () => (window as any).__coachAgent?.stopPTT();
 
   return (
-    <main className="min-h-screen px-4 pt-10 pb-28 max-w-[760px] mx-auto">
+    <main className="relative min-h-svh px-4 pt-10 pb-28 max-w-[760px] mx-auto">
+      <div className="os-bg" />
       <h1 className="text-2xl font-semibold mb-2">{node.label}</h1>
       <p className="opacity-80 mb-6">Tell me what you’re working on. I’ll tailor your next steps.</p>
 

--- a/src/nodes/FocusRunner.tsx
+++ b/src/nodes/FocusRunner.tsx
@@ -45,7 +45,8 @@ export default function FocusRunner({ node, onExit }: Props) {
   const secs = Math.floor(remaining % 60).toString().padStart(2, "0");
 
   return (
-    <main className="min-h-screen px-4 pt-10 pb-28 grid place-items-center text-center">
+    <main className="relative min-h-svh px-4 pt-10 pb-28 grid place-items-center text-center">
+      <div className="os-bg" />
       <div>
         <h1 className="text-2xl font-semibold mb-2">{node.label}</h1>
         <p className="opacity-80 mb-6">Deep focus timer</p>

--- a/src/nodes/HypnosisRunner.tsx
+++ b/src/nodes/HypnosisRunner.tsx
@@ -69,7 +69,8 @@ export default function HypnosisRunner({ node, onExit }: Props) {
   const pct = Math.min(100, Math.round((elapsed / duration) * 100));
 
   return (
-    <main className="min-h-screen px-4 pt-10 pb-28 grid place-items-center text-center">
+    <main className="relative min-h-svh px-4 pt-10 pb-28 grid place-items-center text-center">
+      <div className="os-bg" />
       <div>
         <h1 className="text-2xl font-semibold mb-2">{node.label}</h1>
         <p className="opacity-80 mb-6">Guided hypnosis • {duration}s</p>

--- a/src/nodes/NoteRunner.tsx
+++ b/src/nodes/NoteRunner.tsx
@@ -14,7 +14,8 @@ export default function NoteRunner({ node, onExit }: Props) {
   };
 
   return (
-    <main className="min-h-screen px-4 pt-10 pb-28 max-w-[760px] mx-auto">
+    <main className="relative min-h-svh px-4 pt-10 pb-28 max-w-[760px] mx-auto">
+      <div className="os-bg" />
       <h1 className="text-2xl font-semibold mb-2">{node.label}</h1>
       <p className="opacity-80 mb-6">Quick note capture</p>
 

--- a/src/nodes/RewardRunner.tsx
+++ b/src/nodes/RewardRunner.tsx
@@ -13,7 +13,8 @@ export default function RewardRunner({ node, onExit }: Props) {
   }, [awardXP, complete, node.id]);
 
   return (
-    <main className="min-h-screen px-4 pt-10 pb-28 grid place-items-center text-center">
+    <main className="relative min-h-svh px-4 pt-10 pb-28 grid place-items-center text-center">
+      <div className="os-bg" />
       <div>
         <h1 className="text-2xl font-semibold mb-2">{node.label}</h1>
         <p className="opacity-80 mb-6">You earned +20 XP</p>

--- a/src/pages/AgentRunner.tsx
+++ b/src/pages/AgentRunner.tsx
@@ -21,7 +21,8 @@ export default function AgentRunner() {
   }, []);
 
   return (
-    <main className="min-h-screen px-4 pt-10 pb-28 max-w-[760px] mx-auto">
+    <main className="relative min-h-svh px-4 pt-10 pb-28 max-w-[760px] mx-auto">
+      <div className="os-bg" />
       <h1 className="text-2xl font-semibold mb-2">Aurora Agent</h1>
       <p className="opacity-80 mb-6">Push-to-talk and simple tools</p>
 

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -52,14 +52,16 @@ const AuthPage = () => {
 
   if (initializing || user) {
     return (
-      <div className="w-screen h-screen grid place-items-center">
+      <div className="relative min-h-svh w-screen grid place-items-center">
+        <div className="os-bg" />
         <p className="text-sm text-muted-foreground">Loading...</p>
       </div>
     );
   }
 
   return (
-    <div className="w-screen h-screen grid place-items-center p-4">
+    <div className="relative min-h-svh w-screen grid place-items-center p-4">
+      <div className="os-bg" />
       <Card className="w-full max-w-sm p-6 space-y-4">
         <div className="space-y-1">
           <h1 className="text-xl font-semibold">{mode === "login" ? "Sign in" : "Create account"}</h1>

--- a/src/pages/Extension.tsx
+++ b/src/pages/Extension.tsx
@@ -5,7 +5,8 @@ export default function ExtensionPage() {
     document.title = "Aurora Companion Extension – Setup";
   }, []);
   return (
-    <div className="p-4 md:p-6">
+    <div className="relative min-h-svh p-4 md:p-6">
+      <div className="os-bg" />
       <section className="glass-panel rounded-2xl p-6 max-w-3xl mx-auto">
         <h1 className="text-2xl font-semibold">Aurora Companion Extension</h1>
         <p className="text-sm text-muted-foreground mt-2">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -470,7 +470,8 @@ if (!initializing && !user) {
 }
 
   return (
-    <div className="w-screen h-screen overflow-hidden relative" onPointerDown={onPointerDown} onPointerUp={onPointerUp}>
+    <div className="relative min-h-svh w-screen overflow-hidden" onPointerDown={onPointerDown} onPointerUp={onPointerUp}>
+      <div className="os-bg" />
       <AppHeader />
 
       <div className="absolute inset-0 smooth" style={{ transform: translate }}>

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -66,7 +66,8 @@ export default function LandingPage() {
   }, []);
 
   return (
-    <div className="min-h-screen pb-safe">
+    <div className="relative min-h-svh pb-safe">
+      <div className="os-bg" />
       <header className="px-4 pt-4 flex items-center justify-between max-w-4xl mx-auto">
         <div className="font-semibold tracking-wide">MOS</div>
         <div className="flex items-center gap-3">

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -12,7 +12,8 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+    <div className="relative min-h-svh flex items-center justify-center">
+      <div className="os-bg bg-gray-100" />
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
         <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>

--- a/src/pages/RoadmapHome.tsx
+++ b/src/pages/RoadmapHome.tsx
@@ -18,9 +18,9 @@ export default function RoadmapHome() {
   }, []);
 
   return (
-    <main className="min-h-screen relative overflow-hidden">
+    <main className="relative min-h-svh overflow-hidden">
       {/* vignette bg */}
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(900px_400px_at_50%_-10%,hsl(var(--accent)/.12),transparent)]" />
+      <div className="os-bg pointer-events-none bg-[radial-gradient(900px_400px_at_50%_-10%,hsl(var(--accent)/.12),transparent)]" />
 
       <section className="mx-auto max-w-[720px] px-4 pt-8 pb-28">
         <header className="mb-4">

--- a/src/pages/Stack.tsx
+++ b/src/pages/Stack.tsx
@@ -62,7 +62,8 @@ export default function StackPage() {
   }, []);
 
   return (
-    <div className="min-h-screen">
+    <div className="relative min-h-svh">
+      <div className="os-bg" />
       <AppHeader />
       <main className="pt-24 pb-16 px-4 sm:px-6 max-w-5xl mx-auto">
         <article className="space-y-8">

--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -45,7 +45,8 @@ export default function AppShell() {
     }
   }, [loc.pathname, loc.search]);
   return (
-    <div className={`min-h-screen room-${currentRoom}`} {...swipe}>
+    <div className={`relative min-h-svh room-${currentRoom}`} {...swipe}>
+      <div className="os-bg" />
       <AnimatePresence mode="wait">
         <Routes location={loc} key={loc.pathname + loc.search}>
           {views.map((v) => (

--- a/src/views/ControlView.tsx
+++ b/src/views/ControlView.tsx
@@ -2,7 +2,8 @@ import GameHome from "@/game/path/GameHome";
 
 export default function ControlView() {
   return (
-    <div className="min-h-screen">
+    <div className="relative min-h-svh">
+      <div className="os-bg" />
       <GameHome />
     </div>
   );


### PR DESCRIPTION
## Summary
- make os-bg fill screen and ignore pointer events
- wrap top-level screens in `relative min-h-svh` and move decorative backgrounds into `.os-bg`
- audit overlays to avoid pointer interception

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 195 errors, 19 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68981124a3e48326beaa15fa54b360d4