### PR TITLE
Protect AppShell with Supabase auth

### DIFF
--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -8,11 +8,26 @@ import { bus } from "@/utils/bus";
 import { useViewNav } from "@/state/view";
 import { useXPChime } from "@/hooks/useXPChime";
 import { useSwipeNav } from "@/hooks/useSwipeNav";
+import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
 import ControlView from "@/views/ControlView";
 export default function AppShell() {
+  const { user, initializing } = useSupabaseAuth();
+
+  if (initializing) {
+    return (
+      <div className="relative min-h-svh w-screen grid place-items-center">
+        <div className="os-bg" />
+        <p className="text-sm text-muted-foreground">Loading...</p>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <Navigate to="/auth" replace />;
+  }
+
   const loc = useLocation();
   const open = useViewNav();
-
 
   const currentRoom = useMemo(() => {
     const match = views.find((v) => {


### PR DESCRIPTION
## Summary
- guard AppShell routes with useSupabaseAuth and redirect unauthenticated users to /auth
- show full-screen loading indicator while auth state is initializing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 185 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68983e0b7fe88326966197e11039da24