### PR TITLE
feat: add lifepilot legacy schema

### DIFF
--- a/supabase/migrations/20250810050000_f645fb64-8c74-4fbe-8529-d108cf62cf8a.sql
+++ b/supabase/migrations/20250810050000_f645fb64-8c74-4fbe-8529-d108cf62cf8a.sql
@@ -1,0 +1,31 @@
+-- Create legacy LifePilot schema for data migration
+create schema if not exists lifepilot;
+
+-- Legacy boards table
+create table if not exists lifepilot.boards (
+  id uuid primary key,
+  user_id uuid not null,
+  name text,
+  title text,
+  description text,
+  color text,
+  is_active boolean default false,
+  position integer,
+  created_at timestamptz,
+  updated_at timestamptz
+);
+
+-- Legacy tasks table
+create table if not exists lifepilot.tasks (
+  id uuid primary key,
+  user_id uuid not null,
+  board_id uuid not null references lifepilot.boards(id) on delete cascade,
+  title text not null,
+  description text,
+  due_at timestamptz,
+  status text,
+  position integer,
+  created_at timestamptz,
+  updated_at timestamptz,
+  completed_at timestamptz
+);


### PR DESCRIPTION
## Summary
- define lifepilot schema with boards and tasks for migrating LifePilot data

## Testing
- `psql -f supabase/migrations/20250810050000_f645fb64-8c74-4fbe-8529-d108cf62cf8a.sql`
- `psql -f supabase/migrations/20250810053000_52939ae1-4792-4228-a477-01bd05528431.sql`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898377118948326805ff503b872ebe4