### PR TITLE
feat: add habit tracker with streaks

### DIFF
--- a/src/components/habits/HabitTracker.tsx
+++ b/src/components/habits/HabitTracker.tsx
@@ -1,0 +1,53 @@
+import { motion } from "framer-motion";
+import { Check } from "lucide-react";
+import { useHabitStore, Habit, isCompleted, getStreak } from "@/state/habits";
+
+export default function HabitTracker() {
+  const { habits, toggleHabit } = useHabitStore();
+  const daily = habits.filter((h) => h.frequency === "daily");
+  const weekly = habits.filter((h) => h.frequency === "weekly");
+
+  const renderHabit = (habit: Habit) => {
+    const done = isCompleted(habit);
+    const streak = getStreak(habit);
+    return (
+      <motion.button
+        key={habit.id}
+        whileTap={{ scale: 0.95 }}
+        onClick={() => toggleHabit(habit.id)}
+        className={`flex items-center w-full p-2 rounded-md border border-border text-left mb-2 transition-colors ${
+          done ? "bg-green-500 text-white" : "bg-background"
+        }`}
+      >
+        <span>{habit.title}</span>
+        <span className="ml-auto flex items-center gap-1 text-sm">
+          <span>🔥 {streak}</span>
+          {done && (
+            <motion.span initial={{ scale: 0 }} animate={{ scale: 1 }}>
+              <Check className="w-4 h-4" />
+            </motion.span>
+          )}
+        </span>
+      </motion.button>
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="font-medium mb-2">Daily Habits</h3>
+        {daily.length === 0 && (
+          <p className="text-sm text-muted-foreground">No daily habits.</p>
+        )}
+        {daily.map(renderHabit)}
+      </div>
+      <div>
+        <h3 className="font-medium mb-2">Weekly Habits</h3>
+        {weekly.length === 0 && (
+          <p className="text-sm text-muted-foreground">No weekly habits.</p>
+        )}
+        {weekly.map(renderHabit)}
+      </div>
+    </div>
+  );
+}

--- a/src/state/habits.ts
+++ b/src/state/habits.ts
@@ -1,0 +1,74 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { format, startOfWeek, addDays, addWeeks } from "date-fns";
+
+export type Habit = {
+  id: string;
+  title: string;
+  frequency: "daily" | "weekly";
+  completions: Record<string, boolean>;
+};
+
+type HabitState = {
+  habits: Habit[];
+  setHabits: (
+    list: { id: string; title: string; frequency: "daily" | "weekly" }[]
+  ) => void;
+  toggleHabit: (id: string, date?: Date) => void;
+};
+
+const keyFor = (habit: Habit, date: Date) =>
+  habit.frequency === "daily"
+    ? format(date, "yyyy-MM-dd")
+    : format(startOfWeek(date, { weekStartsOn: 1 }), "yyyy-MM-dd");
+
+export const useHabitStore = create<HabitState>()(
+  persist(
+    (set, get) => ({
+      habits: [],
+      setHabits: (list) =>
+        set((state) => {
+          const map = state.habits.reduce<Record<string, Habit>>((acc, h) => {
+            acc[h.id] = h;
+            return acc;
+          }, {});
+          const habits = list.map((h) =>
+            map[h.id]
+              ? { ...map[h.id], title: h.title, frequency: h.frequency }
+              : { ...h, completions: {} }
+          );
+          return { habits };
+        }),
+      toggleHabit: (id, date = new Date()) =>
+        set((state) => {
+          const habit = state.habits.find((h) => h.id === id);
+          if (!habit) return state;
+          const key = keyFor(habit, date);
+          const completions = { ...habit.completions };
+          if (completions[key]) delete completions[key];
+          else completions[key] = true;
+          const habits = state.habits.map((h) =>
+            h.id === id ? { ...h, completions } : h
+          );
+          return { habits };
+        }),
+    }),
+    { name: "aurora-habits" }
+  )
+);
+
+export const isCompleted = (habit: Habit, date = new Date()) =>
+  !!habit.completions[keyFor(habit, date)];
+
+export const getStreak = (habit: Habit) => {
+  let streak = 0;
+  let current = new Date();
+  while (habit.completions[keyFor(habit, current)]) {
+    streak++;
+    current =
+      habit.frequency === "daily"
+        ? addDays(current, -1)
+        : addWeeks(current, -1);
+  }
+  return streak;
+};

--- a/src/views/MasterPlanView.tsx
+++ b/src/views/MasterPlanView.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useMemo, useState } from "react";
 import GoalForm from "@/components/goals/GoalForm";
 import TasksManager from "@/components/control/TasksManager";
