### PR TITLE
chore: simplify settings and remove lifepilot setup

### DIFF
--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -1,8 +1,31 @@
+import { Button } from "@/components/ui/button";
+import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
+import { supabase } from "@/integrations/supabase/client";
+import { toast } from "@/hooks/use-toast";
+
 export default function SettingsView() {
+  const { user } = useSupabaseAuth();
+
+  const signOut = async () => {
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      toast({ title: "Sign out failed", description: error.message });
+    } else {
+      toast({ title: "Signed out", description: "You have been signed out." });
+    }
+  };
+
   return (
-    <div className="container mx-auto px-4 py-6">
-      <h1 className="text-2xl font-semibold mb-2">Settings</h1>
-      <p className="opacity-70">Preferences and integrations. Coming soon.</p>
+    <div className="container mx-auto px-4 py-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Settings</h1>
+      {user ? (
+        <div className="space-y-2">
+          <div className="text-sm text-muted-foreground">{user.email}</div>
+          <Button variant="softPrimary" onClick={signOut}>Log out</Button>
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">You are not signed in.</p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove lifepilot submodule with obsolete API key and Waku setup pages
- simplify Settings view to show profile and log-out only

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any, no-empty, etc.)*
- `npm run build` *(fails: TypeScript errors in existing files)*
- `curl .../auth/v1/signup` *(mobile sign-up succeeds)*
- `curl ...auth/v1/token?grant_type=password` *(mobile login fails: Email not confirmed)*
- `curl .../auth/v1/signup` *(desktop sign-up succeeds)*
- `curl ...auth/v1/token?grant_type=password` *(desktop login fails: Email not confirmed)*

------
https://chatgpt.com/codex/tasks/task_e_68983a8b51d88326b13cd36f76cd4b57