### PR TITLE
feat: add onboarding flow page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import HypnoShell from "@/routes/hypno/HypnoShell";
 import ExtensionPage from "@/pages/Extension";
 import StackPage from "./pages/Stack";
 import AppShell from "@/routes/AppShell";
+import OnboardingFlow from "./pages/OnboardingFlow";
 const queryClient = new QueryClient();
 
 const App = () => (
@@ -26,6 +27,7 @@ const App = () => (
           <Route path="/world" element={<MindWorldDashboard />} />
           <Route path="/home" element={<Index />} />
           <Route path="/auth" element={<AuthPage />} />
+          <Route path="/onboarding" element={<OnboardingFlow />} />
           <Route path="/browser" element={<Navigate to="/app/browser" replace />} />
           <Route path="/hypno" element={<HypnoShell />} />
           <Route path="/extension" element={<ExtensionPage />} />

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -19,7 +19,6 @@ import LandingPage from './LandingPage';
 import { type PathNode } from '@/game/path/path.data';
 import HUDBar from '@/game/hud/HUDBar';
 import FastTravel from '@/components/overlays/FastTravel';
-import Onboarding from '@/components/overlays/Onboarding';
 import HypnoPanel from '@/components/hypno/HypnoPanel';
 import { useGameStore } from '@/game/store';
 import { REWARDS, DAILY_QUESTS } from '@/game/QuestEngine';
@@ -682,7 +681,6 @@ const Index = () => {
       {/* Overlays */}
       <FastTravel />
       <HypnoPanel />
-      <Onboarding />
     </div>
   );
 };

--- a/src/pages/OnboardingFlow.tsx
+++ b/src/pages/OnboardingFlow.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { supabase } from "@/integrations/supabase/client";
+import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Progress } from "@/components/ui/progress";
+
+type Msg = { role: "assistant" | "user"; content: string };
+
+const QUESTIONS = [
+  "What are your main goals right now?",
+  "What personal values matter most to you?",
+  "What key skills do you want to develop?",
+  "What habits would help you grow?",
+  "What challenges are you facing?",
+];
+
+export default function OnboardingFlow() {
+  const { user } = useSupabaseAuth();
+  const navigate = useNavigate();
+  const [messages, setMessages] = useState<Msg[]>([]);
+  const [step, setStep] = useState(0);
+  const [input, setInput] = useState("");
+  const total = QUESTIONS.length;
+
+  // ask next question
+  useEffect(() => {
+    if (step < total) {
+      setMessages((m) => [...m, { role: "assistant", content: QUESTIONS[step] }]);
+    } else if (step === total && user) {
+      // finished
+      supabase
+        .from("profiles")
+        .update({ onboarded_at: new Date().toISOString() })
+        .eq("id", user.id)
+        .then(() => navigate("/app", { replace: true }));
+    }
+  }, [step, total, user, navigate]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+    const userMsg: Msg = { role: "user", content: input.trim() };
+    const newMessages = [...messages, userMsg];
+    setMessages(newMessages);
+    setInput("");
+
+    const { data } = await supabase.functions.invoke("aurora-chat", {
+      body: {
+        messages: [
+          {
+            role: "system",
+            content:
+              "You are a friendly onboarding assistant. Keep replies short and encouraging.",
+          },
+          ...newMessages,
+        ],
+      },
+    });
+    if (data?.content) {
+      setMessages((m) => [...m, { role: "assistant", content: data.content }]);
+    }
+
+    setStep((s) => s + 1);
+  };
+
+  const progress = (step / total) * 100;
+
+  return (
+    <div className="relative min-h-svh w-screen grid place-items-center p-4">
+      <div className="os-bg" />
+      <Card className="w-full max-w-md p-6 space-y-4">
+        <Progress value={progress} />
+        <div className="space-y-3 text-sm">
+          {messages.map((m, i) => (
+            <div
+              key={i}
+              className={m.role === "assistant" ? "text-muted-foreground" : "text-right"}
+            >
+              {m.content}
+            </div>
+          ))}
+        </div>
+        {step < total && (
+          <form onSubmit={handleSubmit} className="space-y-2">
+            <Textarea
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="Your answer..."
+            />
+            <Button type="submit" className="w-full">
+              Continue
+            </Button>
+          </form>
+        )}
+      </Card>
+    </div>
+  );
+}
+

--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useEffect, useMemo } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import { Route, Routes, useLocation, Navigate } from "react-router-dom";
 import { AnimatePresence, motion } from "framer-motion";
 import { views, type ViewId } from "@/views/registry";
@@ -9,11 +9,28 @@ import { useViewNav } from "@/state/view";
 import { useXPChime } from "@/hooks/useXPChime";
 import { useSwipeNav } from "@/hooks/useSwipeNav";
 import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
+import { supabase } from "@/integrations/supabase/client";
 import ControlView from "@/views/ControlView";
 export default function AppShell() {
   const { user, initializing } = useSupabaseAuth();
   const loc = useLocation();
   const open = useViewNav();
+  const [onboarded, setOnboarded] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (user) {
+      supabase
+        .from("profiles")
+        .select("onboarded_at")
+        .eq("id", user.id)
+        .maybeSingle()
+        .then(({ data }) => {
+          setOnboarded(!!data?.onboarded_at);
+        });
+    } else {
+      setOnboarded(null);
+    }
+  }, [user]);
 
   const currentRoom = useMemo(() => {
     const match = views.find((v) => {
@@ -82,7 +99,7 @@ export default function AppShell() {
     }
   }, [loc.pathname, loc.search]);
 
-  if (initializing) {
+  if (initializing || (user && onboarded === null)) {
     return (
       <div className="relative min-h-svh w-screen grid place-items-center">
         <div className="os-bg" />
@@ -93,6 +110,10 @@ export default function AppShell() {
 
   if (!user) {
     return <Navigate to="/auth" replace />;
+  }
+
+  if (onboarded === false) {
+    return <Navigate to="/onboarding" replace />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- add OnboardingFlow page with sequential chat-based questions
- redirect users to /onboarding until onboarded_at is set
- remove old overlay-based onboarding

## Testing
- `npm run lint` *(fails: Unexpected any, Empty block statement, etc.)*
- `npm run build` *(fails: Type errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68993384a4408326a21eb3ffcbe8273c