### PR TITLE
Show onboarding progress percent with animation

### DIFF
--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -16,8 +16,8 @@ const Progress = React.forwardRef<
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
-      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      className="h-full bg-primary transition-all duration-300"
+      style={{ width: `${Math.max(0, Math.min(100, value || 0))}%` }}
     />
   </ProgressPrimitive.Root>
 ))

--- a/src/pages/OnboardingFlow.tsx
+++ b/src/pages/OnboardingFlow.tsx
@@ -272,7 +272,13 @@ export default function OnboardingFlow() {
     (sum, arr) => sum + arr.filter(Boolean).length,
     0,
   );
-  const progress = (answeredCount / total) * 100;
+  const progressPercent = Math.floor((answeredCount / total) * 100);
+  useEffect(() => {
+    localStorage.setItem(
+      "onboarding_progress_percent",
+      progressPercent.toString(),
+    );
+  }, [progressPercent]);
   const shouldShowForm = phase !== "vision" && phase !== "start";
 
   return (
@@ -280,7 +286,12 @@ export default function OnboardingFlow() {
       <div className="os-bg" />
       <div className="relative z-10 flex h-full flex-col">
         <div className="p-4">
-          <Progress value={progress} />
+          <div className="relative">
+            <Progress value={progressPercent} />
+            <div className="absolute inset-0 grid place-items-center pointer-events-none">
+              <span className="text-xs text-secondary-foreground">{progressPercent}%</span>
+            </div>
+          </div>
         </div>
         <ScrollArea className="flex-1 px-4">
           <div className="space-y-3 text-sm">


### PR DESCRIPTION
## Summary
- compute and persist onboarding progress percent, displaying percent text over progress bar
- add width transition to progress indicator for smooth animations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a3b69e4348326a96de1be10ad2b0e