### PR TITLE
feat: add env vars and hypnotic sphere

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,6 @@
 VITE_SUPABASE_URL=your_supabase_url
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
+VITE_OPENAI_API_KEY=your_openai_api_key
+OPENAI_API_KEY=your_openai_api_key
+VITE_ELEVENLABS_API_KEY=your_elevenlabs_api_key
+ELEVENLABS_API_KEY=your_elevenlabs_api_key

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "sonner": "^1.7.4",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
+        "three": "^0.179.1",
         "vaul": "^0.9.9",
         "vite-plugin-pwa": "^0.20.5",
         "zod": "^3.25.76",
@@ -11154,6 +11155,12 @@
       "dependencies": {
         "real-require": "^0.2.0"
       }
+    },
+    "node_modules/three": {
+      "version": "0.179.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.179.1.tgz",
+      "integrity": "sha512-5y/elSIQbrvKOISxpwXCR4sQqHtGiOI+MKLc3SsBdDXA2hz3Mdp3X59aUp8DyybMa34aeBwbFTpdoLJaUDEWSw==",
+      "license": "MIT"
     },
     "node_modules/through2": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "sonner": "^1.7.4",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
+    "three": "^0.179.1",
     "vaul": "^0.9.9",
     "vite-plugin-pwa": "^0.20.5",
     "zod": "^3.25.76",

--- a/src/components/effects/HypnoSphere.tsx
+++ b/src/components/effects/HypnoSphere.tsx
@@ -1,0 +1,55 @@
+import { useRef, useEffect } from "react";
+import * as THREE from "three";
+
+interface Props {
+  size?: number; // size in pixels
+  className?: string;
+}
+
+export function HypnoSphere({ size = 256, className = "" }: Props) {
+  const mountRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount) return;
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(45, 1, 1, 100);
+    camera.position.z = 35;
+
+    const renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true });
+    renderer.setSize(size, size);
+    mount.appendChild(renderer.domElement);
+
+    const geometry = new THREE.SphereGeometry(10, 64, 64);
+    const material = new THREE.PointsMaterial({ color: 0x666666, size: 0.25 });
+    const particles = new THREE.Points(geometry, material);
+    scene.add(particles);
+
+    const light = new THREE.PointLight(0xffffff, 2);
+    light.position.y = 10;
+    scene.add(light);
+
+    let frameId: number;
+    const animate = () => {
+      particles.rotation.y += 0.002;
+      const scale = 1 + 0.1 * Math.sin(Date.now() * 0.002);
+      particles.scale.set(scale, scale, scale);
+      renderer.render(scene, camera);
+      frameId = requestAnimationFrame(animate);
+    };
+    animate();
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      geometry.dispose();
+      material.dispose();
+      renderer.dispose();
+      mount.removeChild(renderer.domElement);
+    };
+  }, [size]);
+
+  return <div ref={mountRef} className={className} style={{ width: size, height: size }} />;
+}
+
+export default HypnoSphere;

--- a/src/nodes/HypnosisRunner.tsx
+++ b/src/nodes/HypnosisRunner.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useProgressStore } from "@/state/progress";
 import { supabase } from "@/integrations/supabase/client";
+import HypnoSphere from "@/components/effects/HypnoSphere";
 
 type Props = { node: { id: string; label: string; script?: string; duration?: number }; onExit: () => void };
 
@@ -79,7 +80,7 @@ export default function HypnosisRunner({ node, onExit }: Props) {
         <h1 className="text-2xl font-semibold mb-2">{node.label}</h1>
         <p className="opacity-80 mb-6">Guided hypnosis • {duration}s</p>
 
-        <div className="w-64 h-64 mx-auto mb-6 rounded-full bg-[radial-gradient(circle_at_30%_30%,hsl(var(--primary)/.6),transparent_60%)] shadow-[0_0_40px_hsl(var(--primary)/.35)] animate-pulse" />
+        <HypnoSphere className="mx-auto mb-6" size={256} />
 
         <div className="mb-6">
           <div className="h-2 rounded-full bg-white/10 overflow-hidden">


### PR DESCRIPTION
## Summary
- load OpenAI and ElevenLabs credentials via env vars
- render a pulsating Three.js sphere in hypnosis sessions
- install Three.js dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any & other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68982349375c8326b53768531e0f33e9