### PR TITLE
feat: add voice intensity to EvolvingSphere

### DIFF
--- a/src/components/effects/EvolvingSphere.tsx
+++ b/src/components/effects/EvolvingSphere.tsx
@@ -6,6 +6,7 @@ type Props = {
   xpPct?: number;       // 0-100: affects hue
   mood?: "calm" | "focused" | "confident" | "stressed";
   className?: string;
+  speaking?: boolean;   // voice activity
 };
 
 export function EvolvingSphere({
@@ -14,6 +15,7 @@ export function EvolvingSphere({
   xpPct = 0,
   mood = "calm",
   className = "",
+  speaking = false,
 }: Props) {
   // Map XP => hue; mood tints saturation/lightness
   const { hue, sat, light } = useMemo(() => {
@@ -32,6 +34,8 @@ export function EvolvingSphere({
   const satellites = Math.min(6, Math.max(1, Math.floor(level / 3) + 1));
   const speed = Math.max(6, 12 - Math.floor(level / 5)); // faster as you level
 
+  const intensity = speaking ? 1 : 0.3;
+
   const vars: React.CSSProperties = {
     // expose to CSS
     ["--es-size" as any]: `${size}px`,
@@ -39,6 +43,7 @@ export function EvolvingSphere({
     ["--es-sat" as any]: `${sat}%`,
     ["--es-light" as any]: `${light}%`,
     ["--es-speed" as any]: `${speed}s`,
+    ["--es-intensity" as any]: intensity,
   };
 
   return (

--- a/src/components/game/GameHUD.tsx
+++ b/src/components/game/GameHUD.tsx
@@ -5,6 +5,7 @@ import { quickSlots } from "@/game/hud/hud.data";
 import { EvolvingSphere } from "@/components/effects/EvolvingSphere";
 import { Mic, ChevronDown, ChevronUp } from "lucide-react";
 import { useHUDActions } from "@/game/hud/useHUDActions";
+import { useVoiceStore } from "@/state/voice";
 
 function fire(type: string, payload?: any) {
   window.dispatchEvent(new CustomEvent('mos', { detail: { type, payload } }));
@@ -13,6 +14,7 @@ function fire(type: string, payload?: any) {
 export function GameHUD() {
   const stats = useGameStore((s) => s.stats);
   const { run } = useHUDActions();
+  const isSpeaking = useVoiceStore((s) => s.isSpeaking);
 
   // Mobile collapse state
   const isMobile = window.innerWidth <= 768;
@@ -56,7 +58,7 @@ export function GameHUD() {
         <div className="flex items-center gap-3 min-w-0 flex-wrap">
           {/* Identity */}
           <div className="flex items-center gap-3 min-w-0 shrink">
-            <EvolvingSphere size={44} level={stats.level} xpPct={stats.xp} mood="focused" />
+            <EvolvingSphere size={44} level={stats.level} xpPct={stats.xp} mood="focused" speaking={isSpeaking} />
             <div className="min-w-0">
               <div className="text-[13px] opacity-90 truncate">
                 Lv. {stats.level} • Streak {stats.streak}

--- a/src/index.css
+++ b/src/index.css
@@ -473,6 +473,7 @@ All colors MUST be HSL.
   box-shadow:
     0 0 24px hsla(var(--es-hue), var(--es-sat), calc(var(--es-light) + 10%), .35),
     inset 0 0 18px hsla(var(--es-hue), var(--es-sat), calc(var(--es-light) + 20%), .45);
+  opacity: var(--es-intensity, 1);
 }
 
 /* core blob (breathes) */
@@ -482,7 +483,7 @@ All colors MUST be HSL.
   background:
     radial-gradient(60% 60% at 35% 35%, hsla(var(--es-hue), var(--es-sat), 92%, .9), transparent 55%),
     radial-gradient(90% 90% at 50% 50%, hsla(var(--es-hue), var(--es-sat), var(--es-light), 1), hsla(var(--es-hue), var(--es-sat), calc(var(--es-light) - 10%), 1));
-  animation: es-breathe calc(var(--es-speed)) ease-in-out infinite;
+  animation: es-breathe calc(var(--es-speed) / var(--es-intensity, 1)) ease-in-out infinite;
 }
 @keyframes es-breathe {
   0%   { transform: scale(1); }
@@ -514,8 +515,8 @@ All colors MUST be HSL.
     radial-gradient(60% 60% at 35% 35%, hsla(var(--es-hue), var(--es-sat), 96%, .75), transparent 60%),
     radial-gradient(90% 90% at 50% 50%, hsla(var(--es-hue), var(--es-sat), calc(var(--es-light) + 6%), 1), hsla(var(--es-hue), var(--es-sat), calc(var(--es-light) - 6%), 1));
   animation:
-    es-orbit var(--es-speed) linear infinite,
-    es-jelly calc(var(--es-speed) * .6) ease-in-out infinite;
+    es-orbit calc(var(--es-speed) / var(--es-intensity, 1)) linear infinite,
+    es-jelly calc((var(--es-speed) * .6) / var(--es-intensity, 1)) ease-in-out infinite;
   transform-origin: calc(var(--r)) 0;
 }
 @keyframes es-orbit {

--- a/src/nodes/RewardRunner.tsx
+++ b/src/nodes/RewardRunner.tsx
@@ -1,11 +1,13 @@
 import { useEffect } from "react";
 import { useProgressStore } from "@/state/progress";
 import { EvolvingSphere } from "@/components/avatar/EvolvingSphere";
+import { useVoiceStore } from "@/state/voice";
 
 type Props = { node: { id: string; label: string }; onExit: () => void };
 
 export default function RewardRunner({ node, onExit }: Props) {
   const { xp, level, awardXP, complete } = useProgressStore();
+  const isSpeaking = useVoiceStore((s) => s.isSpeaking);
 
   useEffect(() => {
     awardXP(20, { activity: "reward", nodeId: node.id });
@@ -18,7 +20,7 @@ export default function RewardRunner({ node, onExit }: Props) {
       <div>
         <h1 className="text-2xl font-semibold mb-2">{node.label}</h1>
         <p className="opacity-80 mb-6">You earned +20 XP</p>
-        <EvolvingSphere size={128} level={level} xpPct={(xp % 100)} mood="confident" />
+        <EvolvingSphere size={128} level={level} xpPct={(xp % 100)} mood="confident" speaking={isSpeaking} />
         <div className="mt-6">
           <button className="btn" onClick={onExit}>Back</button>
         </div>

--- a/src/state/voice.ts
+++ b/src/state/voice.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+type VoiceState = {
+  isSpeaking: boolean;
+  setSpeaking: (v: boolean) => void;
+};
+
+export const useVoiceStore = create<VoiceState>((set) => ({
+  isSpeaking: false,
+  setSpeaking: (v) => set({ isSpeaking: v }),
+}));

--- a/src/voice/voiceio.ts
+++ b/src/voice/voiceio.ts
@@ -1,3 +1,5 @@
+import { useVoiceStore } from "@/state/voice";
+
 export type VoiceCallbacks = {
   onPartial?: (text: string) => void;
   onFinal?: (text: string) => void;
@@ -59,9 +61,16 @@ export class VoiceIO {
   speak(text: string) {
     if (!('speechSynthesis' in window)) return;
     const u = new SpeechSynthesisUtterance(text);
-    u.onstart = () => this.callbacks.onSpeakingChange?.(true);
-    u.onend = () => this.callbacks.onSpeakingChange?.(false);
-    u.onerror = () => this.callbacks.onSpeakingChange?.(false);
+    u.onstart = () => {
+      useVoiceStore.getState().setSpeaking(true);
+      this.callbacks.onSpeakingChange?.(true);
+    };
+    const end = () => {
+      useVoiceStore.getState().setSpeaking(false);
+      this.callbacks.onSpeakingChange?.(false);
+    };
+    u.onend = end;
+    u.onerror = end;
     // voice selection can be tuned later
     speechSynthesis.speak(u);
     this.utter = u;
@@ -69,6 +78,7 @@ export class VoiceIO {
 
   stopSpeaking() {
     try { window.speechSynthesis.cancel(); } catch {}
+    useVoiceStore.getState().setSpeaking(false);
     this.callbacks.onSpeakingChange?.(false);
     this.utter = null;
   }


### PR DESCRIPTION
## Summary
- add `speaking` prop to `EvolvingSphere` and map to CSS `--es-intensity`
- track global `isSpeaking` in new `useVoiceStore` and update via `VoiceIO`
- feed voice state into `EvolvingSphere` in GameHUD and RewardRunner

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, Empty block statement, A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689a3468fd308326b54d1c84e1a3eb36