### PR TITLE
feat: add plan update engine and hook

### DIFF
--- a/src/brain/masterPlan.ts
+++ b/src/brain/masterPlan.ts
@@ -147,12 +147,19 @@ export function addTrigger (task: Task, trigger: MotivationalTrigger): void {
   task.triggers.push(trigger)
 }
 
-export interface MasterPlan {
+export interface MasterPlanVersion {
   goals: Goal[]
+  habits?: Task[]
+}
+
+export interface MasterPlan extends MasterPlanVersion {
+  plan_versions?: MasterPlanVersion[]
 }
 
 export const masterPlan: MasterPlan = {
-  goals: []
+  goals: [],
+  habits: [],
+  plan_versions: []
 }
 
 export default masterPlan

--- a/src/brain/updateEngine.ts
+++ b/src/brain/updateEngine.ts
@@ -1,0 +1,86 @@
+import { UserProfile } from "@/data/profile";
+import { MasterPlan, Goal, Task, createGoal } from "./masterPlan";
+
+// Utility to generate unique ids without external deps
+function uid(): string {
+  if (typeof globalThis !== "undefined" && globalThis.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2);
+}
+
+function parseList(value?: string): string[] {
+  return value ? value.split(/\r?\n/).map((s) => s.trim()).filter(Boolean) : [];
+}
+
+function diffLists(oldList: string[], newList: string[]) {
+  const added = newList.filter((n) => !oldList.includes(n));
+  const removed = oldList.filter((o) => !newList.includes(o));
+  return { added, removed };
+}
+
+export interface ProfileDiff {
+  goals: { added: string[]; removed: string[] };
+  habits: { added: string[]; removed: string[] };
+}
+
+export function diffUserProfile(oldProfile: UserProfile, newProfile: UserProfile): ProfileDiff {
+  const oldGoals = parseList(oldProfile.goals);
+  const newGoals = parseList(newProfile.goals);
+  const oldHabits = parseList(oldProfile.habits);
+  const newHabits = parseList(newProfile.habits);
+  return {
+    goals: diffLists(oldGoals, newGoals),
+    habits: diffLists(oldHabits, newHabits),
+  };
+}
+
+function generateGoalStructure(name: string): Goal {
+  return createGoal(
+    name,
+    [`${name} annual milestone`],
+    [`${name} quarterly milestone`],
+    [
+      {
+        id: uid(),
+        title: `Daily progress for ${name}`,
+        frequency: "daily",
+      },
+    ],
+    [
+      {
+        id: uid(),
+        title: `Weekly review of ${name}`,
+        frequency: "weekly",
+      },
+    ],
+  );
+}
+
+function generateHabitTask(title: string): Task {
+  return { id: uid(), title, frequency: "daily" };
+}
+
+export function updatePlan(
+  oldProfile: UserProfile,
+  newProfile: UserProfile,
+  plan: MasterPlan,
+): MasterPlan {
+  const diff = diffUserProfile(oldProfile, newProfile);
+
+  const snapshot = JSON.parse(JSON.stringify({ ...plan, plan_versions: undefined })) as MasterPlan;
+  const versions = plan.plan_versions ? [...plan.plan_versions, snapshot] : [snapshot];
+
+  const goals = plan.goals.filter((g) => !diff.goals.removed.includes(g.name));
+  for (const g of diff.goals.added) {
+    goals.push(generateGoalStructure(g));
+  }
+
+  const habits = (plan.habits ?? []).filter((h) => !diff.habits.removed.includes(h.title));
+  for (const h of diff.habits.added) {
+    habits.push(generateHabitTask(h));
+  }
+
+  return { goals, habits, plan_versions: versions };
+}
+

--- a/src/hooks/usePlanUpdater.ts
+++ b/src/hooks/usePlanUpdater.ts
@@ -1,0 +1,19 @@
+import { useCallback, useState } from "react";
+import { UserProfile } from "@/data/profile";
+import { MasterPlan } from "@/brain/masterPlan";
+import { updatePlan } from "@/brain/updateEngine";
+
+export function usePlanUpdater(initialPlan?: MasterPlan) {
+  const [plan, setPlan] = useState<MasterPlan>(
+    initialPlan ?? { goals: [], habits: [], plan_versions: [] },
+  );
+
+  const update = useCallback(
+    (oldProfile: UserProfile, newProfile: UserProfile) => {
+      setPlan((prev) => updatePlan(oldProfile, newProfile, prev));
+    },
+    [],
+  );
+
+  return { plan, update } as const;
+}


### PR DESCRIPTION
## Summary
- add update engine to diff profile changes and recompute affected goals and habits
- store historical plan versions and expose hook for UI plan updates

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, Empty block statement, A `require()` style import is forbidden and more)*

------
https://chatgpt.com/codex/tasks/task_e_689a1fc92f1883269665930625dc491b