### PR TITLE
feat: validate onboarding answers

### DIFF
--- a/src/pages/OnboardingFlow.tsx
+++ b/src/pages/OnboardingFlow.tsx
@@ -8,6 +8,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Progress } from "@/components/ui/progress";
 
 type Msg = { role: "assistant" | "user"; content: string };
+type ChatMsg = Msg | { role: "system"; content: string };
 
 const QUESTIONS = [
   "What are your main goals right now?",
@@ -17,12 +18,26 @@ const QUESTIONS = [
   "What challenges are you facing?",
 ];
 
+const MIN_LENGTH = 10;
+const REQUIRED_KEYWORDS = ["goal", "value", "skill", "habit", "challenge"];
+
+function validateAnswer(answer: string, step: number): string | null {
+  if (answer.length < MIN_LENGTH)
+    return `Please provide at least ${MIN_LENGTH} characters.`;
+  const keyword = REQUIRED_KEYWORDS[step];
+  if (keyword && !answer.toLowerCase().includes(keyword)) {
+    return `Please mention the word "${keyword}" in your response.`;
+  }
+  return null;
+}
+
 export default function OnboardingFlow() {
   const { user } = useSupabaseAuth();
   const navigate = useNavigate();
   const [messages, setMessages] = useState<Msg[]>([]);
   const [step, setStep] = useState(0);
   const [input, setInput] = useState("");
+  const [answers, setAnswers] = useState<string[]>([]);
   const total = QUESTIONS.length;
 
   // ask next question
@@ -47,22 +62,33 @@ export default function OnboardingFlow() {
     setMessages(newMessages);
     setInput("");
 
-    const { data } = await supabase.functions.invoke("aurora-chat", {
-      body: {
-        messages: [
-          {
-            role: "system",
-            content:
-              "You are a friendly onboarding assistant. Keep replies short and encouraging.",
-          },
-          ...newMessages,
-        ],
+    const error = validateAnswer(userMsg.content, step);
+
+    const baseMessages: ChatMsg[] = [
+      {
+        role: "system",
+        content:
+          "You are a friendly onboarding assistant. Keep replies short and encouraging.",
       },
+      ...newMessages,
+    ];
+
+    if (error) {
+      baseMessages.push({
+        role: "system",
+        content: `The user's last answer failed validation: ${error} Ask them to clarify or provide more detail.`,
+      });
+    }
+
+    const { data } = await supabase.functions.invoke("aurora-chat", {
+      body: { messages: baseMessages },
     });
     if (data?.content) {
       setMessages((m) => [...m, { role: "assistant", content: data.content }]);
     }
+    if (error) return;
 
+    setAnswers((a) => [...a, userMsg.content]);
     setStep((s) => s + 1);
   };
 


### PR DESCRIPTION
## Summary
- add validation for onboarding responses using minimum length and keyword checks
- request AI clarification when validation fails
- store valid responses in local state

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npx eslint src/pages/OnboardingFlow.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6899b6ab5d648326b8e8b3d6085b7009