### PR TITLE
style: enhance onboarding UI

### DIFF
--- a/src/pages/OnboardingFlow.module.css
+++ b/src/pages/OnboardingFlow.module.css
@@ -1,0 +1,15 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+.onboardingContainer {
+  font-family: 'Inter', sans-serif;
+  line-height: 1.4;
+}
+
+.messageBubble {
+  @apply max-w-[80%] rounded-[18px] px-3 py-2 backdrop-blur-md text-white shadow-md animate-enter;
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.userBubble {
+  @apply bg-primary/60 text-primary-foreground;
+}

--- a/src/pages/OnboardingFlow.tsx
+++ b/src/pages/OnboardingFlow.tsx
@@ -8,6 +8,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Progress } from "@/components/ui/progress";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import styles from "./OnboardingFlow.module.css";
 
 type Msg = { role: "assistant" | "user"; content: string };
 
@@ -198,8 +199,8 @@ export default function OnboardingFlow() {
 
   // ----- UI -----
   return (
-    <div className="relative h-svh w-screen">
-      <div className="os-bg" />
+    <div className={`relative h-svh w-screen ${styles.onboardingContainer}`}>
+      <div className="os-bg bg-gradient-to-b from-black via-[#191970] to-[#8a2be2]" />
       <div className="relative z-10 flex h-full flex-col">
         <div className="p-4">
           <div className="relative">
@@ -225,10 +226,8 @@ export default function OnboardingFlow() {
                   </Avatar>
                 )}
                 <div
-                  className={`max-w-[80%] rounded-lg px-3 py-2 ${
-                    m.role === "user"
-                      ? "bg-primary text-primary-foreground"
-                      : "bg-muted text-muted-foreground"
+                  className={`${styles.messageBubble} ${
+                    m.role === "user" ? styles.userBubble : ""
                   }`}
                 >
                   {m.content}
@@ -247,7 +246,12 @@ export default function OnboardingFlow() {
               placeholder="Your answer..."
               className="resize-none"
             />
-            <Button type="submit" className="self-end">Continue</Button>
+            <Button
+              type="submit"
+              className="self-end transition-all duration-150 hover:shadow-[0_0_8px_#8a2be2] active:scale-95"
+            >
+              Continue
+            </Button>
           </form>
         )}
 


### PR DESCRIPTION
## Summary
- add gradient background and Inter font to onboarding flow
- polish chat bubbles with glass blur, rounded edges, and entry animations
- glow buttons on hover with quicker press feedback

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any / Empty block statement / require-style import)*

------
https://chatgpt.com/codex/tasks/task_e_689a45e8f4308326a159a43b355d7264