### PR TITLE
Add task trigger scheduling and settings panel

### DIFF
--- a/src/components/control/TasksManager.tsx
+++ b/src/components/control/TasksManager.tsx
@@ -8,6 +8,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { toast } from "@/hooks/use-toast";
 import { useRoadmapProgress } from "@/hooks/useRoadmapProgress";
+import { scheduleTaskTriggers } from "@/lib/triggers";
 
 export type Task = {
   id: string;
@@ -58,6 +59,7 @@ export default function TasksManager({ roadmapId }: { roadmapId: string }) {
       return t;
     });
     setTasks(normalized);
+    scheduleTaskTriggers(normalized, { email: user?.email ?? undefined });
     if (needsUpdate) {
       // Persist positions
       await Promise.all(normalized.map((t) => supabase.from("tasks").update({ position: t.position }).eq("id", t.id)));

--- a/src/components/settings/TriggersPanel.tsx
+++ b/src/components/settings/TriggersPanel.tsx
@@ -1,0 +1,30 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Label } from "@/components/ui/label";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
+import { TriggerDelivery } from "@/lib/triggers";
+
+// Panel for configuring task trigger preferences.
+export default function TriggersPanel() {
+  const [delivery, setDelivery] = useLocalStorage<TriggerDelivery>("settings.triggerDelivery", "notification");
+
+  return (
+    <div className="space-y-2">
+      <h2 className="text-lg font-semibold">Task Triggers</h2>
+      <div className="flex flex-col gap-2 w-full max-w-sm">
+        <Label htmlFor="trigger-delivery">Default delivery</Label>
+        <Select value={delivery} onValueChange={(v) => setDelivery(v as TriggerDelivery)}>
+          <SelectTrigger id="trigger-delivery">
+            <SelectValue placeholder="Choose" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="notification">Browser notification</SelectItem>
+            <SelectItem value="email">Email</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Overdue tasks will use this delivery method.
+      </p>
+    </div>
+  );
+}

--- a/src/lib/triggers.ts
+++ b/src/lib/triggers.ts
@@ -1,0 +1,105 @@
+// Utilities for scheduling and firing task triggers.
+// Triggers can deliver messages either via browser notifications or email.
+
+export type TriggerDelivery = 'notification' | 'email';
+
+export interface Trigger {
+  /** Message to deliver when the trigger fires */
+  message: string;
+  /** Time when the trigger should fire */
+  schedule: Date;
+  /** Delivery mechanism */
+  delivery: TriggerDelivery;
+}
+
+const PREFERENCE_KEY = 'settings.triggerDelivery';
+const TRIGGERED_KEY = 'task.triggers.fired';
+const scheduled: Record<string, number> = {};
+
+function getPreference(): TriggerDelivery {
+  try {
+    const raw = localStorage.getItem(PREFERENCE_KEY);
+    return raw ? (JSON.parse(raw) as TriggerDelivery) : 'notification';
+  } catch {
+    return 'notification';
+  }
+}
+
+function getTriggered(): Record<string, boolean> {
+  try {
+    return JSON.parse(localStorage.getItem(TRIGGERED_KEY) || '{}');
+  } catch {
+    return {};
+  }
+}
+
+function markTriggered(id: string) {
+  try {
+    const fired = getTriggered();
+    fired[id] = true;
+    localStorage.setItem(TRIGGERED_KEY, JSON.stringify(fired));
+  } catch {}
+}
+
+async function fireTrigger(trigger: Trigger, email?: string) {
+  if (trigger.delivery === 'notification') {
+    if (typeof Notification !== 'undefined') {
+      if (Notification.permission === 'granted') {
+        new Notification(trigger.message);
+      } else if (Notification.permission !== 'denied') {
+        const perm = await Notification.requestPermission();
+        if (perm === 'granted') new Notification(trigger.message);
+      }
+    } else {
+      // Fallback to alert if notifications unavailable
+      alert(trigger.message);
+    }
+  } else if (trigger.delivery === 'email') {
+    if (email) {
+      const subject = encodeURIComponent('Task Reminder');
+      const body = encodeURIComponent(trigger.message);
+      window.location.href = `mailto:${email}?subject=${subject}&body=${body}`;
+    } else {
+      console.log('Email trigger:', trigger.message);
+    }
+  }
+}
+
+export function scheduleTrigger(trigger: Trigger, email?: string, id?: string) {
+  const delay = trigger.schedule.getTime() - Date.now();
+  const run = () => {
+    fireTrigger(trigger, email);
+    if (id) markTriggered(id);
+  };
+  if (delay <= 0) {
+    run();
+  } else {
+    const timeoutId = window.setTimeout(run, delay);
+    if (id) scheduled[id] = timeoutId;
+  }
+}
+
+export interface TaskLike {
+  id: string;
+  title: string;
+  due_at: string | null;
+  status: string;
+}
+
+export function scheduleTaskTriggers(tasks: TaskLike[], opts?: { email?: string }) {
+  const fired = getTriggered();
+  const delivery = getPreference();
+  tasks.forEach((t) => {
+    if (!t.due_at || t.status === 'done') return;
+    if (fired[t.id] || scheduled[t.id]) return;
+    const dueDate = new Date(t.due_at);
+    const trigger: Trigger = {
+      message: `Task "${t.title}" is due`,
+      schedule: dueDate,
+      delivery,
+    };
+    scheduleTrigger(trigger, opts?.email, t.id);
+  });
+}
+
+export { getPreference as getTriggerPreference };

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button";
 import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "@/hooks/use-toast";
+import TriggersPanel from "@/components/settings/TriggersPanel";
 
 export default function SettingsView() {
   const { user } = useSupabaseAuth();
@@ -19,9 +20,12 @@ export default function SettingsView() {
     <div className="container mx-auto px-4 py-6 space-y-4">
       <h1 className="text-2xl font-semibold">Settings</h1>
       {user ? (
-        <div className="space-y-2">
-          <div className="text-sm text-muted-foreground">{user.email}</div>
-          <Button variant="softPrimary" onClick={signOut}>Log out</Button>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <div className="text-sm text-muted-foreground">{user.email}</div>
+            <Button variant="softPrimary" onClick={signOut}>Log out</Button>
+          </div>
+          <TriggersPanel />
         </div>
       ) : (
         <p className="text-sm text-muted-foreground">You are not signed in.</p>


### PR DESCRIPTION
## Summary
- add Trigger type and scheduler for notifications or email
- schedule triggers for tasks with due dates
- add settings panel to choose trigger delivery method

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a249707c88326aa9912e13510e6b3