### PR TITLE
feat: add LifePilot modules

### DIFF
--- a/src/ai/Brain.ts
+++ b/src/ai/Brain.ts
@@ -1,0 +1,23 @@
+import cognition, { CognitionConfig } from './cognition';
+import behavior, { BehaviorConfig } from './behavior';
+import filters, { Filter } from './filters';
+import skills, { Skill } from './skills';
+
+/**
+ * Combined configuration for Aura's behaviour and prompts.
+ */
+export interface BrainConfig {
+  cognition: CognitionConfig;
+  behavior: BehaviorConfig;
+  filters: Filter[];
+  skills: Skill[];
+}
+
+export const brain: BrainConfig = {
+  cognition,
+  behavior,
+  filters,
+  skills,
+};
+
+export default brain;

--- a/src/ai/behavior.ts
+++ b/src/ai/behavior.ts
@@ -1,0 +1,12 @@
+export interface BehaviorConfig {
+  /**
+   * Overall communication style of Aura.
+   */
+  style: string;
+}
+
+export const behavior: BehaviorConfig = {
+  style: 'supportive'
+};
+
+export default behavior;

--- a/src/ai/cognition.ts
+++ b/src/ai/cognition.ts
@@ -1,0 +1,17 @@
+export interface CognitionConfig {
+  /**
+   * System prompt used for all chat interactions.
+   */
+  systemPrompt: string;
+  /**
+   * Optional additional context sent with each request.
+   */
+  contextPrompt?: string;
+}
+
+export const cognition: CognitionConfig = {
+  systemPrompt: 'You are Aura, a friendly life coach AI who gives concise and actionable advice.',
+  contextPrompt: 'Respond in a warm and supportive tone.'
+};
+
+export default cognition;

--- a/src/ai/filters.ts
+++ b/src/ai/filters.ts
@@ -1,0 +1,27 @@
+export type Filter = (text: string) => string
+
+export const filterRegistry: Record<string, Filter> = {
+  trim: text => text.trim(),
+  lowercase: text => text.toLowerCase(),
+  uppercase: text => text.toUpperCase()
+}
+
+export type FilterName = keyof typeof filterRegistry
+
+/**
+ * List of filters applied to every outgoing message.
+ */
+export const filters: Filter[] = [filterRegistry.trim]
+
+export function getFilterByName(name: string): Filter | undefined {
+  return filterRegistry[name as FilterName]
+}
+
+export function getFilterName(fn: Filter): string | undefined {
+  for (const [name, filter] of Object.entries(filterRegistry)) {
+    if (filter === fn) return name
+  }
+  return undefined
+}
+
+export default filters

--- a/src/ai/skills.ts
+++ b/src/ai/skills.ts
@@ -1,0 +1,19 @@
+export interface Skill {
+  /**
+   * Name of the skill available to Aura.
+   */
+  name: string;
+  /**
+   * Short description of the skill.
+   */
+  description: string;
+}
+
+export const skills: Skill[] = [
+  {
+    name: 'widgets',
+    description: 'Suggests dashboard widgets based on conversation context.'
+  }
+];
+
+export default skills;

--- a/src/payments/api/subscription.ts
+++ b/src/payments/api/subscription.ts
@@ -1,0 +1,41 @@
+import { Subscription, UsageStats } from '@/payments/types/subscription'
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
+
+async function request(path: string, options: RequestInit = {}) {
+  const token = localStorage.getItem('accessToken')
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(options.headers as Record<string, string> | undefined)
+  }
+  if (token) headers['Authorization'] = `Bearer ${token}`
+
+  const res = await fetch(`${API_BASE_URL}${path}`, { ...options, headers })
+  const data = await res.json().catch(() => ({}))
+  if (!res.ok) {
+    throw new Error((data as any)?.message || res.statusText)
+  }
+  return data
+}
+
+export const getSubscription = () =>
+  request('/subscription') as Promise<{ subscription: Subscription | null; usage: UsageStats }>
+
+export const createCheckoutSession = (priceId: string, billingCycle: 'monthly' | 'yearly') =>
+  request('/subscription/checkout', {
+    method: 'POST',
+    body: JSON.stringify({ priceId, billingCycle })
+  }) as Promise<{ sessionId: string; url: string }>
+
+export const cancelSubscription = (cancelAtPeriodEnd = true) =>
+  request('/subscription/cancel', {
+    method: 'POST',
+    body: JSON.stringify({ cancelAtPeriodEnd })
+  }) as Promise<{ success: boolean; subscription: Subscription }>
+
+export const updateSubscription = (priceId: string, billingCycle: 'monthly' | 'yearly') =>
+  request('/subscription/update', {
+    method: 'POST',
+    body: JSON.stringify({ priceId, billingCycle })
+  }) as Promise<{ success: boolean; subscription: Subscription }>
+

