### PR TITLE
chore: relocate payments module and disable billing ui

### DIFF
--- a/src/modules/payments/api/subscription.ts
+++ b/src/modules/payments/api/subscription.ts
@@ -1,5 +1,8 @@
-import { Subscription, UsageStats } from '@/payments/types/subscription'
+import { Subscription, UsageStats } from '@/modules/payments/types/subscription'
 
+/**
+ * TODO: Enable subscription API when payments module is activated.
+ */
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
 
 async function request(path: string, options: RequestInit = {}) {

--- a/src/modules/payments/components/PricingPage.tsx
+++ b/src/modules/payments/components/PricingPage.tsx
@@ -19,10 +19,17 @@ import {
   Building,
   Crown
 } from 'lucide-react';
-import { PricingTier } from '@/payments/types/subscription'
-import { createCheckoutSession } from '@/payments/api/subscription'
-import { useSubscription } from '@/payments/hooks/useSubscription'
+import { PricingTier } from '@/modules/payments/types/subscription'
+import { createCheckoutSession } from '@/modules/payments/api/subscription'
+import { useSubscription } from '@/modules/payments/hooks/useSubscription'
 import { toast } from '@/hooks/use-toast'
+
+/**
+ * TODO: Activate billing UI when payments module is ready.
+ */
+export function PricingPage() {
+  return null;
+}
 
 const PRICING_TIERS: PricingTier[] = [
   {
@@ -131,7 +138,7 @@ const FEATURE_COMPARISON = [
   { feature: 'Support', freemium: 'Community', personal: 'Email', pro: 'Priority', enterprise: '24/7 Phone' }
 ];
 
-export function PricingPage() {
+function PricingPageUI() {
   const [isYearly, setIsYearly] = useState(false);
   const [showComparison, setShowComparison] = useState(false);
   const [isLoading, setIsLoading] = useState<string | null>(null);

--- a/src/modules/payments/components/SubscriptionManager.tsx
+++ b/src/modules/payments/components/SubscriptionManager.tsx
@@ -16,11 +16,18 @@ import {
   Users,
   MessageSquare
 } from 'lucide-react';
-import { useSubscription } from '@/payments/hooks/useSubscription'
+import { useSubscription } from '@/modules/payments/hooks/useSubscription'
 import { toast } from '@/hooks/use-toast'
 import { formatDistanceToNow } from 'date-fns';
 
+/**
+ * TODO: Activate billing UI when payments module is ready.
+ */
 export function SubscriptionManager() {
+  return null;
+}
+
+function SubscriptionManagerUI() {
   const { subscription, usage, isLoading, isOnTrial, trialDaysLeft, cancelSubscription, refetch } = useSubscription();
   const [showCancelDialog, setShowCancelDialog] = useState(false);
   const [isCanceling, setIsCanceling] = useState(false);

--- a/src/modules/payments/hooks/useSubscription.ts
+++ b/src/modules/payments/hooks/useSubscription.ts
@@ -1,7 +1,10 @@
 import { useState, useEffect, useCallback } from 'react'
-import { Subscription, UsageStats } from '@/payments/types/subscription'
-import { getSubscription, cancelSubscription, updateSubscription } from '@/payments/api/subscription'
+import { Subscription, UsageStats } from '@/modules/payments/types/subscription'
+import { getSubscription, cancelSubscription, updateSubscription } from '@/modules/payments/api/subscription'
 
+/**
+ * TODO: Enable subscription hook when payments module is activated.
+ */
 export function useSubscription() {
   const [subscription, setSubscription] = useState<Subscription | null>(null);
   const [usage, setUsage] = useState<UsageStats | null>(null);

--- a/src/modules/payments/types/subscription.ts
+++ b/src/modules/payments/types/subscription.ts
@@ -1,3 +1,6 @@
+/**
+ * TODO: Review subscription types when payments module is activated.
+ */
 export interface PricingTier {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
- move Stripe payments logic into `src/modules/payments`
- add TODO stubs to pricing and subscription components to hide billing UI for now
- flag payment-related APIs and hooks for later activation

## Testing
- `npm run lint` *(fails: Unexpected any, no-empty, no-require-imports)*
- `npm run build` *(fails: TS2554 Expected 1 arguments, TS2345 Argument of type 'any' is not assignable to parameter of type 'never')*

------
https://chatgpt.com/codex/tasks/task_e_68983a9ee5488326a00afa0146f5e7a9