### PR TITLE
Add revenue target engine with funnel backsolve

### DIFF
--- a/app/engines/targets.test.ts
+++ b/app/engines/targets.test.ts
@@ -1,0 +1,24 @@
+import { deriveRevenueTargets, funnelBacksolve, priors } from './targets';
+
+describe('deriveRevenueTargets', () => {
+  it('distributes revenue across months', () => {
+    const start = new Date('2024-01-01');
+    const end = new Date('2024-04-01');
+    const targets = deriveRevenueTargets(12000, start, end);
+
+    expect(targets).toHaveLength(3);
+    expect(targets.map(t => t.month)).toEqual(['2024-01', '2024-02', '2024-03']);
+    targets.forEach(t => expect(t.revenue).toBeCloseTo(4000));
+  });
+});
+
+describe('funnelBacksolve', () => {
+  it('calculates funnel stages from revenue', () => {
+    const result = funnelBacksolve(5000, priors);
+    expect(result.deals).toBeCloseTo(5);
+    expect(result.calls).toBeCloseTo(20);
+    expect(result.leads).toBeCloseTo(40);
+    expect(result.posts).toBeCloseTo(400);
+  });
+});
+

--- a/app/engines/targets.ts
+++ b/app/engines/targets.ts
@@ -1,0 +1,73 @@
+export type Priors = {
+  arpu: number;
+  closeRate: number;
+  leadToCall: number;
+  postToLead: number;
+  hoursPerWeek: number;
+};
+
+export const priors: Priors = {
+  arpu: 1000,
+  closeRate: 0.25,
+  leadToCall: 0.5,
+  postToLead: 0.1,
+  hoursPerWeek: 20,
+};
+
+function monthsBetween(start: Date, end: Date): number {
+  const years = end.getFullYear() - start.getFullYear();
+  const months = end.getMonth() - start.getMonth();
+  const diff = years * 12 + months;
+  return diff < 0 ? 0 : diff;
+}
+
+export interface MonthlyTarget {
+  month: string;
+  revenue: number;
+}
+
+export function deriveRevenueTargets(
+  totalRevenue: number,
+  start: Date,
+  end: Date,
+): MonthlyTarget[] {
+  const months = monthsBetween(start, end);
+  if (months <= 0) return [];
+
+  const perMonth = totalRevenue / months;
+  const result: MonthlyTarget[] = [];
+
+  for (let i = 0; i < months; i++) {
+    const monthDate = new Date(start.getFullYear(), start.getMonth() + i, 1);
+    result.push({ month: monthDate.toISOString().slice(0, 7), revenue: perMonth });
+  }
+
+  return result;
+}
+
+export interface FunnelOutput {
+  revenue: number;
+  deals: number;
+  calls: number;
+  leads: number;
+  posts: number;
+}
+
+export function funnelBacksolve(
+  monthlyRevenue: number,
+  prior: Priors = priors,
+): FunnelOutput {
+  const deals = monthlyRevenue / prior.arpu;
+  const calls = deals / prior.closeRate;
+  const leads = calls / prior.leadToCall;
+  const posts = leads / prior.postToLead;
+
+  return {
+    revenue: monthlyRevenue,
+    deals,
+    calls,
+    leads,
+    posts,
+  };
+}
+


### PR DESCRIPTION
## Summary
- implement sales revenue targeting engine with `deriveRevenueTargets` and `funnelBacksolve`
- expose `Priors` defaults (ARPU, close rate, lead→call, post→lead, hours/week)
- add unit tests for month range and funnel calculations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a4db003788326b06bff732570862e