### PR TITLE
Refactor onboarding flow with explicit step transitions

### DIFF
--- a/src/pages/OnboardingFlow.tsx
+++ b/src/pages/OnboardingFlow.tsx
@@ -9,119 +9,18 @@ import { Progress } from "@/components/ui/progress";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 
-// Chat-based onboarding flow that gathers key info about the user
-// including their goals, values, skills, habits, and challenges.
-
 type Msg = { role: "assistant" | "user"; content: string };
 type ChatMsg = Msg | { role: "system"; content: string };
 
-type Question = {
-  type: "text" | "choice" | "hypothetical";
-  prompt: string;
-  keyword: string;
-  options?: string[];
-};
-type Module = { topic: string; questions: Question[] };
-
-const MODULES: Module[] = [
-  {
-    topic: "Goals",
-    questions: [
-      { type: "text", prompt: "What are your main goals right now?", keyword: "goal" },
-      {
-        type: "hypothetical",
-        prompt: "If you achieved your main goal, how would your life change?",
-        keyword: "change",
-      },
-    ],
-  },
-  {
-    topic: "Values",
-    questions: [
-      {
-        type: "choice",
-        prompt: "Which value resonates most with you?",
-        options: ["Growth", "Integrity", "Compassion"],
-        keyword: "value",
-      },
-      { type: "text", prompt: "Why is this value important to you?", keyword: "value" },
-    ],
-  },
-  {
-    topic: "Skills",
-    questions: [
-      {
-        type: "choice",
-        prompt: "Which skill would you like to develop next?",
-        options: ["Communication", "Technical", "Leadership"],
-        keyword: "skill",
-      },
-      {
-        type: "text",
-        prompt: "What steps can you take to improve this skill?",
-        keyword: "step",
-      },
-    ],
-  },
-  {
-    topic: "Habits",
-    questions: [
-      {
-        type: "choice",
-        prompt: "What kind of habit do you want to build?",
-        options: ["Daily", "Weekly", "Monthly"],
-        keyword: "habit",
-      },
-      { type: "text", prompt: "Describe a habit that would help you grow.", keyword: "habit" },
-    ],
-  },
-  {
-    topic: "Challenges",
-    questions: [
-      { type: "text", prompt: "What challenges are you facing?", keyword: "challenge" },
-      {
-        type: "hypothetical",
-        prompt: "Imagine overcoming these challenges. How would you feel?",
-        keyword: "feel",
-      },
-    ],
-  },
-];
-
-const MIN_LENGTH = 10;
-
-function validateAnswer(answer: string, moduleIndex: number, questionIndex: number): string | null {
-  const question = MODULES[moduleIndex].questions[questionIndex];
-  if (question.type === "choice") return null;
-  if (answer.length < MIN_LENGTH) return `Please provide at least ${MIN_LENGTH} characters.`;
-  const keyword = question.keyword;
-  if (keyword && !answer.toLowerCase().includes(keyword)) {
-    return `Please mention the word "${keyword}" in your response.`;
-  }
-  return null;
+enum Step {
+  START,
+  GREET,
+  ASK_MAIN_GOAL,
+  CLARIFY_GOAL,
+  CONFIRM_SUMMARY,
+  VISION_CARD,
+  END,
 }
-
-const MAX_QUESTIONS = Math.max(...MODULES.map((m) => m.questions.length));
-
-const getNextState = (
-  moduleIndex: number,
-  questionIndex: number,
-): { module: number | null; question: number } => {
-  let nextModule = moduleIndex + 1;
-  let qIdx = questionIndex;
-
-  for (; qIdx < MAX_QUESTIONS; qIdx++) {
-    for (let m = nextModule; m < MODULES.length; m++) {
-      if (MODULES[m].questions[qIdx]) {
-        return { module: m, question: qIdx };
-      }
-    }
-    nextModule = 0;
-  }
-  return { module: null, question: qIdx };
-};
-
-type Phase = "start" | "question" | "summary" | "vision";
 
 export default function OnboardingFlow() {
   const { user } = useSupabaseAuth();
@@ -130,13 +29,11 @@ export default function OnboardingFlow() {
   const getInitialState = () => {
     if (typeof window === "undefined") return {};
     try {
-      return JSON.parse(localStorage.getItem("aurora_chat_v1") ?? "{}") as {
+      return JSON.parse(localStorage.getItem("aurora_simple_onboarding") ?? "{}") as {
         messages?: Msg[];
-        phase?: Phase;
-        currentModule?: number;
-        questionIndex?: number;
-        progressPercent?: number;
-        answers?: string[][];
+        step?: Step;
+        mainGoal?: string;
+        goalDetail?: string;
       };
     } catch {
       return {};
@@ -146,15 +43,14 @@ export default function OnboardingFlow() {
   const initial = getInitialState();
 
   const [messages, setMessages] = useState<Msg[]>(initial.messages || []);
-  const [phase, setPhase] = useState<Phase>(initial.phase || "start");
-  const [currentModule, setCurrentModule] = useState<number>(initial.currentModule || 0);
-  const [questionIndex, setQuestionIndex] = useState<number>(initial.questionIndex || 0);
-  const [progressPercent, setProgressPercent] = useState<number>(initial.progressPercent || 0);
+  const [step, setStep] = useState<Step>(initial.step ?? Step.START);
+  const [mainGoal, setMainGoal] = useState(initial.mainGoal || "");
+  const [goalDetail, setGoalDetail] = useState(initial.goalDetail || "");
   const [input, setInput] = useState("");
-  const [answers, setAnswers] = useState<string[][]>(initial.answers || MODULES.map(() => []));
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  const total = MODULES.reduce((sum, module) => sum + module.questions.length, 0);
+  const TOTAL_STEPS = Step.VISION_CARD;
+  const progressPercent = Math.min((step / TOTAL_STEPS) * 100, 100);
 
   const sendPrompt = (prompt: string) => {
     setMessages((msgs) => {
@@ -163,80 +59,82 @@ export default function OnboardingFlow() {
     });
   };
 
-  const askQuestion = (mIndex: number, qIndex: number) => {
-    const prompt = MODULES[mIndex].questions[qIndex].prompt;
-    const prev: string[] = [];
-    answers.forEach((ans, mi) => {
-      if (mi < mIndex) {
-        ans.forEach((a, qi) => {
-          if (a) prev.push(`${MODULES[mi].questions[qi].keyword}: ${a}`);
-        });
-      }
-    });
-    const prefix = prev.length ? `Earlier you mentioned ${prev.join("; ")}. ` : "";
-    sendPrompt(prefix + prompt);
+  const start = () => {
+    sendPrompt("Hi, I'm Aurora. Let's get to know you a bit better.");
+    setStep(Step.GREET);
   };
 
-  const showSummary = (currentAnswers: string[][]) => {
-    const lines: string[] = [];
-    MODULES.forEach((mod, mi) => {
-      mod.questions.forEach((q, qi) => {
-        const ans = currentAnswers[mi]?.[qi];
-        if (ans) lines.push(`- ${q.keyword}: ${ans}`);
+  const askMainGoal = () => {
+    sendPrompt("What are your main goals right now?");
+    setStep(Step.ASK_MAIN_GOAL);
+  };
+
+  const handleMainGoal = async (answer: string) => {
+    setMainGoal(answer);
+    if (user) {
+      await supabase.from("onboarding_answers").insert({
+        user_id: user.id,
+        question: "What are your main goals right now?",
+        answer,
       });
-    });
-    sendPrompt(`Here's what I heard:\n${lines.join("\n")}\nDoes this look right?`);
-    setPhase("summary");
+    }
+    sendPrompt("If you achieved your main goal, how would your life change?");
+    setStep(Step.CLARIFY_GOAL);
   };
 
-  // Scroll to latest message
+  const handleGoalDetail = async (answer: string) => {
+    setGoalDetail(answer);
+    if (user) {
+      await supabase.from("onboarding_answers").insert({
+        user_id: user.id,
+        question: "If you achieved your main goal, how would your life change?",
+        answer,
+      });
+    }
+    sendPrompt(
+      `Here's what I heard:\n- goal: ${mainGoal}\n- change: ${answer}\nDoes this look right?`
+    );
+    setStep(Step.CONFIRM_SUMMARY);
+  };
+
+  const handleSummaryConfirmation = (answer: string) => {
+    if (answer.toLowerCase().startsWith("yes")) {
+      setStep(Step.VISION_CARD);
+    } else {
+      sendPrompt('Please reply "yes" if the summary is correct.');
+    }
+  };
+
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
-  // Persist whole onboarding state
   useEffect(() => {
     if (typeof window !== "undefined") {
       localStorage.setItem(
-        "aurora_chat_v1",
-        JSON.stringify({
-          messages,
-          phase,
-          currentModule,
-          questionIndex,
-          progressPercent,
-          answers,
-        }),
+        "aurora_simple_onboarding",
+        JSON.stringify({ messages, step, mainGoal, goalDetail })
       );
     }
-  }, [messages, phase, currentModule, questionIndex, progressPercent, answers]);
+  }, [messages, step, mainGoal, goalDetail]);
 
-  // Compute progress %
-  useEffect(() => {
-    const answered = answers.reduce((sum, arr) => sum + arr.filter(Boolean).length, 0);
-    const pct = (answered / total) * 100;
-    setProgressPercent(pct);
-  }, [answers, total]);
-
-  // Also persist a simple integer percent for other UIs if needed
   useEffect(() => {
     if (typeof window !== "undefined") {
-      localStorage.setItem("onboarding_progress_percent", String(Math.floor(progressPercent)));
+      localStorage.setItem(
+        "onboarding_progress_percent",
+        String(Math.floor(progressPercent))
+      );
     }
   }, [progressPercent]);
 
-  // Kick off first question
   useEffect(() => {
-    if (phase === "start") {
-      sendPrompt("Hi, I'm Aurora. Let's get to know you a bit better.");
-      setPhase("question");
-      setTimeout(() => askQuestion(currentModule, questionIndex), 0);
-    }
-  }, [phase, currentModule, questionIndex]);
+    if (step === Step.START) start();
+    else if (step === Step.GREET) askMainGoal();
+  }, [step]);
 
-  const handleSubmit = async (e?: React.FormEvent, choice?: string) => {
+  const handleSubmit = async (e?: React.FormEvent) => {
     e?.preventDefault();
-    const answer = choice ?? input.trim();
+    const answer = input.trim();
     if (!answer) return;
 
     const userMsg: Msg = { role: "user", content: answer };
@@ -244,86 +142,50 @@ export default function OnboardingFlow() {
     setMessages(newMessages);
     setInput("");
 
-    let error: string | null = null;
-    if (phase === "question") {
-      error = validateAnswer(userMsg.content, currentModule, questionIndex);
-    }
-
     const baseMessages: ChatMsg[] = [
-      { role: "system", content: "You are a friendly onboarding assistant. Keep replies short and encouraging." },
+      {
+        role: "system",
+        content:
+          "You are a friendly onboarding assistant. Keep replies short and encouraging.",
+      },
       ...newMessages,
     ];
 
-    if (error) {
-      baseMessages.push({
-        role: "system",
-        content: `The user's last answer failed validation: ${error} Ask them to clarify or provide more detail.`,
-      });
-    }
-
-    const summaryParts: string[] = [];
-    MODULES.forEach((mod, mi) => {
-      mod.questions.forEach((q, qi) => {
-        const ans = mi === currentModule && qi === questionIndex ? userMsg.content : answers[mi]?.[qi];
-        if (ans) summaryParts.push(`${q.keyword}: ${ans}`);
-      });
+    const { data } = await supabase.functions.invoke("aurora-chat", {
+      body: { messages: baseMessages },
     });
-    if (summaryParts.length > 0) {
-      baseMessages.push({
-        role: "system",
-        content: `Relevant past answers: ${summaryParts.join(
-          "; ",
-        )}. Reference the user's earlier statements when replying, e.g., "Earlier you mentioned..."`,
-      });
-    }
-
-    const { data } = await supabase.functions.invoke("aurora-chat", { body: { messages: baseMessages } });
     if (data?.content) {
       setMessages((m) => [...m, { role: "assistant", content: data.content }]);
     }
-    if (error) return;
 
-    if (phase === "question") {
-      const updatedAnswers = answers.map((a) => [...a]);
-
-      if (user) {
-        await supabase.from("onboarding_answers").insert({
-          user_id: user.id,
-          question: MODULES[currentModule].questions[questionIndex].prompt,
-          answer: userMsg.content,
-        });
-      }
-
-      if (!updatedAnswers[currentModule]) updatedAnswers[currentModule] = [];
-      updatedAnswers[currentModule][questionIndex] = userMsg.content;
-      setAnswers(updatedAnswers);
-
-      const next = getNextState(currentModule, questionIndex);
-      if (next.module === null) {
-        showSummary(updatedAnswers);
-      } else {
-        setCurrentModule(next.module);
-        setQuestionIndex(next.question);
-        askQuestion(next.module, next.question);
-      }
-    } else if (phase === "summary") {
-      setPhase("vision");
+    if (step === Step.ASK_MAIN_GOAL) {
+      await handleMainGoal(answer);
+    } else if (step === Step.CLARIFY_GOAL) {
+      await handleGoalDetail(answer);
+    } else if (step === Step.CONFIRM_SUMMARY) {
+      handleSummaryConfirmation(answer);
     }
   };
 
   const handleFinish = async () => {
     if (user) {
-      await supabase.from("profiles").update({ onboarded_at: new Date().toISOString() }).eq("id", user.id);
-      await supabase.functions.invoke("generate-plan", { body: { answers: answers.flat() } });
+      await supabase
+        .from("profiles")
+        .update({ onboarded_at: new Date().toISOString() })
+        .eq("id", user.id);
+      await supabase.functions.invoke("generate-plan", {
+        body: { answers: [mainGoal, goalDetail] },
+      });
     }
+    setStep(Step.END);
     navigate("/app/plan", { replace: true });
   };
 
-  const shouldShowForm = phase !== "vision" && phase !== "start";
-  const currentQuestion = MODULES[currentModule]?.questions[questionIndex];
-  const showChoice = shouldShowForm && currentQuestion?.type === "choice";
-  const showText = shouldShowForm && currentQuestion?.type !== "choice";
-  const percentDisplay = Math.floor(progressPercent);
+  const shouldShowForm =
+    step !== Step.START &&
+    step !== Step.GREET &&
+    step !== Step.VISION_CARD &&
+    step !== Step.END;
 
   return (
     <div className="relative h-svh w-screen">
@@ -333,14 +195,19 @@ export default function OnboardingFlow() {
           <div className="relative">
             <Progress value={progressPercent} />
             <div className="pointer-events-none absolute inset-0 grid place-items-center">
-              <span className="text-xs text-secondary-foreground">{percentDisplay}%</span>
+              <span className="text-xs text-secondary-foreground">
+                {Math.floor(progressPercent)}%
+              </span>
             </div>
           </div>
         </div>
         <ScrollArea className="flex-1 px-4">
           <div className="space-y-3 text-sm">
             {messages.map((m, i) => (
-              <div key={i} className={`flex ${m.role === "user" ? "justify-end" : "justify-start"}`}>
+              <div
+                key={i}
+                className={`flex ${m.role === "user" ? "justify-end" : "justify-start"}`}
+              >
                 {m.role === "assistant" && (
                   <Avatar className="mr-2 h-8 w-8">
                     <AvatarFallback>A</AvatarFallback>
@@ -348,7 +215,9 @@ export default function OnboardingFlow() {
                 )}
                 <div
                   className={`max-w-[80%] rounded-lg px-3 py-2 ${
-                    m.role === "user" ? "bg-primary text-primary-foreground" : "bg-muted text-muted-foreground"
+                    m.role === "user"
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-muted text-muted-foreground"
                   }`}
                 >
                   {m.content}
@@ -359,7 +228,7 @@ export default function OnboardingFlow() {
           </div>
         </ScrollArea>
 
-        {showText && (
+        {shouldShowForm && (
           <form onSubmit={handleSubmit} className="flex flex-col gap-2 border-t bg-background p-4">
             <Textarea
               value={input}
@@ -372,22 +241,14 @@ export default function OnboardingFlow() {
             </Button>
           </form>
         )}
-        {showChoice && currentQuestion?.options && (
-          <div className="flex flex-col gap-2 border-t bg-background p-4">
-            {currentQuestion.options.map((opt) => (
-              <Button key={opt} onClick={() => handleSubmit(undefined, opt)}>
-                {opt}
-              </Button>
-            ))}
-          </div>
-        )}
 
-        {phase === "vision" && (
+        {step === Step.VISION_CARD && (
           <div className="border-t bg-background p-4">
-            <VisionCard answers={answers.flat()} onClose={handleFinish} />
+            <VisionCard answers={[mainGoal, goalDetail]} onClose={handleFinish} />
           </div>
         )}
       </div>
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- streamline onboarding to a linear Step enum flow
- add explicit transition functions for each step and remove module logic

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any, no-empty, @typescript-eslint/no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_689a41cc00988326a3f9531667c27348