### PR TITLE
feat: add floating assistant overlay

### DIFF
--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -3,6 +3,7 @@ import { Route, Routes, useLocation, Navigate } from "react-router-dom";
 import { AnimatePresence, motion } from "framer-motion";
 import { views, type ViewId } from "@/views/registry";
 import { GameHUD } from "@/components/hud/GameHUD";
+import { FloatingAssistant } from "@/components/live/FloatingAssistant";
 import { bus } from "@/utils/bus";
 import { useViewNav } from "@/state/view";
 import { useXPChime } from "@/hooks/useXPChime";
@@ -104,7 +105,8 @@ export default function AppShell() {
         </Routes>
       </AnimatePresence>
 
-      
+
+      <FloatingAssistant task={null} onUpdated={() => {}} />
       <GameHUD />
     </div>
   );


### PR DESCRIPTION
## Summary
- import and render `FloatingAssistant` in `AppShell` so assistant overlay is available across views

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, Empty block statement, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68981cf471ac83269a7b31858f2db9a4