### PR TITLE
Add extra HUD gap for chat drawer

### DIFF
--- a/src/components/live/FloatingAssistant.tsx
+++ b/src/components/live/FloatingAssistant.tsx
@@ -136,7 +136,7 @@ export function FloatingAssistant({
           style={{
             zIndex: 'var(--z-modal)',
             bottom:
-              'calc(var(--hud-h) + var(--hud-gap) + env(safe-area-inset-bottom))',
+              'calc(var(--hud-h) + var(--hud-gap) + env(safe-area-inset-bottom) + 12px)',
             paddingBottom: 'env(safe-area-inset-bottom)',
           }}
         >


### PR DESCRIPTION
## Summary
- ensure chat drawer leaves an additional gap above the HUD

## Testing
- `npm run lint` *(fails: Unexpected any / no-empty, require imports)*

------
https://chatgpt.com/codex/tasks/task_e_68981cee3ba88326937cad98d799367a