### PR TITLE
Auto-start hypno session with immediate TTS

### DIFF
--- a/src/nodes/HypnosisRunner.tsx
+++ b/src/nodes/HypnosisRunner.tsx
@@ -15,10 +15,6 @@ export default function HypnosisRunner({ node, onExit }: Props) {
   const duration = Math.min(180, Math.max(60, node.duration ?? 90));
   const text = node.script ?? `Close your eyes. Breathe gently. With each breath, relax deeper. Your focus gets sharper and calmer. When you open your eyes, you will feel refreshed and ready.`;
 
-  useEffect(() => {
-    return () => stopAll();
-  }, []);
-
   const start = async () => {
     if (playing) return;
     setPlaying(true);
@@ -68,6 +64,11 @@ export default function HypnosisRunner({ node, onExit }: Props) {
 
   const pct = Math.min(100, Math.round((elapsed / duration) * 100));
 
+  useEffect(() => {
+    start();
+    return () => stopAll();
+  }, []);
+
   return (
     <main className="relative min-h-svh px-4 pt-10 pb-28 grid place-items-center text-center">
       <div className="os-bg" />
@@ -84,10 +85,7 @@ export default function HypnosisRunner({ node, onExit }: Props) {
           <div className="text-sm mt-2 opacity-80">{elapsed}s / {duration}s</div>
         </div>
 
-        {!playing && !ended && (
-          <button className="rounded-md px-4 py-2 bg-[hsl(var(--primary))] text-white/95 hover:opacity-90 transition" onClick={start}>Start</button>
-        )}
-        {playing && (
+        {playing && !ended && (
           <button className="rounded-md px-4 py-2 bg-[hsl(var(--primary))] text-white/95 hover:opacity-90 transition" onClick={stop}>Stop & Wake</button>
         )}
         {ended && (

--- a/src/views/HypnoView.tsx
+++ b/src/views/HypnoView.tsx
@@ -1,9 +1,14 @@
-import HypnoPanel from "@/components/hypno/HypnoPanel";
+import { useNavigate } from "react-router-dom";
+import HypnosisRunner from "@/nodes/HypnosisRunner";
+import { getNodeById } from "@/data/roadmap";
 
 export default function HypnoView() {
+  const nav = useNavigate();
+  const node = getNodeById("hypno-calm-60");
+  if (!node) return <div className="p-6">Session unavailable.</div>;
   return (
     <div className="container mx-auto px-4 py-4">
-      <HypnoPanel />
+      <HypnosisRunner node={node} onExit={() => nav("/app")} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- launch default hypnosis session directly and remove extra dialogs
- auto-start Web Speech TTS and award XP when audio finishes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any / no-empty / @typescript-eslint/no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_6898304045ac832693e8802917a60e9d