### PR TITLE
Integrate LifePilot brain prompts

### DIFF
--- a/src/agent/AuroraAgent.ts
+++ b/src/agent/AuroraAgent.ts
@@ -66,11 +66,7 @@ export class AuroraAgent {
     try {
       const { data, error } = await supabase.functions.invoke('aurora-chat', {
         body: {
-          model: 'o4-mini-2025-04-16',
-          messages: [
-            { role: 'system', content: 'You are Aurora, a concise voice assistant for focus and productivity.' },
-            { role: 'user', content: text }
-          ]
+          prompt: text,
         }
       });
       if (error) throw error;

--- a/src/brain/brain/Brain.ts
+++ b/src/brain/brain/Brain.ts
@@ -1,7 +1,7 @@
-import cognition, { CognitionConfig } from './cognition';
-import behavior, { BehaviorConfig } from './behavior';
-import filters, { Filter } from './filters';
-import skills, { Skill } from './skills';
+import cognition, { CognitionConfig } from './cognition.ts';
+import behavior, { BehaviorConfig } from './behavior.ts';
+import filters, { Filter } from './filters.ts';
+import skills, { Skill } from './skills.ts';
 
 /**
  * Combined configuration for Aura's behaviour and prompts.

--- a/src/brain/prompts.ts
+++ b/src/brain/prompts.ts
@@ -1,3 +1,0 @@
-export const systemPrompt = `You are Aurora, a concise, friendly focus coach. Reply in short, actionable steps.`;
-
-export const behaviorPrompt = `Keep responses brief and centered on the user's current focus.`;

--- a/supabase/functions/aurora-chat/index.ts
+++ b/supabase/functions/aurora-chat/index.ts
@@ -1,9 +1,7 @@
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import {
-  systemPrompt,
-  behaviorPrompt,
-} from "../../../src/brain/prompts.ts";
+import brain from "../../../src/brain/brain/Brain.ts";
+import { getFilterName } from "../../../src/brain/brain/filters.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -31,9 +29,28 @@ serve(async (req) => {
     const usedModel = model || "o4-mini-2025-04-16"; // cost-effective default
 
     const systemMessages = [
-      { role: "system", content: systemPrompt },
-      { role: "system", content: behaviorPrompt },
+      { role: "system", content: brain.cognition.systemPrompt },
     ];
+
+    if (brain.cognition.contextPrompt) {
+      systemMessages.push({ role: "system", content: brain.cognition.contextPrompt });
+    }
+
+    systemMessages.push({ role: "system", content: `Behavior style: ${brain.behavior.style}` });
+
+    const skillPrompt = brain.skills
+      .map((s) => `${s.name}: ${s.description}`)
+      .join("; ");
+    if (skillPrompt) {
+      systemMessages.push({ role: "system", content: `Available skills: ${skillPrompt}` });
+    }
+
+    const filterNames = brain.filters
+      .map((f) => getFilterName(f))
+      .filter((n): n is string => Boolean(n));
+    if (filterNames.length > 0) {
+      systemMessages.push({ role: "system", content: `Applied filters: ${filterNames.join(", ")}` });
+    }
 
     const payload = messages && Array.isArray(messages)
       ? { model: usedModel, messages: [...systemMessages, ...messages] }
@@ -64,7 +81,11 @@ serve(async (req) => {
     }
 
     const data = await resp.json();
-    const content = data?.choices?.[0]?.message?.content ?? "Okay.";
+    let content = data?.choices?.[0]?.message?.content ?? "Okay.";
+
+    for (const filter of brain.filters) {
+      content = filter(content);
+    }
 
     return new Response(JSON.stringify({ content }), {
       headers: { ...corsHeaders, "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- load LifePilot brain config in aurora-chat edge function, injecting cognition, behavior, skill and filter layers and applying filters to responses
- simplify AuroraAgent to rely on backend prompts
- remove outdated prompts file

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 158 errors, 19 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6898736e1dc88326aee5d587b4a1cd90