### PR TITLE
Handle mos events for view navigation

### DIFF
--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -1,7 +1,7 @@
 import { Suspense, useEffect, useMemo } from "react";
 import { Route, Routes, useLocation, Navigate } from "react-router-dom";
 import { AnimatePresence, motion } from "framer-motion";
-import { views } from "@/views/registry";
+import { views, type ViewId } from "@/views/registry";
 import { GameHUD } from "@/components/hud/GameHUD";
 import { bus } from "@/utils/bus";
 import { useViewNav } from "@/state/view";
@@ -19,6 +19,26 @@ export default function AppShell() {
   useEffect(() => {
     const off = bus.on('nav:view', ({ id, params }) => open(id as any, params));
     return off;
+  }, [open]);
+
+  useEffect(() => {
+    const onMos = (e: any) => {
+      const t = e.detail?.type as string | undefined;
+      const map: Record<string, ViewId> = {
+        startFocus: 'focus',
+        startHypnosis: 'hypno',
+        voiceNote: 'voice',
+        addNote: 'notes',
+        openAnalyze: 'analyze',
+        openMap: 'portal',
+      };
+      const vid = t ? map[t] : undefined;
+      if (vid) open(vid);
+    };
+    window.addEventListener('mos', onMos as any);
+    return () => {
+      window.removeEventListener('mos', onMos as any);
+    };
   }, [open]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- listen for global `mos` events in `AppShell` and open matching views
- map event types like `startFocus`, `voiceNote`, and `openAnalyze` to `ViewId`s
- clean up the event listener on unmount

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689815fe08648326b836bbdd5d4116c7