--- a/src/payments/components/PricingPage.tsx
+++ b/src/payments/components/PricingPage.tsx
@@ -1,0 +1,435 @@
+import React, { useState } from 'react';
+import { motion } from 'framer-motion';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Switch } from '@/components/ui/switch';
+import { Separator } from '@/components/ui/separator';
+import {
+  Check,
+  Star,
+  Zap,
+  Users,
+  Shield,
+  Headphones,
+  MessageSquare,
+  BarChart3,
+  Cloud,
+  Mic,
+  Building,
+  Crown
+} from 'lucide-react';
+import { PricingTier } from '@/payments/types/subscription'
+import { createCheckoutSession } from '@/payments/api/subscription'
+import { useSubscription } from '@/payments/hooks/useSubscription'
+import { toast } from '@/hooks/use-toast'
+
+const PRICING_TIERS: PricingTier[] = [
+  {
+    id: 'freemium',
+    name: 'Freemium',
+    price: { monthly: 0, yearly: 0 },
+    features: [
+      '3 unlocked widgets',
+      '500 AI messages/month',
+      'Basic sphere + chat',
+      'Local storage only',
+      'Community support'
+    ],
+    limits: {
+      widgets: 3,
+      aiMessages: 500
+    },
+    buttonText: 'Get Started Free',
+    stripePriceIds: {
+      monthly: '',
+      yearly: ''
+    }
+  },
+  {
+    id: 'personal',
+    name: 'Personal',
+    price: { monthly: 9, yearly: 90 },
+    features: [
+      'Unlimited widgets',
+      '1,500 AI messages/month',
+      'Full analytics dashboard',
+      'Calendar & fitness integrations',
+      'Cloud sync across devices',
+      'Email support'
+    ],
+    limits: {
+      widgets: 'unlimited',
+      aiMessages: 1500
+    },
+    popular: true,
+    buttonText: 'Start Free Trial',
+    stripePriceIds: {
+      monthly: 'price_personal_monthly',
+      yearly: 'price_personal_yearly'
+    }
+  },
+  {
+    id: 'pro',
+    name: 'Pro',
+    price: { monthly: 25, yearly: 240 },
+    features: [
+      '5,000 AI messages/month',
+      'Voice features (ElevenLabs + Whisper)',
+      'Team projects (5 seats)',
+      'Custom widgets via API',
+      'API access & webhooks',
+      '2-year data history',
+      'Priority support'
+    ],
+    limits: {
+      widgets: 'unlimited',
+      aiMessages: 5000,
+      teamSeats: 5,
+      history: '2 years'
+    },
+    buttonText: 'Upgrade to Pro',
+    stripePriceIds: {
+      monthly: 'price_pro_monthly',
+      yearly: 'price_pro_yearly'
+    }
+  },
+  {
+    id: 'enterprise',
+    name: 'Enterprise',
+    price: { monthly: 0, yearly: 0 },
+    features: [
+      'Unlimited usage',
+      'SLA & dedicated instance',
+      'HIPAA/GDPR compliance',
+      'SSO & white-label',
+      'Dedicated success manager',
+      'Custom integrations',
+      '24/7 phone support'
+    ],
+    limits: {
+      widgets: 'unlimited',
+      aiMessages: 'unlimited'
+    },
+    buttonText: 'Contact Sales',
+    stripePriceIds: {
+      monthly: '',
+      yearly: ''
+    }
+  }
+];
+
+const FEATURE_COMPARISON = [
+  { feature: 'AI Messages', freemium: '500/month', personal: '1,500/month', pro: '5,000/month', enterprise: 'Unlimited' },
+  { feature: 'Widgets', freemium: '3', personal: 'Unlimited', pro: 'Unlimited', enterprise: 'Unlimited' },
+  { feature: 'Cloud Sync', freemium: '❌', personal: '✅', pro: '✅', enterprise: '✅' },
+  { feature: 'Analytics', freemium: 'Basic', personal: 'Full', pro: 'Advanced', enterprise: 'Custom' },
+  { feature: 'Team Seats', freemium: '1', personal: '1', pro: '5', enterprise: 'Unlimited' },
+  { feature: 'Voice Features', freemium: '❌', personal: '❌', pro: '✅', enterprise: '✅' },
+  { feature: 'API Access', freemium: '❌', personal: '❌', pro: '✅', enterprise: '✅' },
+  { feature: 'Data History', freemium: '30 days', personal: '1 year', pro: '2 years', enterprise: 'Unlimited' },
+  { feature: 'Support', freemium: 'Community', personal: 'Email', pro: 'Priority', enterprise: '24/7 Phone' }
+];
+
+export function PricingPage() {
+  const [isYearly, setIsYearly] = useState(false);
+  const [showComparison, setShowComparison] = useState(false);
+  const [isLoading, setIsLoading] = useState<string | null>(null);
+  const { subscription } = useSubscription();
+
+  const handleSubscribe = async (tier: PricingTier) => {
+    if (tier.id === 'freemium') {
+      toast({
+        title: "Already on Free Plan",
+        description: "You're currently using the free tier. Upgrade to unlock more features!"
+      });
+      return;
+    }
+
+    if (tier.id === 'enterprise') {
+      window.open('mailto:sales@lifepilot.ai?subject=Enterprise Plan Inquiry', '_blank');
+      return;
+    }
+
+    try {
+      setIsLoading(tier.id);
+      const priceId = isYearly ? tier.stripePriceIds.yearly : tier.stripePriceIds.monthly;
+      const response = await createCheckoutSession(priceId, isYearly ? 'yearly' : 'monthly');
+
+      // In a real app, redirect to Stripe Checkout
+      window.open((response as any).url, '_blank');
+
+      toast({
+        title: "Redirecting to Checkout",
+        description: "You'll be redirected to Stripe to complete your subscription."
+      });
+    } catch (error) {
+      toast({
+        title: "Error",
+        description: "Failed to create checkout session. Please try again.",
+        variant: "destructive"
+      });
+    } finally {
+      setIsLoading(null);
+    }
+  };
+
+  const getDiscountPercentage = (tier: PricingTier) => {
+    if (tier.price.monthly === 0) return 0;
+    const monthlyTotal = tier.price.monthly * 12;
+    const yearlyPrice = tier.price.yearly;
+    return Math.round(((monthlyTotal - yearlyPrice) / monthlyTotal) * 100);
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-purple-50 dark:from-slate-900 dark:via-blue-900 dark:to-purple-900">
+      <div className="max-w-7xl mx-auto px-4 py-16">
+        {/* Header */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="text-center mb-16"
+        >
+          <h1 className="text-4xl md:text-5xl font-bold text-gray-900 dark:text-white mb-4">
+            Choose Your <span className="bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent">LifePilot</span> Plan
+          </h1>
+          <p className="text-xl text-gray-600 dark:text-gray-300 mb-8 max-w-3xl mx-auto">
+            Unlock your potential with AI-powered life management. Start free, upgrade when you're ready.
+          </p>
+
+          {/* Billing Toggle */}
+          <div className="flex items-center justify-center space-x-4 mb-8">
+            <span className={`text-sm font-medium ${!isYearly ? 'text-gray-900 dark:text-white' : 'text-gray-500 dark:text-gray-400'}`}>
+              Monthly
+            </span>
+            <Switch
+              checked={isYearly}
+              onCheckedChange={setIsYearly}
+              className="data-[state=checked]:bg-purple-600"
+            />
+            <span className={`text-sm font-medium ${isYearly ? 'text-gray-900 dark:text-white' : 'text-gray-500 dark:text-gray-400'}`}>
+              Yearly
+            </span>
+            <Badge className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
+              Save up to 25%
+            </Badge>
+          </div>
+        </motion.div>
+
+        {/* Pricing Cards */}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-16">
+          {PRICING_TIERS.map((tier, index) => (
+            <motion.div
+              key={tier.id}
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: index * 0.1 }}
+              className="relative"
+            >
+              {tier.popular && (
+                <div className="absolute -top-4 left-1/2 transform -translate-x-1/2">
+                  <Badge className="bg-gradient-to-r from-purple-600 to-blue-600 text-white px-4 py-1">
+                    <Star className="w-3 h-3 mr-1" />
+                    Most Popular
+                  </Badge>
+                </div>
+              )}
+
+              <Card className={`h-full ${tier.popular ? 'ring-2 ring-purple-500 shadow-xl' : 'shadow-lg'} bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm hover:shadow-xl transition-all duration-300`}>
+                <CardHeader className="text-center pb-4">
+                  <div className="flex justify-center mb-4">
+                    {tier.id === 'freemium' && <Zap className="w-8 h-8 text-blue-500" />}
+                    {tier.id === 'personal' && <Users className="w-8 h-8 text-purple-500" />}
+                    {tier.id === 'pro' && <Crown className="w-8 h-8 text-yellow-500" />}
+                    {tier.id === 'enterprise' && <Building className="w-8 h-8 text-gray-700" />}
+                  </div>
+                  <CardTitle className="text-2xl font-bold text-gray-900 dark:text-white">
+                    {tier.name}
+                  </CardTitle>
+                  <div className="mt-4">
+                    {tier.price.monthly === 0 ? (
+                      <div className="text-4xl font-bold text-gray-900 dark:text-white">
+                        {tier.id === 'enterprise' ? 'Custom' : 'Free'}
+                      </div>
+                    ) : (
+                      <div className="space-y-2">
+                        <div className="text-4xl font-bold text-gray-900 dark:text-white">
+                          ${isYearly ? Math.round(tier.price.yearly / 12) : tier.price.monthly}
+                          <span className="text-lg font-normal text-gray-500 dark:text-gray-400">/mo</span>
+                        </div>
+                        {isYearly && tier.price.yearly > 0 && (
+                          <div className="text-sm text-green-600 dark:text-green-400">
+                            Save {getDiscountPercentage(tier)}% annually
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                </CardHeader>
+
+                <CardContent className="space-y-6">
+                  <ul className="space-y-3">
+                    {tier.features.map((feature, featureIndex) => (
+                      <li key={featureIndex} className="flex items-start space-x-3">
+                        <Check className="w-5 h-5 text-green-500 flex-shrink-0 mt-0.5" />
+                        <span className="text-sm text-gray-600 dark:text-gray-300">{feature}</span>
+                      </li>
+                    ))}
+                  </ul>
+
+                  <Button
+                    onClick={() => handleSubscribe(tier)}
+                    disabled={isLoading === tier.id}
+                    className={`w-full ${
+                      tier.popular
+                        ? 'bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700'
+                        : tier.id === 'freemium'
+                        ? 'bg-gray-600 hover:bg-gray-700'
+                        : 'bg-gray-800 hover:bg-gray-900 dark:bg-gray-700 dark:hover:bg-gray-600'
+                    } text-white`}
+                  >
+                    {isLoading === tier.id ? 'Processing...' : tier.buttonText}
+                  </Button>
+
+                  {tier.id === 'personal' && (
+                    <p className="text-xs text-center text-gray-500 dark:text-gray-400">
+                      14-day free trial • No credit card required
+                    </p>
+                  )}
+                </CardContent>
+              </Card>
+            </motion.div>
+          ))}
+        </div>
+
+        {/* Add-ons Section */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.5 }}
+          className="mb-16"
+        >
+          <Card className="bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm">
+            <CardHeader>
+              <CardTitle className="text-2xl font-bold text-center text-gray-900 dark:text-white">
+                Add-ons & Extras
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                <div className="text-center p-6 rounded-lg bg-gradient-to-br from-blue-50 to-purple-50 dark:from-blue-900/20 dark:to-purple-900/20">
+                  <MessageSquare className="w-8 h-8 text-blue-500 mx-auto mb-3" />
+                  <h3 className="font-semibold text-gray-900 dark:text-white mb-2">Extra AI Messages</h3>
+                  <p className="text-2xl font-bold text-gray-900 dark:text-white mb-2">$5</p>
+                  <p className="text-sm text-gray-600 dark:text-gray-300">+1,000 messages</p>
+                </div>
+                <div className="text-center p-6 rounded-lg bg-gradient-to-br from-green-50 to-blue-50 dark:from-green-900/20 dark:to-blue-900/20">
+                  <Users className="w-8 h-8 text-green-500 mx-auto mb-3" />
+                  <h3 className="font-semibold text-gray-900 dark:text-white mb-2">Additional Team Seat</h3>
+                  <p className="text-2xl font-bold text-gray-900 dark:text-white mb-2">$5</p>
+                  <p className="text-sm text-gray-600 dark:text-gray-300">per month each</p>
+                </div>
+                <div className="text-center p-6 rounded-lg bg-gradient-to-br from-purple-50 to-pink-50 dark:from-purple-900/20 dark:to-pink-900/20">
+                  <Shield className="w-8 h-8 text-purple-500 mx-auto mb-3" />
+                  <h3 className="font-semibold text-gray-900 dark:text-white mb-2">Custom Integrations</h3>
+                  <p className="text-2xl font-bold text-gray-900 dark:text-white mb-2">Quote</p>
+                  <p className="text-sm text-gray-600 dark:text-gray-300">Tailored solutions</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </motion.div>
+
+        {/* Feature Comparison */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.6 }}
+        >
+          <Card className="bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm">
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <CardTitle className="text-2xl font-bold text-gray-900 dark:text-white">
+                  Compare Features
+                </CardTitle>
+                <Button
+                  variant="outline"
+                  onClick={() => setShowComparison(!showComparison)}
+                  className="border-purple-200 hover:bg-purple-50 dark:border-purple-700 dark:hover:bg-purple-900/20"
+                >
+                  {showComparison ? 'Hide' : 'Show'} Comparison
+                </Button>
+              </div>
+            </CardHeader>
+            {showComparison && (
+              <CardContent>
+                <div className="overflow-x-auto">
+                  <table className="w-full">
+                    <thead>
+                      <tr className="border-b border-gray-200 dark:border-gray-700">
+                        <th className="text-left py-3 px-4 font-semibold text-gray-900 dark:text-white">Feature</th>
+                        <th className="text-center py-3 px-4 font-semibold text-gray-900 dark:text-white">Freemium</th>
+                        <th className="text-center py-3 px-4 font-semibold text-purple-600">Personal</th>
+                        <th className="text-center py-3 px-4 font-semibold text-gray-900 dark:text-white">Pro</th>
+                        <th className="text-center py-3 px-4 font-semibold text-gray-900 dark:text-white">Enterprise</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {FEATURE_COMPARISON.map((row, index) => (
+                        <tr key={index} className="border-b border-gray-100 dark:border-gray-800">
+                          <td className="py-3 px-4 font-medium text-gray-900 dark:text-white">{row.feature}</td>
+                          <td className="py-3 px-4 text-center text-gray-600 dark:text-gray-300">{row.freemium}</td>
+                          <td className="py-3 px-4 text-center text-purple-600 font-medium">{row.personal}</td>
+                          <td className="py-3 px-4 text-center text-gray-600 dark:text-gray-300">{row.pro}</td>
+                          <td className="py-3 px-4 text-center text-gray-600 dark:text-gray-300">{row.enterprise}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </CardContent>
+            )}
+          </Card>
+        </motion.div>
+
+        {/* FAQ Section */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.7 }}
+          className="mt-16 text-center"
+        >
+          <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-8">
+            Frequently Asked Questions
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-4xl mx-auto">
+            <Card className="bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm text-left">
+              <CardContent className="p-6">
+                <h3 className="font-semibold text-gray-900 dark:text-white mb-2">Can I change plans anytime?</h3>
+                <p className="text-gray-600 dark:text-gray-300">Yes! You can upgrade or downgrade your plan at any time. Changes are prorated automatically.</p>
+              </CardContent>
+            </Card>
+            <Card className="bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm text-left">
+              <CardContent className="p-6">
+                <h3 className="font-semibold text-gray-900 dark:text-white mb-2">What happens to my data if I cancel?</h3>
+                <p className="text-gray-600 dark:text-gray-300">Your data is safely stored for 90 days after cancellation, giving you time to reactivate or export.</p>
+              </CardContent>
+            </Card>
+            <Card className="bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm text-left">
+              <CardContent className="p-6">
+                <h3 className="font-semibold text-gray-900 dark:text-white mb-2">Is there a free trial?</h3>
+                <p className="text-gray-600 dark:text-gray-300">Yes! Personal plan includes a 14-day free trial with no credit card required.</p>
+              </CardContent>
+            </Card>
+            <Card className="bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm text-left">
+              <CardContent className="p-6">
+                <h3 className="font-semibold text-gray-900 dark:text-white mb-2">How does billing work?</h3>
+                <p className="text-gray-600 dark:text-gray-300">We bill monthly or annually. Annual plans save up to 25% and all changes are prorated.</p>
+              </CardContent>
+            </Card>
+          </div>
+        </motion.div>
+      </div>
+    </div>
+  );
+}

--- a/src/payments/components/SubscriptionManager.tsx
+++ b/src/payments/components/SubscriptionManager.tsx
@@ -1,0 +1,294 @@
+import React, { useState } from 'react';
+import { motion } from 'framer-motion';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Progress } from '@/components/ui/progress';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import {
+  CreditCard,
+  Calendar,
+  AlertTriangle,
+  CheckCircle,
+  XCircle,
+  Settings,
+  Download,
+  Users,
+  MessageSquare
+} from 'lucide-react';
+import { useSubscription } from '@/payments/hooks/useSubscription'
+import { toast } from '@/hooks/use-toast'
+import { formatDistanceToNow } from 'date-fns';
+
+export function SubscriptionManager() {
+  const { subscription, usage, isLoading, isOnTrial, trialDaysLeft, cancelSubscription, refetch } = useSubscription();
+  const [showCancelDialog, setShowCancelDialog] = useState(false);
+  const [isCanceling, setIsCanceling] = useState(false);
+
+  const handleCancelSubscription = async (cancelAtPeriodEnd: boolean) => {
+    try {
+      setIsCanceling(true);
+      await cancelSubscription(cancelAtPeriodEnd);
+      toast({
+        title: "Subscription Updated",
+        description: cancelAtPeriodEnd
+          ? "Your subscription will cancel at the end of the current period."
+          : "Your subscription has been canceled immediately."
+      });
+      setShowCancelDialog(false);
+      refetch();
+    } catch (error) {
+      toast({
+        title: "Error",
+        description: "Failed to cancel subscription. Please try again.",
+        variant: "destructive"
+      });
+    } finally {
+      setIsCanceling(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="max-w-4xl mx-auto p-6">
+        <div className="animate-pulse space-y-6">
+          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3"></div>
+          <div className="h-32 bg-gray-200 dark:bg-gray-700 rounded"></div>
+          <div className="h-24 bg-gray-200 dark:bg-gray-700 rounded"></div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!subscription) {
+    return (
+      <div className="max-w-4xl mx-auto p-6 text-center">
+        <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-4">No Active Subscription</h2>
+        <p className="text-gray-600 dark:text-gray-300 mb-6">You're currently on the free plan.</p>
+        <Button className="bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700">
+          Upgrade Now
+        </Button>
+      </div>
+    );
+  }
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'active': return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200';
+      case 'trialing': return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200';
+      case 'past_due': return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200';
+      case 'canceled': return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200';
+      default: return 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200';
+    }
+  };
+
+  const getUsagePercentage = (used: number, limit: number | 'unlimited') => {
+    if (limit === 'unlimited') return 0;
+    return Math.min((used / limit) * 100, 100);
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Subscription Management</h1>
+        <Button variant="outline" onClick={refetch}>
+          <Settings className="w-4 h-4 mr-2" />
+          Refresh
+        </Button>
+      </div>
+
+      {/* Current Plan */}
+      <Card className="bg-white dark:bg-gray-900">
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-xl font-semibold text-gray-900 dark:text-white">
+              Current Plan
+            </CardTitle>
+            <Badge className={getStatusColor(subscription.status)}>
+              {subscription.status.charAt(0).toUpperCase() + subscription.status.slice(1)}
+            </Badge>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div>
+              <p className="text-sm text-gray-600 dark:text-gray-400">Plan</p>
+              <p className="text-lg font-semibold text-gray-900 dark:text-white capitalize">
+                {subscription.planId}
+              </p>
+            </div>
+            <div>
+              <p className="text-sm text-gray-600 dark:text-gray-400">Billing Cycle</p>
+              <p className="text-lg font-semibold text-gray-900 dark:text-white capitalize">
+                {subscription.billingCycle}
+              </p>
+            </div>
+            <div>
+              <p className="text-sm text-gray-600 dark:text-gray-400">Next Billing</p>
+              <p className="text-lg font-semibold text-gray-900 dark:text-white">
+                {formatDistanceToNow(new Date(subscription.currentPeriodEnd), { addSuffix: true })}
+              </p>
+            </div>
+          </div>
+
+          {isOnTrial && (
+            <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
+              <div className="flex items-center space-x-2">
+                <Calendar className="w-5 h-5 text-blue-500" />
+                <span className="font-medium text-blue-900 dark:text-blue-100">
+                  Free Trial - {trialDaysLeft} days remaining
+                </span>
+              </div>
+            </div>
+          )}
+
+          {subscription.cancelAtPeriodEnd && (
+            <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4">
+              <div className="flex items-center space-x-2">
+                <AlertTriangle className="w-5 h-5 text-yellow-500" />
+                <span className="font-medium text-yellow-900 dark:text-yellow-100">
+                  Subscription will cancel on {new Date(subscription.currentPeriodEnd).toLocaleDateString()}
+                </span>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Usage Statistics */}
+      {usage && (
+        <Card className="bg-white dark:bg-gray-900">
+          <CardHeader>
+            <CardTitle className="text-xl font-semibold text-gray-900 dark:text-white">
+              Usage This Month
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="space-y-4">
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <div className="flex items-center space-x-2">
+                    <MessageSquare className="w-4 h-4 text-blue-500" />
+                    <span className="text-sm font-medium text-gray-900 dark:text-white">AI Messages</span>
+                  </div>
+                  <span className="text-sm text-gray-600 dark:text-gray-400">
+                    {usage.aiMessagesUsed} / {subscription.planId === 'freemium' ? '500' : subscription.planId === 'personal' ? '1,500' : subscription.planId === 'pro' ? '5,000' : 'Unlimited'}
+                  </span>
+                </div>
+                <Progress 
+                  value={getUsagePercentage(usage.aiMessagesUsed, subscription.planId === 'freemium' ? 500 : subscription.planId === 'personal' ? 1500 : subscription.planId === 'pro' ? 5000 : 'unlimited')} 
+                  className="h-2"
+                />
+              </div>
+
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <div className="flex items-center space-x-2">
+                    <Settings className="w-4 h-4 text-green-500" />
+                    <span className="text-sm font-medium text-gray-900 dark:text-white">Active Widgets</span>
+                  </div>
+                  <span className="text-sm text-gray-600 dark:text-gray-400">
+                    {usage.widgetsActive} / {subscription.planId === 'freemium' ? '3' : 'Unlimited'}
+                  </span>
+                </div>
+                <Progress 
+                  value={getUsagePercentage(usage.widgetsActive, subscription.planId === 'freemium' ? 3 : 'unlimited')} 
+                  className="h-2"
+                />
+              </div>
+
+              {subscription.planId === 'pro' && (
+                <div>
+                  <div className="flex items-center justify-between mb-2">
+                    <div className="flex items-center space-x-2">
+                      <Users className="w-4 h-4 text-purple-500" />
+                      <span className="text-sm font-medium text-gray-900 dark:text-white">Team Seats</span>
+                    </div>
+                    <span className="text-sm text-gray-600 dark:text-gray-400">
+                      {usage.teamSeatsUsed} / 5
+                    </span>
+                  </div>
+                  <Progress value={getUsagePercentage(usage.teamSeatsUsed, 5)} className="h-2" />
+                </div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Actions */}
+      <Card className="bg-white dark:bg-gray-900">
+        <CardHeader>
+          <CardTitle className="text-xl font-semibold text-gray-900 dark:text-white">
+            Manage Subscription
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <Button variant="outline" className="justify-start">
+              <CreditCard className="w-4 h-4 mr-2" />
+              Update Payment Method
+            </Button>
+            <Button variant="outline" className="justify-start">
+              <Download className="w-4 h-4 mr-2" />
+              Download Invoices
+            </Button>
+            <Button variant="outline" className="justify-start">
+              <Settings className="w-4 h-4 mr-2" />
+              Change Plan
+            </Button>
+            <Button 
+              variant="outline" 
+              className="justify-start text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20"
+              onClick={() => setShowCancelDialog(true)}
+            >
+              <XCircle className="w-4 h-4 mr-2" />
+              Cancel Subscription
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Cancel Subscription Dialog */}
+      <Dialog open={showCancelDialog} onOpenChange={setShowCancelDialog}>
+        <DialogContent className="bg-white dark:bg-gray-900">
+          <DialogHeader>
+            <DialogTitle className="text-xl font-semibold text-gray-900 dark:text-white">
+              Cancel Subscription
+            </DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <p className="text-gray-600 dark:text-gray-300">
+              Are you sure you want to cancel your subscription? You can choose to cancel immediately or at the end of your current billing period.
+            </p>
+            <div className="flex space-x-3">
+              <Button
+                variant="outline"
+                onClick={() => handleCancelSubscription(true)}
+                disabled={isCanceling}
+                className="flex-1"
+              >
+                Cancel at Period End
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={() => handleCancelSubscription(false)}
+                disabled={isCanceling}
+                className="flex-1"
+              >
+                {isCanceling ? 'Canceling...' : 'Cancel Immediately'}
+              </Button>
+            </div>
+            <Button
+              variant="ghost"
+              onClick={() => setShowCancelDialog(false)}
+              className="w-full"
+            >
+              Keep Subscription
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/payments/hooks/useSubscription.ts
+++ b/src/payments/hooks/useSubscription.ts
@@ -1,0 +1,85 @@
+import { useState, useEffect, useCallback } from 'react'
+import { Subscription, UsageStats } from '@/payments/types/subscription'
+import { getSubscription, cancelSubscription, updateSubscription } from '@/payments/api/subscription'
+
+export function useSubscription() {
+  const [subscription, setSubscription] = useState<Subscription | null>(null);
+  const [usage, setUsage] = useState<UsageStats | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchSubscription = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const response = await getSubscription();
+      setSubscription((response as any).subscription);
+      setUsage((response as any).usage);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch subscription');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSubscription();
+  }, [fetchSubscription]);
+
+  const cancelSub = useCallback(async (cancelAtPeriodEnd: boolean = true) => {
+    try {
+      const response = await cancelSubscription(cancelAtPeriodEnd);
+      setSubscription((response as any).subscription);
+      return response;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to cancel subscription');
+      throw err;
+    }
+  }, []);
+
+  const updateSub = useCallback(async (priceId: string, billingCycle: 'monthly' | 'yearly') => {
+    try {
+      const response = await updateSubscription(priceId, billingCycle);
+      setSubscription((response as any).subscription);
+      return response;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update subscription');
+      throw err;
+    }
+  }, []);
+
+  const isOnTrial = subscription?.status === 'trialing';
+  const trialDaysLeft = subscription?.trialEnd 
+    ? Math.max(0, Math.ceil((new Date(subscription.trialEnd).getTime() - Date.now()) / (1000 * 60 * 60 * 24)))
+    : 0;
+
+  const canAccessFeature = useCallback((feature: string) => {
+    if (!subscription) return false;
+    
+    switch (subscription.planId) {
+      case 'freemium':
+        return ['basic_chat', 'basic_widgets'].includes(feature);
+      case 'personal':
+        return !['team_projects', 'api_access', 'voice_features'].includes(feature);
+      case 'pro':
+        return feature !== 'enterprise_features';
+      case 'enterprise':
+        return true;
+      default:
+        return false;
+    }
+  }, [subscription]);
+
+  return {
+    subscription,
+    usage,
+    isLoading,
+    error,
+    isOnTrial,
+    trialDaysLeft,
+    canAccessFeature,
+    cancelSubscription: cancelSub,
+    updateSubscription: updateSub,
+    refetch: fetchSubscription
+  };
+}

--- a/src/payments/types/subscription.ts
+++ b/src/payments/types/subscription.ts
@@ -1,0 +1,41 @@
+export interface PricingTier {
+  id: string;
+  name: string;
+  price: {
+    monthly: number;
+    yearly: number;
+  };
+  features: string[];
+  limits: {
+    widgets: number | 'unlimited';
+    aiMessages: number | 'unlimited';
+    teamSeats?: number;
+    history?: string;
+  };
+  popular?: boolean;
+  buttonText: string;
+  stripePriceIds: {
+    monthly: string;
+    yearly: string;
+  };
+}
+
+export interface Subscription {
+  id: string;
+  userId: string;
+  planId: string;
+  status: 'active' | 'trialing' | 'past_due' | 'canceled' | 'unpaid';
+  currentPeriodStart: Date;
+  currentPeriodEnd: Date;
+  trialEnd?: Date;
+  cancelAtPeriodEnd: boolean;
+  stripeCustomerId: string;
+  stripeSubscriptionId: string;
+  billingCycle: 'monthly' | 'yearly';
+}
+
+export interface UsageStats {
+  aiMessagesUsed: number;
+  widgetsActive: number;
+  teamSeatsUsed: number;
+}

--- a/src/voice/useTextToSpeech.ts
+++ b/src/voice/useTextToSpeech.ts
@@ -1,0 +1,49 @@
+import { useState, useCallback } from 'react'
+
+const ELEVENLABS_API_KEY = import.meta.env.VITE_ELEVENLABS_API_KEY as string | undefined
+
+export function useTextToSpeech() {
+  const [isSpeaking, setIsSpeaking] = useState(false)
+
+  const speak = useCallback(async (text: string) => {
+    if (!text) return
+    try {
+      const apiKey = ELEVENLABS_API_KEY
+
+      if (apiKey) {
+        const voiceId = '21m00Tcm4TlvDq8ikWAM'
+        const response = await fetch(`https://api.elevenlabs.io/v1/text-to-speech/${voiceId}`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'xi-api-key': apiKey
+          },
+          body: JSON.stringify({ text })
+        })
+
+        const blob = await response.blob()
+        const url = URL.createObjectURL(blob)
+        const audio = new Audio(url)
+        setIsSpeaking(true)
+        audio.onended = () => {
+          setIsSpeaking(false)
+          URL.revokeObjectURL(url)
+        }
+        await audio.play()
+      } else {
+        const utterance = new SpeechSynthesisUtterance(text)
+        utterance.onend = () => setIsSpeaking(false)
+        setIsSpeaking(true)
+        speechSynthesis.speak(utterance)
+      }
+    } catch (err) {
+      console.error('TTS error', err)
+      const utter = new SpeechSynthesisUtterance(text)
+      utter.onend = () => setIsSpeaking(false)
+      setIsSpeaking(true)
+      speechSynthesis.speak(utter)
+    }
+  }, [])
+
+  return { speak, isSpeaking }
+}

--- a/src/voice/useVoiceInput.ts
+++ b/src/voice/useVoiceInput.ts
@@ -1,0 +1,79 @@
+import { useState, useRef, useCallback } from 'react'
+
+const OPENAI_API_KEY = import.meta.env.VITE_OPENAI_API_KEY as string | undefined
+
+export function useVoiceInput() {
+  const [isRecording, setIsRecording] = useState(false)
+  const [transcript, setTranscript] = useState('')
+  const recognitionRef = useRef<any>(null)
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null)
+  const chunksRef = useRef<Blob[]>([])
+
+  const start = useCallback(async () => {
+    if (isRecording) return
+    if ((window as any).SpeechRecognition || (window as any).webkitSpeechRecognition) {
+      const Rec = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition
+      const recognition = new Rec()
+      recognition.lang = 'en-US'
+      recognition.interimResults = false
+      recognition.onresult = e => {
+        const text = Array.from(e.results).map(r => r[0].transcript).join(' ')
+        setTranscript(text)
+      }
+      recognition.onend = () => setIsRecording(false)
+      recognition.onerror = () => setIsRecording(false)
+      recognition.start()
+      recognitionRef.current = recognition
+      setIsRecording(true)
+    } else {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+        const recorder = new MediaRecorder(stream)
+        chunksRef.current = []
+        recorder.ondataavailable = e => {
+          if (e.data.size > 0) chunksRef.current.push(e.data)
+        }
+        recorder.onstop = async () => {
+          const blob = new Blob(chunksRef.current, { type: 'audio/webm' })
+          try {
+            const formData = new FormData()
+            formData.append('file', blob, 'recording.webm')
+            formData.append('model', 'whisper-1')
+
+            const apiKey = OPENAI_API_KEY
+            if (!apiKey) throw new Error('Missing OpenAI API key')
+
+            const res = await fetch('https://api.openai.com/v1/audio/transcriptions', {
+              method: 'POST',
+              headers: {
+                Authorization: `Bearer ${apiKey}`
+              },
+              body: formData
+            })
+            const data = await res.json()
+            if (data?.text) setTranscript(data.text)
+          } catch (err) {
+            console.error('Whisper transcription failed', err)
+          }
+          setIsRecording(false)
+        }
+        recorder.start()
+        mediaRecorderRef.current = recorder
+        setIsRecording(true)
+      } catch (err) {
+        console.error('Unable to access microphone', err)
+      }
+    }
+  }, [isRecording])
+
+  const stop = useCallback(() => {
+    recognitionRef.current?.stop()
+    recognitionRef.current = null
+    if (mediaRecorderRef.current) {
+      mediaRecorderRef.current.stop()
+      mediaRecorderRef.current = null
+    }
+  }, [])
+
+  return { startRecording: start, stopRecording: stop, transcript, setTranscript, isRecording }
+}


### PR DESCRIPTION
## Summary
- integrate LifePilot's brain configuration for AI
- add voice hooks with environment-driven API keys
- add subscription pricing components and API without Waku

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 361 problems)*

------
https://chatgpt.com/codex/tasks/task_e_689824ca7b688326b9935c22859846d4