### PR TITLE
fix: ensure chat widget clears HUD

### DIFF
--- a/src/components/live/FloatingAssistant.tsx
+++ b/src/components/live/FloatingAssistant.tsx
@@ -98,7 +98,13 @@ export function FloatingAssistant({ task, onUpdated }: { task: Task | null; onUp
       </button>
 
       <Drawer open={open} onOpenChange={setOpen} shouldScaleBackground>
-        <DrawerContent className="p-0 z-[var(--z-modal)]" style={{ paddingBottom: 'calc(env(safe-area-inset-bottom) + var(--hud-h, 96px) + var(--hud-gap, 12px))' }}>
+        <DrawerContent
+          className="p-0 z-[var(--z-modal)]"
+          style={{
+            bottom: 'calc(var(--hud-h) + var(--hud-gap) + env(safe-area-inset-bottom))',
+            paddingBottom: 'env(safe-area-inset-bottom)'
+          }}
+        >
           <DrawerHeader className="p-3 border-b">
             <div className="flex items-center justify-between">
               <DrawerTitle>Assistant</DrawerTitle>


### PR DESCRIPTION
## Summary
- Offset assistant drawer so chat widget renders above the HUD

## Testing
- `npm run lint` *(fails: Unexpected any & other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689801c8b8248326a1125af575c18c96