### PR TITLE
feat: add profile export and deletion

### DIFF
--- a/docs/gdpr-compliance.md
+++ b/docs/gdpr-compliance.md
@@ -1,0 +1,17 @@
+# Data Export and Deletion
+
+Aurora provides controls to support GDPR-style data portability and erasure.
+
+## Exporting your profile
+
+1. Sign in to your account.
+2. Open **Settings** and choose **Export Profile**.
+3. An encrypted `.json` file containing your profile will download. Store it safely; it can only be decrypted with your password.
+
+## Deleting your profile
+
+1. Sign in to your account.
+2. Open **Settings** and choose **Delete Profile**.
+3. Confirm the prompt. Your local profile data is permanently removed.
+
+These procedures give users access to their data and the ability to remove it, aiding GDPR compliance.

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -1,4 +1,9 @@
-import { saveProfile, loadProfile } from "./storage";
+import {
+  saveProfile,
+  loadProfile,
+  exportProfile,
+  deleteProfile,
+} from "./storage";
 
 describe("storage", () => {
   it("saves and loads profile with encryption", () => {
@@ -12,5 +17,21 @@ describe("storage", () => {
     saveProfile(profile);
     const loaded = loadProfile("user1", "password123");
     expect(loaded).toEqual({ userId: "user1", name: "Alice", goals: ["grow"] });
+  });
+
+  it("exports and deletes profile", () => {
+    const profile = {
+      userId: "user2",
+      password: "pass456",
+      name: "Bob",
+    };
+
+    saveProfile(profile);
+    const exported = exportProfile("user2");
+    expect(exported).toBeTruthy();
+
+    deleteProfile("user2");
+    const loaded = loadProfile("user2", "pass456");
+    expect(loaded).toBeNull();
   });
 });

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -82,3 +82,11 @@ export function loadProfile(userId: string, password: string): any | null {
   return JSON.parse(decrypted.toString("utf8"));
 }
 
+export function exportProfile(userId: string): string | null {
+  return storage.getItem(STORAGE_PREFIX + userId);
+}
+
+export function deleteProfile(userId: string): void {
+  storage.removeItem?.(STORAGE_PREFIX + userId);
+}
+

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -2,6 +2,18 @@ import { Button } from "@/components/ui/button";
 import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "@/hooks/use-toast";
+import { exportProfile, deleteProfile } from "@/lib/storage";
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from "@/components/ui/alert-dialog";
 
 export default function SettingsView() {
   const { user } = useSupabaseAuth();
@@ -15,12 +27,60 @@ export default function SettingsView() {
     }
   };
 
+  const handleExport = () => {
+    if (!user) return;
+    const data = exportProfile(user.id);
+    if (!data) {
+      toast({ title: "No data", description: "No profile found to export." });
+      return;
+    }
+    const blob = new Blob([data], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `profile-${user.id}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+    toast({ title: "Profile exported", description: "Encrypted profile downloaded." });
+  };
+
+  const handleDelete = () => {
+    if (!user) return;
+    deleteProfile(user.id);
+    toast({ title: "Profile deleted", description: "Your profile has been removed." });
+  };
+
   return (
     <div className="container mx-auto px-4 py-6 space-y-4">
       <h1 className="text-2xl font-semibold">Settings</h1>
       {user ? (
         <div className="space-y-2">
           <div className="text-sm text-muted-foreground">{user.email}</div>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={handleExport}>
+              Export Profile
+            </Button>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="destructive">Delete Profile</Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Delete profile?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This will remove your profile data from this device. This action
+                    cannot be undone.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction onClick={handleDelete}>
+                    Delete
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
           <Button variant="softPrimary" onClick={signOut}>Log out</Button>
         </div>
       ) : (


### PR DESCRIPTION
## Summary
- add exportProfile and deleteProfile helpers for encrypted profiles
- expose export and delete controls with confirmation in settings
- document GDPR-style data export and deletion procedures

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, empty block statements, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689a2587a92c83269117eaa52c340ca4