### PR TITLE
feat: allow editing master plan with version history

### DIFF
--- a/src/hooks/usePlanUpdater.ts
+++ b/src/hooks/usePlanUpdater.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { UserProfile } from "@/data/profile";
 import { MasterPlan } from "@/brain/masterPlan";
 import { updatePlan } from "@/brain/updateEngine";
@@ -7,6 +7,12 @@ export function usePlanUpdater(initialPlan?: MasterPlan) {
   const [plan, setPlan] = useState<MasterPlan>(
     initialPlan ?? { goals: [], habits: [], plan_versions: [] },
   );
+
+  useEffect(() => {
+    if (initialPlan) {
+      setPlan(initialPlan);
+    }
+  }, [initialPlan]);
 
   const update = useCallback(
     (oldProfile: UserProfile, newProfile: UserProfile) => {

--- a/src/views/MasterPlanView.tsx
+++ b/src/views/MasterPlanView.tsx
@@ -3,9 +3,14 @@ import GoalForm from "@/components/goals/GoalForm";
 import TasksManager from "@/components/control/TasksManager";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { supabase } from "@/integrations/supabase/client";
 import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
 import { toast } from "@/hooks/use-toast";
+import { usePlanUpdater } from "@/hooks/usePlanUpdater";
+import { UserProfile } from "@/data/profile";
 
 interface PlanTask {
   title: string;
@@ -32,6 +37,7 @@ interface PlanHabit {
 interface MasterPlan {
   goals?: PlanGoal[];
   habits?: PlanHabit[];
+  plan_versions?: MasterPlan[];
 }
 
 interface Roadmap {
@@ -50,7 +56,12 @@ interface DBHabit {
 
 export default function MasterPlanView() {
   const { user } = useSupabaseAuth();
-  const [plan, setPlan] = useState<MasterPlan | null>(null);
+  const [dbPlan, setDbPlan] = useState<MasterPlan | null>(null);
+  const { plan: plan, update } = usePlanUpdater(dbPlan as any);
+  const [profile, setProfile] = useState<UserProfile>({ history: [] });
+  const [editField, setEditField] = useState<"goals" | "habits" | null>(null);
+  const [editValue, setEditValue] = useState("");
+  const [versionIndex, setVersionIndex] = useState(-1);
   const [roadmaps, setRoadmaps] = useState<Roadmap[]>([]);
   const [habits, setHabits] = useState<DBHabit[]>([]);
   const [loading, setLoading] = useState(false);
@@ -79,7 +90,11 @@ export default function MasterPlanView() {
     ]);
 
     const planRecord = planData as { plan: MasterPlan } | null;
-    setPlan(planRecord?.plan ?? null);
+    if (planRecord?.plan) {
+      setDbPlan({ ...planRecord.plan, plan_versions: (planRecord.plan as any).plan_versions ?? [] });
+    } else {
+      setDbPlan(null);
+    }
     setRoadmaps((roadmapData as Roadmap[]) ?? []);
     setHabits((habitData as DBHabit[]) ?? []);
     setLoading(false);
@@ -87,11 +102,43 @@ export default function MasterPlanView() {
 
   useEffect(() => { fetchData(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [user]);
 
+  useEffect(() => {
+    if (plan) {
+      const goalsStr = plan.goals?.map((g: any) => g.title ?? g.name).join("\n") ?? "";
+      const habitsStr = plan.habits?.map((h: any) => h.title ?? h.name).join("\n") ?? "";
+      setProfile((p) => ({ ...p, goals: goalsStr, habits: habitsStr }));
+    }
+  }, [plan]);
+
   const roadmapByTitle = useMemo(() => {
     const map: Record<string, string> = {};
     roadmaps.forEach((r: Roadmap) => { map[r.title] = r.id; });
     return map;
   }, [roadmaps]);
+
+  const openEdit = (field: "goals" | "habits") => {
+    setEditField(field);
+    setEditValue((profile as any)[field] ?? "");
+  };
+
+  const handleSaveEdit = () => {
+    if (!editField) return;
+    const newProfile: UserProfile = {
+      ...profile,
+      [editField]: editValue,
+      history: [
+        ...profile.history,
+        {
+          question: `Updated ${editField}`,
+          answer: editValue,
+          timestamp: new Date().toISOString(),
+        },
+      ],
+    };
+    update(profile, newProfile);
+    setProfile(newProfile);
+    setEditField(null);
+  };
 
   const updateHabit = async (id: string, fields: { title?: string; frequency?: string; trigger?: string }) => {
     if (!user) { toast({ title: "Sign in required", description: "Connect Supabase to edit habits." }); return; }
@@ -142,38 +189,62 @@ export default function MasterPlanView() {
     );
   }
 
+  const displayPlan = versionIndex === -1 ? plan : plan?.plan_versions?.[versionIndex];
+
   return (
     <div className="container mx-auto px-4 py-6 space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-semibold">Master Plan</h1>
-        <Button onClick={requestRevision} disabled={loading}>Request Revision</Button>
+        <div className="flex items-center gap-2">
+          {plan?.plan_versions && plan.plan_versions.length > 0 && (
+            <Select value={versionIndex.toString()} onValueChange={(v) => setVersionIndex(Number(v))}>
+              <SelectTrigger className="w-[140px]"><SelectValue placeholder="Version" /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="-1">Current</SelectItem>
+                {plan.plan_versions.map((_, idx) => (
+                  <SelectItem key={idx} value={idx.toString()}>Version {idx + 1}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+          <Button onClick={requestRevision} disabled={loading}>Request Revision</Button>
+        </div>
       </div>
 
-      {plan ? (
+      {displayPlan ? (
         <div className="grid gap-8">
           <div className="grid gap-4">
-            <h2 className="text-xl font-semibold">Goals</h2>
-            {plan.goals?.map((g, idx) => (
+            <div className="flex items-center justify-between">
+              <h2 className="text-xl font-semibold">Goals</h2>
+              <Button variant="ghost" size="sm" onClick={() => openEdit("goals")}>Edit</Button>
+            </div>
+            {displayPlan.goals?.map((g: any, idx: number) => (
               <div key={idx} className="rounded-lg border border-border p-4 space-y-3">
                 <div>
-                  <div className="font-medium">{g.title}</div>
+                  <div className="font-medium">{g.title ?? g.name}</div>
                   {g.description && <p className="text-sm text-muted-foreground">{g.description}</p>}
                 </div>
-                {g.milestones?.map((m, j) => (
-                  <div key={j} className="ml-4 space-y-1">
-                    <div className="font-medium">{m.title}</div>
-                    {m.tasks && (
-                      <ul className="list-disc ml-4">
-                        {m.tasks.map((t, k) => (
-                          <li key={k} className="text-sm">{t.title}</li>
-                        ))}
-                      </ul>
-                    )}
-                  </div>
-                ))}
-                {roadmapByTitle[g.title] && (
+                {Array.isArray(g.milestones)
+                  ? g.milestones.map((m: any, j: number) => (
+                      <div key={j} className="ml-4 space-y-1">
+                        <div className="font-medium">{m.title ?? m}</div>
+                        {m.tasks && (
+                          <ul className="list-disc ml-4">
+                            {m.tasks.map((t: any, k: number) => (
+                              <li key={k} className="text-sm">{t.title ?? t}</li>
+                            ))}
+                          </ul>
+                        )}
+                      </div>
+                    ))
+                  : g.milestones?.annual?.map((m: any, j: number) => (
+                      <div key={j} className="ml-4 space-y-1">
+                        <div className="font-medium">{m}</div>
+                      </div>
+                    ))}
+                {roadmapByTitle[g.title ?? g.name] && (
                   <div className="mt-4">
-                    <TasksManager roadmapId={roadmapByTitle[g.title]} />
+                    <TasksManager roadmapId={roadmapByTitle[g.title ?? g.name]} />
                   </div>
                 )}
               </div>
@@ -184,7 +255,10 @@ export default function MasterPlanView() {
           </div>
 
           <div className="grid gap-4">
-            <h2 className="text-xl font-semibold">Habits</h2>
+            <div className="flex items-center justify-between">
+              <h2 className="text-xl font-semibold">Habits</h2>
+              <Button variant="ghost" size="sm" onClick={() => openEdit("habits")}>Edit</Button>
+            </div>
             {habits.length === 0 && <p className="text-sm text-muted-foreground">No habits yet.</p>}
             {habits.map(h => (
               <div key={h.id} className="rounded-lg border border-border p-3 flex flex-col sm:flex-row sm:items-center gap-3">
@@ -213,6 +287,18 @@ export default function MasterPlanView() {
       ) : (
         <p className="text-sm text-muted-foreground">No plan generated yet.</p>
       )}
+
+      <Dialog open={!!editField} onOpenChange={(v) => !v && setEditField(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit {editField}</DialogTitle>
+          </DialogHeader>
+          <Textarea value={editValue} onChange={(e) => setEditValue(e.target.value)} />
+          <DialogFooter>
+            <Button onClick={handleSaveEdit}>Save</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow updating existing plans via dialogs and plan updater
- track plan versions and profile change history
- expose version selector to browse previous plan snapshots

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_689a24c0de748326abd17035b19c219f