### PR TITLE
Add hypnosis scripts with conditional TTS playback

### DIFF
--- a/src/data/hypno/scripts.ts
+++ b/src/data/hypno/scripts.ts
@@ -1,0 +1,11 @@
+export const defaultHypnosisScripts = {
+  calm: `Close your eyes and take a slow, deep breath. With each exhale, feel your shoulders drop and your mind grow quieter. Allow a gentle wave of relaxation to flow from the top of your head down to your toes. You are calm, centered, and safe.`,
+  focus: `Let your attention settle on the rhythm of your breathing. Each inhale brings clarity; each exhale releases distraction. See your goals ahead of you and feel a steady determination guiding you forward. Your mind is sharp and focused.`,
+  confidence: `Picture a warm light glowing in your chest, growing brighter with every breath. It spreads through your body, filling you with strength and certainty. You carry this confidence with you, ready to face any challenge.`
+} as const;
+
+export type HypnosisScriptId = keyof typeof defaultHypnosisScripts;
+
+export function getHypnosisScript(id: HypnosisScriptId): string {
+  return defaultHypnosisScripts[id];
+}

--- a/src/data/roadmap.ts
+++ b/src/data/roadmap.ts
@@ -14,15 +14,38 @@ export type RoadmapNode = {
 
 export type Track = { id: string; label: string; nodes: RoadmapNode[] };
 
+import { defaultHypnosisScripts } from "./hypno/scripts";
+
 export const tracks: Track[] = [
   {
     id: "mind",
     label: "Mind Power",
     nodes: [
-      { id: "hypno-calm-60", label: "Calm Induction", type: "hypnosis", duration: 60 },
+      {
+        id: "hypno-calm-60",
+        label: "Calm Induction",
+        type: "hypnosis",
+        duration: 60,
+        script: defaultHypnosisScripts.calm,
+      },
       { id: "coach-intro", label: "Coach: Setup", type: "coach" },
       { id: "reward-1", label: "Reward: Orb Glow", type: "reward" },
-      { id: "hypno-focus-120", label: "Focus Induction", type: "hypnosis", duration: 120, locked: true },
+      {
+        id: "hypno-focus-120",
+        label: "Focus Induction",
+        type: "hypnosis",
+        duration: 120,
+        locked: true,
+        script: defaultHypnosisScripts.focus,
+      },
+      {
+        id: "hypno-confidence-90",
+        label: "Confidence Boost",
+        type: "hypnosis",
+        duration: 90,
+        locked: true,
+        script: defaultHypnosisScripts.confidence,
+      },
     ],
   },
   {

--- a/src/hypno/tts.ts
+++ b/src/hypno/tts.ts
@@ -1,0 +1,51 @@
+import { supabase } from "@/integrations/supabase/client";
+
+export type PlaybackHandle = {
+  stop: () => void;
+};
+
+/**
+ * Play hypnosis text using high quality audio when available.
+ * Falls back to the Web Speech API if the Supabase function fails.
+ */
+export async function playHypno(text: string, onEnd: () => void): Promise<PlaybackHandle | null> {
+  // Try ElevenLabs via Supabase function
+  try {
+    const { data, error } = await supabase.functions.invoke("tts-generate", {
+      body: { text },
+    });
+    if (!error && data?.audioBase64) {
+      const src = `data:${data.contentType};base64,${data.audioBase64}`;
+      const audio = new Audio(src);
+      audio.onended = onEnd;
+      await audio.play();
+      return {
+        stop: () => {
+          audio.pause();
+          audio.currentTime = 0;
+        },
+      };
+    }
+  } catch (e) {
+    console.error("[hypno] tts-generate failed", e);
+  }
+
+  // Fallback to Web Speech API
+  if (typeof window !== "undefined" && "speechSynthesis" in window) {
+    try { window.speechSynthesis.cancel(); } catch {}
+    const utter = new SpeechSynthesisUtterance(text);
+    utter.rate = 0.95;
+    utter.pitch = 1.0;
+    utter.onend = onEnd;
+    window.speechSynthesis.speak(utter);
+    return {
+      stop: () => {
+        try { window.speechSynthesis.cancel(); } catch {}
+      },
+    };
+  }
+
+  // If no TTS available, immediately end
+  onEnd();
+  return null;
+}

--- a/src/nodes/HypnosisRunner.tsx
+++ b/src/nodes/HypnosisRunner.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useProgressStore } from "@/state/progress";
-import { supabase } from "@/integrations/supabase/client";
+import { useGameStore } from "@/game/store";
+import { playHypno, type PlaybackHandle } from "@/hypno/tts";
 import HypnoSphere from "@/components/effects/HypnoSphere";
 
 type Props = { node: { id: string; label: string; script?: string; duration?: number }; onExit: () => void };
@@ -10,7 +11,7 @@ export default function HypnosisRunner({ node, onExit }: Props) {
   const [elapsed, setElapsed] = useState(0);
   const [ended, setEnded] = useState(false);
   const timerRef = useRef<number | null>(null);
-  const utterRef = useRef<SpeechSynthesisUtterance | null>(null);
+  const playbackRef = useRef<PlaybackHandle | null>(null);
   const { awardXP, complete } = useProgressStore();
 
   const duration = Math.min(180, Math.max(60, node.duration ?? 90));
@@ -21,16 +22,7 @@ export default function HypnosisRunner({ node, onExit }: Props) {
     setPlaying(true);
     setEnded(false);
 
-    // Fallback TTS via Web Speech
-    if ("speechSynthesis" in window) {
-      try { window.speechSynthesis.cancel(); } catch {}
-      const u = new SpeechSynthesisUtterance(text);
-      u.rate = 0.95;
-      u.pitch = 1.0;
-      u.onend = handleEnd;
-      utterRef.current = u;
-      window.speechSynthesis.speak(u);
-    }
+    playbackRef.current = await playHypno(text, handleEnd);
 
     const startedAt = performance.now();
     timerRef.current = window.setInterval(() => {
@@ -44,20 +36,16 @@ export default function HypnosisRunner({ node, onExit }: Props) {
     timerRef.current && clearInterval(timerRef.current);
 
     // Award XP + streak
-    awardXP(25, { activity: "hypnosis", nodeId: node.id });
-    try {
-      await supabase.rpc("award_xp", { activity: "hypnosis_session", amount: 25, metadata: { node_id: node.id } });
-    } catch {}
+    const amount = 25;
+    awardXP(amount, { activity: "hypnosis", nodeId: node.id });
+    useGameStore.getState().awardXP(amount);
+    useGameStore.getState().incStreak();
     complete(node.id);
   };
 
   const stopAll = () => {
-    if (utterRef.current) {
-      try {
-        window.speechSynthesis.cancel();
-      } catch {}
-      utterRef.current = null;
-    }
+    playbackRef.current?.stop();
+    playbackRef.current = null;
     timerRef.current && clearInterval(timerRef.current);
   };
 

--- a/src/views/HypnoView.tsx
+++ b/src/views/HypnoView.tsx
@@ -1,10 +1,12 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import HypnosisRunner from "@/nodes/HypnosisRunner";
 import { getNodeById } from "@/data/roadmap";
 
 export default function HypnoView() {
   const nav = useNavigate();
-  const node = getNodeById("hypno-calm-60");
+  const [params] = useSearchParams();
+  const nodeId = params.get("id") ?? "hypno-calm-60";
+  const node = getNodeById(nodeId);
   if (!node) return <div className="p-6">Session unavailable.</div>;
   return (
     <div className="container mx-auto px-4 py-4">


### PR DESCRIPTION
## Summary
- Add default calm, focus, and confidence hypnosis scripts and reference them in roadmap nodes
- Introduce reusable TTS helper that uses Supabase ElevenLabs function with Web Speech fallback
- Allow Hypno sessions to pick scripts via query parameter and award XP and streak on completion

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 169 problems)*
- `npm run build` *(fails: TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6899309c20f88326ac4d1537bed30b01