### PR TITLE
Disable background scaling for assistant drawer

### DIFF
--- a/src/components/live/FloatingAssistant.tsx
+++ b/src/components/live/FloatingAssistant.tsx
@@ -130,7 +130,7 @@ export function FloatingAssistant({
         <MessageSquare className="w-6 h-6" />
       </button>
 
-      <Drawer open={open} onOpenChange={setOpen} shouldScaleBackground>
+      <Drawer open={open} onOpenChange={setOpen} shouldScaleBackground={false}>
         <DrawerContent
           className="p-0"
           style={{


### PR DESCRIPTION
## Summary
- prevent the assistant drawer from shrinking the background by disabling its background scaling

## Testing
- `npm run lint` *(fails: Unexpected any, forbidden require import)*
- `npm run build`
- `node <playwright-script>` *(failed: Timeout waiting for chat button)*

------
https://chatgpt.com/codex/tasks/task_e_68981ce8e35083269ebdecd711b8789a