### PR TITLE
Expose current task to floating assistant

### DIFF
--- a/src/components/live/FloatingAssistant.tsx
+++ b/src/components/live/FloatingAssistant.tsx
@@ -11,18 +11,13 @@ import { Input } from '@/components/ui/input';
 import { MessageSquare, Send, X, Bot, Minimize2, Mic, Volume2 } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
 import { useLocation } from 'react-router-dom';
+import type { Task } from '@/state/task';
 
 // Minimal typings for browsers without built-in Web Speech definitions
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type SpeechRecognition = any;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type SpeechRecognitionEvent = any;
-
-type Task = {
-  id: string;
-  title: string;
-  description: string | null;
-};
 
 type ChatMessage = {
   id: string;
@@ -96,11 +91,19 @@ export function FloatingAssistant({
         .concat(userMsg)
         .slice(-12)
         .map((m) => ({ role: m.role, content: m.content }));
-      const context = `Route: ${loc.pathname}${task ? ` | Task: ${task.title}` : ''}`;
+      const systemMessages: { role: 'system'; content: string }[] = [
+        { role: 'system', content: `Route: ${loc.pathname}` },
+      ];
+      if (task) {
+        systemMessages.push({
+          role: 'system',
+          content: `Task: ${JSON.stringify({ id: task.id, title: task.title, description: task.description })}`,
+        });
+      }
       const { data, error } = await supabase.functions.invoke('aurora-chat', {
         body: {
           model: 'o4-mini-2025-04-16',
-          messages: [{ role: 'system', content: context }, ...history],
+          messages: [...systemMessages, ...history],
         },
       });
       if (error) throw error;

--- a/src/components/live/LiveFocusView.tsx
+++ b/src/components/live/LiveFocusView.tsx
@@ -15,6 +15,7 @@ import { PanelHeaderUnified } from '@/components/layout/PanelHeaderUnified';
 import QuickAddTaskFAB from '@/components/tasks/QuickAddTaskFAB';
 import { StreakBadge } from '@/components/live/StreakBadge';
 import { setActiveRoadmap, fetchNextTask } from '@/modules/roadmaps';
+import { useCurrentTask, type Task } from '@/state/task';
 
 type Roadmap = {
   id: string;
@@ -24,15 +25,6 @@ type Roadmap = {
   status: string;
 };
 
-type Task = {
-  id: string;
-  title: string;
-  description: string | null;
-  due_at: string | null;
-  roadmap_id: string;
-  status: string;
-  position: number | null;
-};
 
 export default function LiveFocusView({
   onManageRoadmaps,
@@ -49,6 +41,11 @@ export default function LiveFocusView({
     activeRoadmap?.id ?? null
   );
   const [reloadKey, setReloadKey] = useState(0);
+  const setCurrentTaskStore = useCurrentTask((s) => s.setCurrentTask);
+
+  useEffect(() => {
+    setCurrentTaskStore(task);
+  }, [task, setCurrentTaskStore]);
 
   // Load roadmaps, active roadmap, and focused task
   useEffect(() => {

--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -4,6 +4,7 @@ import { AnimatePresence, motion } from "framer-motion";
 import { views, type ViewId } from "@/views/registry";
 import { GameHUD } from "@/components/game/GameHUD";
 import { FloatingAssistant } from "@/components/live/FloatingAssistant";
+import { useCurrentTask } from "@/state/task";
 import { bus } from "@/utils/bus";
 import { useViewNav } from "@/state/view";
 import { useXPChime } from "@/hooks/useXPChime";
@@ -16,6 +17,7 @@ export default function AppShell() {
   const loc = useLocation();
   const open = useViewNav();
   const [onboarded, setOnboarded] = useState<boolean | null>(null);
+  const currentTask = useCurrentTask((s) => s.currentTask);
 
   useEffect(() => {
     if (user) {
@@ -147,7 +149,7 @@ export default function AppShell() {
       </AnimatePresence>
 
 
-      <FloatingAssistant task={null} onUpdated={() => {}} />
+      <FloatingAssistant task={currentTask} onUpdated={() => {}} />
       <GameHUD />
     </div>
   );

--- a/src/state/task.ts
+++ b/src/state/task.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+
+export type Task = {
+  id: string;
+  title: string;
+  description: string | null;
+  due_at: string | null;
+  roadmap_id: string;
+  status: string;
+  position: number | null;
+};
+
+type TaskState = {
+  currentTask: Task | null;
+  setCurrentTask: (task: Task | null) => void;
+};
+
+export const useCurrentTask = create<TaskState>((set) => ({
+  currentTask: null,
+  setCurrentTask: (task) => set({ currentTask: task }),
+}));


### PR DESCRIPTION
## Summary
- share current task via a dedicated Zustand store
- sync live focus view's task into the new store
- pass stored task to FloatingAssistant and include task data in assistant context

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a171fc23c8326bc8a7026b4d548d0