### PR TITLE
feat: add encrypted profile storage

### DIFF
--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -1,0 +1,16 @@
+import { saveProfile, loadProfile } from "./storage";
+
+describe("storage", () => {
+  it("saves and loads profile with encryption", () => {
+    const profile = {
+      userId: "user1",
+      password: "password123",
+      name: "Alice",
+      goals: ["grow"],
+    };
+
+    saveProfile(profile);
+    const loaded = loadProfile("user1", "password123");
+    expect(loaded).toEqual({ userId: "user1", name: "Alice", goals: ["grow"] });
+  });
+});

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,84 @@
+import { randomBytes, pbkdf2Sync, createCipheriv, createDecipheriv } from "crypto";
+
+interface SaveProfileInput {
+  userId: string;
+  password: string;
+  [key: string]: any;
+}
+
+interface StoredPayload {
+  salt: string;
+  iv: string;
+  tag: string;
+  data: string;
+}
+
+const STORAGE_PREFIX = "profile:";
+
+interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem?(key: string): void;
+  clear?(): void;
+}
+
+const createMemoryStorage = (): StorageLike => {
+  const store: Record<string, string> = {};
+  return {
+    getItem: (key) => (key in store ? store[key] : null),
+    setItem: (key, value) => {
+      store[key] = value;
+    },
+    removeItem: (key) => {
+      delete store[key];
+    },
+    clear: () => {
+      for (const k of Object.keys(store)) delete store[k];
+    },
+  };
+};
+
+const storage: StorageLike =
+  typeof globalThis !== "undefined" && (globalThis as any).localStorage
+    ? (globalThis as any).localStorage
+    : createMemoryStorage();
+
+export function saveProfile(profile: SaveProfileInput): void {
+  const { userId, password, ...data } = profile;
+  const salt = randomBytes(16);
+  const iv = randomBytes(12);
+  const key = pbkdf2Sync(password, salt, 100000, 32, "sha256");
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(JSON.stringify({ userId, ...data }), "utf8"),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+
+  const payload: StoredPayload = {
+    salt: salt.toString("base64"),
+    iv: iv.toString("base64"),
+    tag: tag.toString("base64"),
+    data: ciphertext.toString("base64"),
+  };
+
+  storage.setItem(STORAGE_PREFIX + userId, JSON.stringify(payload));
+}
+
+export function loadProfile(userId: string, password: string): any | null {
+  const raw = storage.getItem(STORAGE_PREFIX + userId);
+  if (!raw) return null;
+
+  const payload: StoredPayload = JSON.parse(raw);
+  const salt = Buffer.from(payload.salt, "base64");
+  const iv = Buffer.from(payload.iv, "base64");
+  const tag = Buffer.from(payload.tag, "base64");
+  const data = Buffer.from(payload.data, "base64");
+
+  const key = pbkdf2Sync(password, salt, 100000, 32, "sha256");
+  const decipher = createDecipheriv("aes-256-gcm", key, iv);
+  decipher.setAuthTag(tag);
+  const decrypted = Buffer.concat([decipher.update(data), decipher.final()]);
+  return JSON.parse(decrypted.toString("utf8"));
+}
+


### PR DESCRIPTION
## Summary
- add AES-256-GCM encrypted storage utilities using PBKDF2 derived keys
- provide saveProfile and loadProfile helpers
- cover round-trip behavior with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a229d0ef883268540c8a8a19d9b2a