### PR TITLE
fix: resolve brain imports for aurora-chat

### DIFF
--- a/supabase/functions/aurora-chat/index.ts
+++ b/supabase/functions/aurora-chat/index.ts
@@ -1,8 +1,8 @@
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 
-import brain from "@/brain/brain/Brain.ts";
-import { getFilterName } from "@/brain/brain/filters.ts";
+import brain from "../../../src/brain/Brain.ts";
+import { getFilterName } from "../../../src/brain/filters.ts";
 
 
 const corsHeaders = {


### PR DESCRIPTION
## Summary
- fix `aurora-chat` function imports to use relative paths for brain modules

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint supabase/functions/aurora-chat/index.ts` *(fails: Cannot find package '@eslint/js')*
- `DENO_TLS_CA_STORE=system deno check supabase/functions/aurora-chat/index.ts`
- `curl -i -X OPTIONS localhost:8000`

------
https://chatgpt.com/codex/tasks/task_e_689a01ac66f883268ee69e4c6f163d50