### PR TITLE
feat: add trigger to habits

### DIFF
--- a/src/views/MasterPlanView.tsx
+++ b/src/views/MasterPlanView.tsx
@@ -44,6 +44,7 @@ interface DBHabit {
   id: string;
   title: string;
   frequency: string | null;
+  trigger: string | null;
   status: string | null;
 }
 
@@ -72,7 +73,7 @@ export default function MasterPlanView() {
         .order("created_at", { ascending: true }),
       supabase
         .from("habits")
-        .select("id, title, frequency, status")
+        .select("id, title, frequency, trigger, status")
         .eq("user_id", user.id)
         .order("created_at", { ascending: true }),
     ]);
@@ -92,7 +93,7 @@ export default function MasterPlanView() {
     return map;
   }, [roadmaps]);
 
-  const updateHabit = async (id: string, fields: { title?: string; frequency?: string }) => {
+  const updateHabit = async (id: string, fields: { title?: string; frequency?: string; trigger?: string }) => {
     if (!user) { toast({ title: "Sign in required", description: "Connect Supabase to edit habits." }); return; }
     const { error } = await supabase
       .from("habits")
@@ -179,6 +180,12 @@ export default function MasterPlanView() {
                   onChange={(e) => setHabits(prev => prev.map(x => x.id === h.id ? { ...x, frequency: e.target.value } : x))}
                   onBlur={(e) => updateHabit(h.id, { frequency: e.target.value })}
                   placeholder="Frequency"
+                />
+                <Input
+                  value={h.trigger ?? ""}
+                  onChange={(e) => setHabits(prev => prev.map(x => x.id === h.id ? { ...x, trigger: e.target.value } : x))}
+                  onBlur={(e) => updateHabit(h.id, { trigger: e.target.value })}
+                  placeholder="Trigger"
                 />
               </div>
             ))}

--- a/supabase/functions/generate-plan/index.ts
+++ b/supabase/functions/generate-plan/index.ts
@@ -171,6 +171,7 @@ serve(async (req) => {
           user_id: auth.user.id,
           title: habit.title,
           frequency: habit.frequency ?? null,
+          trigger: habit.trigger ?? null,
         });
         if (hError) throw hError;
       }

--- a/supabase/migrations/20250811155616_add_trigger_to_habits.sql
+++ b/supabase/migrations/20250811155616_add_trigger_to_habits.sql
@@ -1,0 +1,2 @@
+-- Add trigger column to habits
+alter table public.habits add column if not exists trigger text;


### PR DESCRIPTION
## Summary
- add migration to include `trigger` column in `habits`
- store `trigger` when generating plans
- allow viewing and editing `trigger` in MasterPlan view

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*
- `npm run build` *(fails: TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689a12455dfc8326b06fb0580fe64809