### PR TITLE
feat: configure websocket endpoint and token handling

### DIFF
--- a/aurora-extension/lib/agent.js
+++ b/aurora-extension/lib/agent.js
@@ -1,7 +1,7 @@
 // lib/agent.js
-// Placeholder agent using OpenAI (wire later with secure key)
+// Minimal agent stub; replace with model integration when API keys are available
 
 export async function runAgent(prompt, context){
-  // Intentionally left as a stub for now
+  // Echoes inputs for development/testing purposes
   return { ok: true, prompt, context };
 }

--- a/aurora-extension/lib/ws.js
+++ b/aurora-extension/lib/ws.js
@@ -1,10 +1,23 @@
 // lib/ws.js
-// Placeholder WS bridge to app (device token TBD)
+// WebSocket bridge to backend service
 
+const WS_URL = globalThis.AURORA_WS_URL || 'wss://api.auroraapp.dev/ws';
+
+/**
+ * Create a WebSocket connection to the backend.
+ *
+ * @param {string} token Authentication token retrieved from your backend's
+ * login flow. Obtain the token via a secure HTTP request and store it
+ * (e.g. in extension storage) before calling this function.
+ * @returns {WebSocket | null} Active WebSocket or null if connection fails.
+ */
 export function connect(token){
+  if (!token) {
+    console.error('Cannot connect: auth token is missing');
+    return null;
+  }
   try {
-    const ws = new WebSocket(`wss://app.yourdomain/ws?token=${encodeURIComponent(token)}`);
-    return ws;
+    return new WebSocket(`${WS_URL}?token=${encodeURIComponent(token)}`);
   } catch (e) {
     console.warn('WS connect failed', e);
     return null;


### PR DESCRIPTION
## Summary
- configure WebSocket URL via `AURORA_WS_URL` with sensible default
- add token validation and docs for connecting to backend
- refine agent stub comments for clarity

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 157 errors, 18 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6898211584f483268f52626ff6382665