+import HabitTracker from "@/components/habits/HabitTracker";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { supabase } from "@/integrations/supabase/client";
 import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
 import { toast } from "@/hooks/use-toast";
+import { useHabitStore } from "@/state/habits";
 
 interface PlanTask {
   title: string;
@@ -52,7 +54,7 @@ export default function MasterPlanView() {
   const { user } = useSupabaseAuth();
   const [plan, setPlan] = useState<MasterPlan | null>(null);
   const [roadmaps, setRoadmaps] = useState<Roadmap[]>([]);
-  const [habits, setHabits] = useState<DBHabit[]>([]);
+  const [dbHabits, setDbHabits] = useState<DBHabit[]>([]);
   const [loading, setLoading] = useState(false);
 
   const fetchData = async () => {
@@ -81,7 +83,15 @@ export default function MasterPlanView() {
     const planRecord = planData as { plan: MasterPlan } | null;
     setPlan(planRecord?.plan ?? null);
     setRoadmaps((roadmapData as Roadmap[]) ?? []);
-    setHabits((habitData as DBHabit[]) ?? []);
+    const dbH = (habitData as DBHabit[]) ?? [];
+    setDbHabits(dbH);
+    useHabitStore.getState().setHabits(
+      dbH.map((h) => ({
+        id: h.id,
+        title: h.title,
+        frequency: h.frequency === "weekly" ? "weekly" : "daily",
+      }))
+    );
     setLoading(false);
   };
 
@@ -185,24 +195,25 @@ export default function MasterPlanView() {
 
           <div className="grid gap-4">
             <h2 className="text-xl font-semibold">Habits</h2>
-            {habits.length === 0 && <p className="text-sm text-muted-foreground">No habits yet.</p>}
-            {habits.map(h => (
+            <HabitTracker />
+            {dbHabits.length === 0 && <p className="text-sm text-muted-foreground">No habits yet.</p>}
+            {dbHabits.map(h => (
               <div key={h.id} className="rounded-lg border border-border p-3 flex flex-col sm:flex-row sm:items-center gap-3">
                 <Input
                   value={h.title}
-                  onChange={(e) => setHabits(prev => prev.map(x => x.id === h.id ? { ...x, title: e.target.value } : x))}
+                  onChange={(e) => setDbHabits(prev => prev.map(x => x.id === h.id ? { ...x, title: e.target.value } : x))}
                   onBlur={(e) => updateHabit(h.id, { title: e.target.value })}
                   placeholder="Habit title"
                 />
                 <Input
                   value={h.frequency ?? ""}
-                  onChange={(e) => setHabits(prev => prev.map(x => x.id === h.id ? { ...x, frequency: e.target.value } : x))}
+                  onChange={(e) => setDbHabits(prev => prev.map(x => x.id === h.id ? { ...x, frequency: e.target.value } : x))}
                   onBlur={(e) => updateHabit(h.id, { frequency: e.target.value })}
                   placeholder="Frequency"
                 />
                 <Input
                   value={h.trigger ?? ""}
-                  onChange={(e) => setHabits(prev => prev.map(x => x.id === h.id ? { ...x, trigger: e.target.value } : x))}
+                  onChange={(e) => setDbHabits(prev => prev.map(x => x.id === h.id ? { ...x, trigger: e.target.value } : x))}
                   onBlur={(e) => updateHabit(h.id, { trigger: e.target.value })}
                   placeholder="Trigger"
                 />


### PR DESCRIPTION
## Summary
- add Zustand habit store with persistent completions and streak helpers
- create HabitTracker component with animated checkmarks and streak display
- integrate HabitTracker into MasterPlanView and sync Supabase habits

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and other existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a22a04d4c8326ba591ef013ae30e8