### PR TITLE
feat: sync xp awards with edge function

### DIFF
--- a/src/components/game/GameHUD.tsx
+++ b/src/components/game/GameHUD.tsx
@@ -59,7 +59,7 @@ export function GameHUD() {
             <EvolvingSphere size={44} level={stats.level} xpPct={stats.xp} mood="focused" />
             <div className="min-w-0">
               <div className="text-[13px] opacity-90 truncate">
-                Lv. {stats.level} • Streak {stats.streak} • Mind Wizard
+                Lv. {stats.level} • Streak {stats.streak}
               </div>
               <div className="text-[15px] font-semibold truncate">Dean</div>
             </div>

--- a/src/components/live/CurrentFocusCard.tsx
+++ b/src/components/live/CurrentFocusCard.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button";
 import { toast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
 import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
+import { awardXPRemote } from "@/integrations/supabase/gameSync";
 import { useState } from "react";
 import { StickyNote } from "lucide-react";
 
@@ -61,7 +62,7 @@ export function CurrentFocusCard({
 
     // Award XP for task completion and update streak
     try {
-      await supabase.rpc('award_xp', { activity: 'task_complete', amount: 10, metadata: { task_id: task.id } as Record<string, unknown> });
+      await awardXPRemote("task_complete", 10, { task_id: task.id });
     } catch (e) { console.error(e); }
 
     onAdvance();

--- a/src/components/live/QuickActionsBar.tsx
+++ b/src/components/live/QuickActionsBar.tsx
@@ -6,6 +6,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { toast } from "@/hooks/use-toast";
 
 import { supabase } from "@/integrations/supabase/client";
+import { awardXPRemote } from "@/integrations/supabase/gameSync";
 import { useEffect, useRef, useState } from "react";
 
 type Task = {
@@ -151,7 +152,9 @@ type Track = {
           setLibraryOpen(true);
           // Award XP for starting a hypnosis session
           (async () => {
-            try { await supabase.rpc('award_xp', { activity: 'hypnosis_session', amount: 20, metadata: { mode } as any }); } catch {}
+            try {
+              await awardXPRemote("hypnosis_session", 20, { mode });
+            } catch {}
           })();
           return 0;
         }

--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { awardXPRemote, upsertQuest, logEvent } from "@/integrations/supabase/gameSync";
+import { supabase } from "@/integrations/supabase/client";
 import logger from "@/lib/logger";
 
 export type Stats = { hp: number; mp: number; xp: number; level: number; streak: number };
@@ -15,6 +16,7 @@ export type GameState = {
   incStreak: () => void;
   resetDaily: () => void;
   setStats: (s: Partial<Stats>) => void;
+  fetchStats: () => Promise<void>;
 };
 
 const defaults: GameState = {
@@ -29,6 +31,7 @@ const defaults: GameState = {
   incStreak() {},
   resetDaily() {},
   setStats() {},
+  fetchStats: async () => {},
 };
 
 export const useGameStore = create<GameState>((set, get) => {
@@ -50,6 +53,23 @@ export const useGameStore = create<GameState>((set, get) => {
 
   return {
     ...init,
+    fetchStats: async () => {
+      const { data } = await supabase.auth.getUser();
+      const user = data.user;
+      if (!user) return;
+      const { data: stats } = await supabase
+        .from("user_stats")
+        .select("total_xp, streak_count")
+        .eq("user_id", user.id)
+        .maybeSingle();
+      if (!stats) return;
+      const total = stats.total_xp ?? 0;
+      const xp = total % 100;
+      const level = Math.floor(total / 100) + 1;
+      const patch: Partial<Stats> = { xp, level };
+      if (typeof stats.streak_count === "number") patch.streak = stats.streak_count;
+      persist({ stats: { ...get().stats, ...patch } });
+    },
     setPos: (x, y) => persist({ pos: { x, y } }),
     setMood: (m) => persist({ mood: m }),
     awardXP: (amount) => {
@@ -101,12 +121,15 @@ export const useGameStore = create<GameState>((set, get) => {
 if (typeof window !== "undefined") {
   window.addEventListener("xp-total-update", (e: any) => {
     const total = e.detail?.total_xp;
-    if (typeof total !== "number") return;
-    const streak = e.detail?.streak;
-    const xp = total % 100;
-    const level = Math.floor(total / 100) + 1;
-    const patch: Partial<Stats> = { xp, level };
-    if (typeof streak === "number") patch.streak = streak;
-    useGameStore.getState().setStats(patch);
+    if (typeof total === "number") {
+      const streak = e.detail?.streak;
+      const xp = total % 100;
+      const level = Math.floor(total / 100) + 1;
+      const patch: Partial<Stats> = { xp, level };
+      if (typeof streak === "number") patch.streak = streak;
+      useGameStore.getState().setStats(patch);
+    }
+    // Also refresh from server for accuracy
+    useGameStore.getState().fetchStats().catch(() => {});
   });
 }

--- a/src/hooks/useSupabaseAuth.tsx
+++ b/src/hooks/useSupabaseAuth.tsx
@@ -2,13 +2,13 @@
 import { useEffect, useState } from "react";
 import type { Session, User } from "@supabase/supabase-js";
 import { supabase } from "@/integrations/supabase/client";
-import { useGameStore, type Stats } from "@/game/store";
+import { useGameStore } from "@/game/store";
 
 export function useSupabaseAuth() {
   const [session, setSession] = useState<Session | null>(null);
   const [user, setUser] = useState<User | null>(null);
   const [initializing, setInitializing] = useState(true);
-  const setStats = useGameStore(s => s.setStats);
+  const fetchStats = useGameStore(s => s.fetchStats);
 
   useEffect(() => {
     const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, newSession) => {
@@ -28,23 +28,10 @@ export function useSupabaseAuth() {
     }, []);
 
   useEffect(() => {
-    if (!user) return;
-    supabase
-      .from("user_stats")
-      .select("total_xp, streak_count")
-      .eq("user_id", user.id)
-      .maybeSingle()
-      .then(({ data }) => {
-        if (!data) return;
-        const total = data.total_xp ?? 0;
-        const xp = total % 100;
-        const level = Math.floor(total / 100) + 1;
-        const patch: Partial<Stats> = { xp, level };
-        if (typeof data.streak_count === "number") patch.streak = data.streak_count;
-        setStats(patch);
-      })
-      .catch(() => {});
-  }, [user, setStats]);
+    if (user) {
+      fetchStats().catch(() => {});
+    }
+  }, [user, fetchStats]);
 
   return { session, user, initializing };
 }

--- a/src/integrations/supabase/gameSync.ts
+++ b/src/integrations/supabase/gameSync.ts
@@ -18,7 +18,9 @@ export async function awardXPRemote(activity: string, amount: number, metadata: 
     logger.debug("[gameSync] awardXPRemote skipped (no user)", { activity, amount });
     return null;
   }
-  const { data, error } = await supabase.rpc("award_xp", { activity, amount, metadata });
+  const { data, error } = await supabase.functions.invoke("award_xp", {
+    body: { activity, amount, metadata },
+  });
   if (error) {
     console.error("[gameSync] award_xp error", error);
     return null;
@@ -26,7 +28,7 @@ export async function awardXPRemote(activity: string, amount: number, metadata: 
   logger.info("[gameSync] award_xp ok", data);
   // Notify UI so components like XPBar can reflect server totals instantly
   try {
-    const first = Array.isArray(data) ? data[0] : data as any;
+    const first = Array.isArray(data) ? data[0] : (data as any);
     const total = first?.total_xp ?? null;
     const streak = first?.streak_count;
     if (typeof total === "number") {

--- a/src/nodes/HypnosisRunner.tsx
+++ b/src/nodes/HypnosisRunner.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useProgressStore } from "@/state/progress";
-import { supabase } from "@/integrations/supabase/client";
 import HypnoSphere from "@/components/effects/HypnoSphere";
+import { awardXPRemote } from "@/integrations/supabase/gameSync";
 
 type Props = { node: { id: string; label: string; script?: string; duration?: number }; onExit: () => void };
 
@@ -46,7 +46,7 @@ export default function HypnosisRunner({ node, onExit }: Props) {
     // Award XP + streak
     awardXP(25, { activity: "hypnosis", nodeId: node.id });
     try {
-      await supabase.rpc("award_xp", { activity: "hypnosis_session", amount: 25, metadata: { node_id: node.id } });
+      await awardXPRemote("hypnosis_session", 25, { node_id: node.id });
     } catch {}
     complete(node.id);
   };

--- a/supabase/functions/award_xp/index.ts
+++ b/supabase/functions/award_xp/index.ts
@@ -1,0 +1,56 @@
+import "https://deno.land/x/xhr@0.1.0/mod.ts";
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const supabaseKey = Deno.env.get("SUPABASE_ANON_KEY");
+    if (!supabaseUrl || !supabaseKey) {
+      throw new Error("Missing Supabase env vars");
+    }
+    const supabase = createClient(supabaseUrl, supabaseKey, {
+      global: { headers: { Authorization: req.headers.get("Authorization") || "" } },
+    });
+
+    const { data: auth } = await supabase.auth.getUser();
+    if (!auth.user) {
+      return new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const { activity, amount, metadata = {} } = body ?? {};
+
+    const { data, error } = await supabase.rpc("award_xp", {
+      activity,
+      amount,
+      metadata,
+    });
+
+    if (error) {
+      throw error;
+    }
+
+    return new Response(JSON.stringify(data), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    console.error("award_xp error", error);
+    return new Response(JSON.stringify({ error: String(error) }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add Supabase edge function `award_xp`
- call award_xp for task completion and hypnosis events
- sync user stats on login and XP updates, surface level/streak in HUD

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any, no-empty, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689894bf72608326b9cb898fc0fcef02