### PR TITLE
refactor: switch view paths to relative

### DIFF
--- a/src/hooks/useSwipeNav.ts
+++ b/src/hooks/useSwipeNav.ts
@@ -25,7 +25,10 @@ export function useSwipeNav(threshold = 60) {
     if (dt > 600) return;
     if (Math.abs(dx) < threshold || Math.abs(dx) < Math.abs(dy)) return;
 
-    const paths = views.map((v) => v.path);
+    const paths = views.map((v) => {
+      const full = v.path ? `/app/${v.path}` : "/app";
+      return full.replace(/:.*/, "");
+    });
     const idx = paths.findIndex((p) => loc.pathname.startsWith(p));
     if (idx === -1) return;
 

--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -11,7 +11,14 @@ export default function AppShell() {
   const loc = useLocation();
   const open = useViewNav();
 
-  const currentRoom = useMemo(() => (views.find(v => loc.pathname.startsWith(v.path))?.id ?? "control"), [loc.pathname]);
+  const currentRoom = useMemo(() => {
+    const match = views.find((v) => {
+      const full = v.path ? `/app/${v.path}` : "/app";
+      const prefix = full.replace(/:.*/, "");
+      return loc.pathname.startsWith(prefix);
+    });
+    return match?.id ?? "control";
+  }, [loc.pathname]);
 
   useXPChime();
   const swipe = useSwipeNav();
@@ -22,7 +29,11 @@ export default function AppShell() {
   }, [open]);
 
   useEffect(() => {
-    const meta = views.find(v => loc.pathname.startsWith(v.path));
+    const meta = views.find((v) => {
+      const full = v.path ? `/app/${v.path}` : "/app";
+      const prefix = full.replace(/:.*/, "");
+      return loc.pathname.startsWith(prefix);
+    });
     if (meta) {
       document.title = `Aurora OS — ${meta.label}`;
       // SEO: update description and canonical
@@ -52,7 +63,8 @@ export default function AppShell() {
           {views.map((v) => (
             <Route
               key={v.id}
-              path={v.path}
+              path={v.path || undefined}
+              index={v.path === "" ? true : undefined}
               element={
                 <motion.div
                   initial={{ opacity: 0, y: 12 }}

--- a/src/state/view.ts
+++ b/src/state/view.ts
@@ -25,7 +25,9 @@ export function useViewNav() {
       console.error('[useViewNav] Unknown view id', id, 'params', params);
       return;
     }
-    const target = `${meta.path}${qs}`;
+    const base = "/app";
+    const fullPath = meta.path ? `${base}/${meta.path}` : base;
+    const target = `${fullPath}${qs}`;
     console.debug('[useViewNav] navigating to', target);
     nav(target);
   };

--- a/src/views/registry.tsx
+++ b/src/views/registry.tsx
@@ -14,16 +14,16 @@ export type ViewMeta = {
 };
 
 export const views: ViewMeta[] = [
-  { id: "control", label: "Control", path: "/app",          component: lazy(() => import("./ControlView")) },
-  { id: "focus",   label: "Focus",   path: "/app/focus",    component: lazy(() => import("./FocusView")) },
-  { id: "hypno",   label: "Hypno",   path: "/app/hypno",    component: lazy(() => import("./HypnoView")) },
-  { id: "voice",   label: "Voice",   path: "/app/voice",    component: lazy(() => import("./VoiceView")) },
-  { id: "notes",   label: "Notes",   path: "/app/notes",    component: lazy(() => import("./NotesView")) },
-  { id: "analyze", label: "Analyze", path: "/app/analyze",  component: lazy(() => import("./AnalyzeView")) },
-  { id: "browser", label: "Browser", path: "/app/browser",  component: lazy(() => import("./BrowserView")) },
-  { id: "portal",  label: "Portal",  path: "/app/portal",   component: lazy(() => import("./PortalView")) },
-  { id: "archive", label: "Archive", path: "/app/archive",  component: lazy(() => import("./ArchiveView")) },
-  { id: "settings",label: "Settings",path: "/app/settings", component: lazy(() => import("./SettingsView")) },
-  { id: "agent",   label: "Agent",   path: "/app/agent",    component: lazy(() => import("./AgentFullView")) },
-  { id: "runner",  label: "Node",    path: "/app/node/:id", component: lazy(() => import("../pages/NodeRunner")) },
+  { id: "control", label: "Control", path: "",            component: lazy(() => import("./ControlView")) },
+  { id: "focus",   label: "Focus",   path: "focus",      component: lazy(() => import("./FocusView")) },
+  { id: "hypno",   label: "Hypno",   path: "hypno",      component: lazy(() => import("./HypnoView")) },
+  { id: "voice",   label: "Voice",   path: "voice",      component: lazy(() => import("./VoiceView")) },
+  { id: "notes",   label: "Notes",   path: "notes",      component: lazy(() => import("./NotesView")) },
+  { id: "analyze", label: "Analyze", path: "analyze",    component: lazy(() => import("./AnalyzeView")) },
+  { id: "browser", label: "Browser", path: "browser",    component: lazy(() => import("./BrowserView")) },
+  { id: "portal",  label: "Portal",  path: "portal",     component: lazy(() => import("./PortalView")) },
+  { id: "archive", label: "Archive", path: "archive",    component: lazy(() => import("./ArchiveView")) },
+  { id: "settings",label: "Settings",path: "settings",  component: lazy(() => import("./SettingsView")) },
+  { id: "agent",   label: "Agent",   path: "agent",      component: lazy(() => import("./AgentFullView")) },
+  { id: "runner",  label: "Node",    path: "node/:id",   component: lazy(() => import("../pages/NodeRunner")) },
 ];


### PR DESCRIPTION
## Summary
- refactor view registry to use relative paths
- prefix navigation and swipe detection with `/app`
- adjust AppShell room detection for new relative paths

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, Empty block statement)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898163cecdc8326bc5ecd82b8dcb6c3