### PR TITLE
Auto-start hypno session and award XP

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import NotFound from "./pages/NotFound";
 import AuthPage from "./pages/Auth";
 import MindWorldDashboard from "@/components/mindworld/MindWorldDashboard";
 import BrowserShell from "@/routes/browser/BrowserShell";
+import HypnoShell from "@/routes/hypno/HypnoShell";
 import ExtensionPage from "@/pages/Extension";
 import StackPage from "./pages/Stack";
 import AppShell from "@/routes/AppShell";
@@ -27,6 +28,7 @@ const App = () => (
           <Route path="/home" element={<Index />} />
           <Route path="/auth" element={<AuthPage />} />
           <Route path="/browser" element={<BrowserShell />} />
+          <Route path="/hypno" element={<HypnoShell />} />
           <Route path="/extension" element={<ExtensionPage />} />
           <Route path="/stack" element={<StackPage />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/nodes/HypnosisRunner.tsx
+++ b/src/nodes/HypnosisRunner.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useProgressStore } from "@/state/progress";
-import { awardXPRemote } from "@/integrations/supabase/gameSync";
+import { supabase } from "@/integrations/supabase/client";
 
 type Props = { node: { id: string; label: string; script?: string; duration?: number }; onExit: () => void };
 
@@ -22,6 +22,7 @@ export default function HypnosisRunner({ node, onExit }: Props) {
 
     // Fallback TTS via Web Speech
     if ("speechSynthesis" in window) {
+      try { window.speechSynthesis.cancel(); } catch {}
       const u = new SpeechSynthesisUtterance(text);
       u.rate = 0.95;
       u.pitch = 1.0;
@@ -43,7 +44,9 @@ export default function HypnosisRunner({ node, onExit }: Props) {
 
     // Award XP + streak
     awardXP(25, { activity: "hypnosis", nodeId: node.id });
-    await awardXPRemote("hypnosis", 25, { nodeId: node.id }).catch(() => {});
+    try {
+      await supabase.rpc("award_xp", { activity: "hypnosis_session", amount: 25, metadata: { node_id: node.id } });
+    } catch {}
     complete(node.id);
   };
 

--- a/src/routes/hypno/HypnoShell.tsx
+++ b/src/routes/hypno/HypnoShell.tsx
@@ -1,0 +1,10 @@
+import { useNavigate } from "react-router-dom";
+import HypnosisRunner from "@/nodes/HypnosisRunner";
+import { getNodeById } from "@/data/roadmap";
+
+export default function HypnoShell() {
+  const nav = useNavigate();
+  const node = getNodeById("hypno-calm-60");
+  if (!node) return <div className="p-6">Session unavailable.</div>;
+  return <HypnosisRunner node={node} onExit={() => nav("/app")}/>;
+}


### PR DESCRIPTION
## Summary
- Add direct `/hypno` route that immediately runs the default hypnosis session
- Invoke Web Speech TTS on mount and award XP via Supabase `award_xp` RPC when playback ends
- Register new hypno route in app shell

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, empty block statements, etc.)*
- `npm run build` *(fails: TS2345, TS2554 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6898366ea7d88326bec74ef6d5276766