### PR TITLE
Ensure Control view handles /app index route

### DIFF
--- a/src/hooks/useSwipeNav.ts
+++ b/src/hooks/useSwipeNav.ts
@@ -25,7 +25,7 @@ export function useSwipeNav(threshold = 60) {
     if (dt > 600) return;
     if (Math.abs(dx) < threshold || Math.abs(dx) < Math.abs(dy)) return;
 
-    const paths = views.map((v) => v.path);
+    const paths = views.map((v) => (v.path ? `/app/${v.path}` : "/app"));
     const idx = paths.findIndex((p) => loc.pathname.startsWith(p));
     if (idx === -1) return;
 

--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -7,11 +7,17 @@ import { bus } from "@/utils/bus";
 import { useViewNav } from "@/state/view";
 import { useXPChime } from "@/hooks/useXPChime";
 import { useSwipeNav } from "@/hooks/useSwipeNav";
+import ControlView from "@/views/ControlView";
 export default function AppShell() {
   const loc = useLocation();
   const open = useViewNav();
 
-  const currentRoom = useMemo(() => (views.find(v => loc.pathname.startsWith(v.path))?.id ?? "control"), [loc.pathname]);
+  const currentRoom = useMemo(
+    () =>
+      views.find((v) => loc.pathname.startsWith(v.path ? `/app/${v.path}` : "/app"))?.id ??
+      "control",
+    [loc.pathname]
+  );
 
   useXPChime();
   const swipe = useSwipeNav();
@@ -22,7 +28,7 @@ export default function AppShell() {
   }, [open]);
 
   useEffect(() => {
-    const meta = views.find(v => loc.pathname.startsWith(v.path));
+    const meta = views.find((v) => loc.pathname.startsWith(v.path ? `/app/${v.path}` : "/app"));
     if (meta) {
       document.title = `Aurora OS — ${meta.label}`;
       // SEO: update description and canonical
@@ -49,7 +55,8 @@ export default function AppShell() {
       <div className="os-bg" />
       <AnimatePresence mode="wait">
         <Routes location={loc} key={loc.pathname + loc.search}>
-          {views.map((v) => (
+          <Route index element={<ControlView />} />
+          {views.filter((v) => v.id !== "control").map((v) => (
             <Route
               key={v.id}
               path={v.path}
@@ -68,7 +75,6 @@ export default function AppShell() {
               }
             />
           ))}
-          <Route path="/" element={<Navigate to="/app" replace />} />
           <Route path="*" element={<Navigate to="/app" replace />} />
         </Routes>
       </AnimatePresence>

--- a/src/state/view.ts
+++ b/src/state/view.ts
@@ -25,7 +25,8 @@ export function useViewNav() {
       console.error('[useViewNav] Unknown view id', id, 'params', params);
       return;
     }
-    const target = `${meta.path}${qs}`;
+    const path = meta.path ? `/app/${meta.path}` : "/app";
+    const target = `${path}${qs}`;
     console.debug('[useViewNav] navigating to', target);
     nav(target);
   };

--- a/src/views/registry.tsx
+++ b/src/views/registry.tsx
@@ -14,16 +14,16 @@ export type ViewMeta = {
 };
 
 export const views: ViewMeta[] = [
-  { id: "control", label: "Control", path: "/app",          component: lazy(() => import("./ControlView")) },
-  { id: "focus",   label: "Focus",   path: "/app/focus",    component: lazy(() => import("./FocusView")) },
-  { id: "hypno",   label: "Hypno",   path: "/app/hypno",    component: lazy(() => import("./HypnoView")) },
-  { id: "voice",   label: "Voice",   path: "/app/voice",    component: lazy(() => import("./VoiceView")) },
-  { id: "notes",   label: "Notes",   path: "/app/notes",    component: lazy(() => import("./NotesView")) },
-  { id: "analyze", label: "Analyze", path: "/app/analyze",  component: lazy(() => import("./AnalyzeView")) },
-  { id: "browser", label: "Browser", path: "/app/browser",  component: lazy(() => import("./BrowserView")) },
-  { id: "portal",  label: "Portal",  path: "/app/portal",   component: lazy(() => import("./PortalView")) },
-  { id: "archive", label: "Archive", path: "/app/archive",  component: lazy(() => import("./ArchiveView")) },
-  { id: "settings",label: "Settings",path: "/app/settings", component: lazy(() => import("./SettingsView")) },
-  { id: "agent",   label: "Agent",   path: "/app/agent",    component: lazy(() => import("./AgentFullView")) },
-  { id: "runner",  label: "Node",    path: "/app/node/:id", component: lazy(() => import("../pages/NodeRunner")) },
+  { id: "control", label: "Control", path: "",          component: lazy(() => import("./ControlView")) },
+  { id: "focus",   label: "Focus",   path: "focus",    component: lazy(() => import("./FocusView")) },
+  { id: "hypno",   label: "Hypno",   path: "hypno",    component: lazy(() => import("./HypnoView")) },
+  { id: "voice",   label: "Voice",   path: "voice",    component: lazy(() => import("./VoiceView")) },
+  { id: "notes",   label: "Notes",   path: "notes",    component: lazy(() => import("./NotesView")) },
+  { id: "analyze", label: "Analyze", path: "analyze",  component: lazy(() => import("./AnalyzeView")) },
+  { id: "browser", label: "Browser", path: "browser",  component: lazy(() => import("./BrowserView")) },
+  { id: "portal",  label: "Portal",  path: "portal",   component: lazy(() => import("./PortalView")) },
+  { id: "archive", label: "Archive", path: "archive",  component: lazy(() => import("./ArchiveView")) },
+  { id: "settings",label: "Settings",path: "settings", component: lazy(() => import("./SettingsView")) },
+  { id: "agent",   label: "Agent",   path: "agent",    component: lazy(() => import("./AgentFullView")) },
+  { id: "runner",  label: "Node",    path: "node/:id", component: lazy(() => import("../pages/NodeRunner")) },
 ];


### PR DESCRIPTION
## Summary
- Define view paths relative to `/app` and update navigation helpers
- Render `ControlView` via an index `<Route>` so `/app` with no subpath shows control room

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, empty block statement)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68981791ad5083269197d32a24ef7b31