### PR TITLE
Enable TTS in onboarding flow

### DIFF
--- a/src/pages/OnboardingFlow.tsx
+++ b/src/pages/OnboardingFlow.tsx
@@ -8,6 +8,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Progress } from "@/components/ui/progress";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { useTextToSpeech } from "@/voice/useTextToSpeech";
 
 // Chat-based onboarding flow that gathers key info about the user
 // including their goals, values, skills, habits, and challenges.
@@ -154,6 +155,8 @@ export default function OnboardingFlow() {
   const [answers, setAnswers] = useState<string[][]>(initial.answers || MODULES.map(() => []));
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
+  const { speak, cancel } = useTextToSpeech();
+
   const total = MODULES.reduce((sum, module) => sum + module.questions.length, 0);
 
   const sendPrompt = (prompt: string) => {
@@ -188,6 +191,15 @@ export default function OnboardingFlow() {
     sendPrompt(`Here's what I heard:\n${lines.join("\n")}\nDoes this look right?`);
     setPhase("summary");
   };
+
+  // Speak assistant messages as they appear
+  useEffect(() => {
+    const last = messages[messages.length - 1];
+    if (last?.role === "assistant") {
+      speak(last.content);
+    }
+    return cancel;
+  }, [messages, speak, cancel]);
 
   // Scroll to latest message
   useEffect(() => {

--- a/src/voice/useTextToSpeech.ts
+++ b/src/voice/useTextToSpeech.ts
@@ -1,49 +1,66 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useRef } from 'react'
 
 const ELEVENLABS_API_KEY = import.meta.env.VITE_ELEVENLABS_API_KEY as string | undefined
 
 export function useTextToSpeech() {
   const [isSpeaking, setIsSpeaking] = useState(false)
+  const audioRef = useRef<HTMLAudioElement | null>(null)
 
-  const speak = useCallback(async (text: string) => {
-    if (!text) return
-    try {
-      const apiKey = ELEVENLABS_API_KEY
-
-      if (apiKey) {
-        const voiceId = '21m00Tcm4TlvDq8ikWAM'
-        const response = await fetch(`https://api.elevenlabs.io/v1/text-to-speech/${voiceId}`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'xi-api-key': apiKey
-          },
-          body: JSON.stringify({ text })
-        })
-
-        const blob = await response.blob()
-        const url = URL.createObjectURL(blob)
-        const audio = new Audio(url)
-        audio.onplay = () => setIsSpeaking(true)
-        audio.onended = () => {
-          setIsSpeaking(false)
-          URL.revokeObjectURL(url)
-        }
-        await audio.play()
-      } else {
-        const utterance = new SpeechSynthesisUtterance(text)
-        utterance.onstart = () => setIsSpeaking(true)
-        utterance.onend = () => setIsSpeaking(false)
-        speechSynthesis.speak(utterance)
-      }
-    } catch (err) {
-      console.error('TTS error', err)
-      const utter = new SpeechSynthesisUtterance(text)
-      utter.onstart = () => setIsSpeaking(true)
-      utter.onend = () => setIsSpeaking(false)
-      speechSynthesis.speak(utter)
-    }
+  const cancel = useCallback(() => {
+    audioRef.current?.pause()
+    audioRef.current = null
+    speechSynthesis.cancel()
+    setIsSpeaking(false)
   }, [])
 
-  return { speak, isSpeaking }
+  const speak = useCallback(
+    async (text: string) => {
+      if (!text) return
+      cancel()
+      try {
+        const apiKey = ELEVENLABS_API_KEY
+
+        if (apiKey) {
+          const voiceId = '21m00Tcm4TlvDq8ikWAM'
+          const response = await fetch(
+            `https://api.elevenlabs.io/v1/text-to-speech/${voiceId}`,
+            {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'xi-api-key': apiKey,
+              },
+              body: JSON.stringify({ text }),
+            },
+          )
+
+          const blob = await response.blob()
+          const url = URL.createObjectURL(blob)
+          const audio = new Audio(url)
+          audioRef.current = audio
+          audio.onplay = () => setIsSpeaking(true)
+          audio.onended = () => {
+            setIsSpeaking(false)
+            URL.revokeObjectURL(url)
+            audioRef.current = null
+          }
+          await audio.play()
+        } else {
+          const utterance = new SpeechSynthesisUtterance(text)
+          utterance.onstart = () => setIsSpeaking(true)
+          utterance.onend = () => setIsSpeaking(false)
+          speechSynthesis.speak(utterance)
+        }
+      } catch (err) {
+        console.error('TTS error', err)
+        const utter = new SpeechSynthesisUtterance(text)
+        utter.onstart = () => setIsSpeaking(true)
+        utter.onend = () => setIsSpeaking(false)
+        speechSynthesis.speak(utter)
+      }
+    },
+    [cancel],
+  )
+
+  return { speak, isSpeaking, cancel }
 }


### PR DESCRIPTION
## Summary
- speak assistant messages during onboarding using a text-to-speech hook
- stop ongoing audio when new assistant messages arrive to prevent overlap

## Testing
- `npm test`
- `npm run lint` *(fails: 172 problems, 152 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a43c2d6488326bb15cfd619548578