### PR TITLE
feat: add conversational context summary

### DIFF
--- a/src/agent/AuroraAgent.ts
+++ b/src/agent/AuroraAgent.ts
@@ -15,6 +15,7 @@ export type AgentEvents = {
 export class AuroraAgent {
   private voice: VoiceIO;
   private listening = false;
+  private history: { role: 'user' | 'assistant'; content: string }[] = [];
 
   constructor(private events: AgentEvents = {}) {
     this.voice = new VoiceIO({
@@ -39,6 +40,13 @@ export class AuroraAgent {
 
   private async onFinalText(text: string) {
     this.events.onFinal?.(text);
+    this.history.push({ role: 'user', content: text });
+    if (this.history.length > 20) this.history = this.history.slice(-20);
+
+    const userSummary = this.history
+      .filter((m) => m.role === 'user')
+      .map((m) => m.content)
+      .join(' ');
 
     if (!validateAnswer(text)) {
       try {
@@ -47,10 +55,14 @@ export class AuroraAgent {
             messages: [
               {
                 role: 'system',
+                content: `Recent user statements: ${userSummary}`,
+              },
+              {
+                role: 'system',
                 content:
                   "The user's response was incomplete or unclear. Ask a follow-up question to clarify.",
               },
-              { role: 'user', content: text },
+              ...this.history,
             ],
           },
         });
@@ -90,8 +102,11 @@ export class AuroraAgent {
     try {
       const { data, error } = await supabase.functions.invoke('aurora-chat', {
         body: {
-          prompt: text,
-        }
+          messages: [
+            { role: 'system', content: `Recent user statements: ${userSummary}. Use this context and reference earlier user comments when appropriate.` },
+            ...this.history,
+          ],
+        },
       });
       if (error) throw error;
       const reply = (data as any)?.content ?? 'Okay.';
@@ -103,6 +118,8 @@ export class AuroraAgent {
   }
 
   say(text: string) {
+    this.history.push({ role: 'assistant', content: text });
+    if (this.history.length > 20) this.history = this.history.slice(-20);
     this.events.onResponse?.(text);
     this.voice.speak(text);
   }

--- a/src/components/live/FloatingAssistant.tsx
+++ b/src/components/live/FloatingAssistant.tsx
@@ -93,9 +93,19 @@ export function FloatingAssistant({
         .concat(userMsg)
         .slice(-12)
         .map((m) => ({ role: m.role, content: m.content }));
+      const userSummary = history
+        .filter((m) => m.role === 'user')
+        .map((m) => m.content)
+        .join(' ');
       const systemMessages: { role: 'system'; content: string }[] = [
         { role: 'system', content: `Route: ${loc.pathname}` },
       ];
+      if (userSummary) {
+        systemMessages.push({
+          role: 'system',
+          content: `Summary of user statements: ${userSummary}. Refer back to these when replying, e.g., "Earlier you mentioned..."`,
+        });
+      }
       if (task) {
         systemMessages.push({
           role: 'system',

--- a/src/pages/OnboardingFlow.tsx
+++ b/src/pages/OnboardingFlow.tsx
@@ -148,7 +148,18 @@ export default function OnboardingFlow() {
 
   const askQuestion = (mIndex: number, qIndex: number) => {
     const prompt = MODULES[mIndex].questions[qIndex].prompt;
-    sendPrompt(prompt);
+    const prev: string[] = [];
+    answers.forEach((ans, mi) => {
+      if (mi < mIndex) {
+        ans.forEach((a, qi) => {
+          if (a) {
+            prev.push(`${MODULES[mi].questions[qi].keyword}: ${a}`);
+          }
+        });
+      }
+    });
+    const prefix = prev.length ? `Earlier you mentioned ${prev.join('; ')}. ` : '';
+    sendPrompt(prefix + prompt);
   };
 
   const showSummary = (currentAnswers: string[][]) => {
@@ -216,6 +227,22 @@ export default function OnboardingFlow() {
       baseMessages.push({
         role: "system",
         content: `The user's last answer failed validation: ${error} Ask them to clarify or provide more detail.`,
+      });
+    }
+
+    const summaryParts: string[] = [];
+    MODULES.forEach((mod, mi) => {
+      mod.questions.forEach((q, qi) => {
+        const ans = mi === currentModule && qi === questionIndex
+          ? userMsg.content
+          : answers[mi]?.[qi];
+        if (ans) summaryParts.push(`${q.keyword}: ${ans}`);
+      });
+    });
+    if (summaryParts.length > 0) {
+      baseMessages.push({
+        role: 'system',
+        content: `Relevant past answers: ${summaryParts.join('; ')}. Reference the user's earlier statements when replying, e.g., "Earlier you mentioned..."`,
       });
     }
 


### PR DESCRIPTION
## Summary
- add conversation history tracking and user summary before aurora-chat requests
- include summarized user statements in floating assistant and onboarding flow queries
- reference earlier user answers when asking onboarding questions

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: ERESOLVE could not resolve)
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_689a3cbb0e208326b5b05695a028d309