### PR TITLE
feat: add roadmap planning engine

### DIFF
--- a/app/engines/roadmap.test.ts
+++ b/app/engines/roadmap.test.ts
@@ -1,0 +1,27 @@
+import { buildRoadmap, planQuarters } from './roadmap';
+
+describe('planQuarters', () => {
+  it('labels quarters between start and end', () => {
+    const start = new Date('2024-01-01');
+    const end = new Date('2024-12-31');
+    const quarters = planQuarters(start, end);
+    expect(quarters.map(q => q.label)).toEqual([
+      'Q1 2024',
+      'Q2 2024',
+      'Q3 2024',
+      'Q4 2024',
+    ]);
+  });
+});
+
+describe('buildRoadmap', () => {
+  it('seeds tasks with ids', () => {
+    const roadmap = buildRoadmap('2099-01-01', 'growth', 14);
+    expect(roadmap.tasks).toHaveLength(2);
+    roadmap.tasks.forEach(task => {
+      expect(typeof task.id).toBe('string');
+      expect(task.id.length).toBeGreaterThan(0);
+      expect(task.title).toContain('growth');
+    });
+  });
+});

--- a/app/engines/roadmap.ts
+++ b/app/engines/roadmap.ts
@@ -1,0 +1,83 @@
+import { randomBytes } from 'crypto';
+
+export interface Milestone {
+  label: string;
+  start: string;
+  end: string;
+  acceptance: string;
+}
+
+export interface Sprint {
+  start: string;
+  end: string;
+}
+
+export interface Task {
+  id: string;
+  title: string;
+}
+
+export function cryptoId(): string {
+  return randomBytes(8).toString('hex');
+}
+
+export function planQuarters(start: Date, end: Date): { label: string; start: Date; end: Date }[] {
+  const quarters: { label: string; start: Date; end: Date }[] = [];
+  const current = new Date(start.getFullYear(), Math.floor(start.getMonth() / 3) * 3, 1);
+
+  while (current <= end) {
+    const qStart = new Date(current);
+    const qEnd = new Date(qStart.getFullYear(), qStart.getMonth() + 3, 0);
+    const label = `Q${Math.floor(qStart.getMonth() / 3) + 1} ${qStart.getFullYear()}`;
+    quarters.push({ label, start: qStart, end: qEnd });
+    current.setMonth(current.getMonth() + 3);
+  }
+
+  return quarters;
+}
+
+export function acceptanceFor(strategy: string, label: string): string {
+  return `${strategy} ${label}`;
+}
+
+export function makeSprint(start: Date, lengthDays: number): Sprint {
+  const end = new Date(start);
+  end.setDate(end.getDate() + lengthDays);
+  return { start: start.toISOString(), end: end.toISOString() };
+}
+
+export function seedTasks(strategy: string): Task[] {
+  return [
+    { id: cryptoId(), title: `${strategy} kickoff` },
+    { id: cryptoId(), title: `${strategy} review` },
+  ];
+}
+
+export function buildRoadmap(
+  deadlineISO: string,
+  strategy: string,
+  sprintLenDays: number,
+): { milestones: Milestone[]; sprints: Sprint[]; tasks: Task[] } {
+  const now = new Date();
+  const deadline = new Date(deadlineISO);
+
+  const milestones = planQuarters(now, deadline).map(q => ({
+    label: q.label,
+    start: q.start.toISOString(),
+    end: q.end.toISOString(),
+    acceptance: acceptanceFor(strategy, q.label),
+  }));
+
+  const sprints: Sprint[] = [];
+  let cursor = new Date(now);
+  while (cursor < deadline) {
+    const sprint = makeSprint(cursor, sprintLenDays);
+    sprints.push(sprint);
+    cursor = new Date(sprint.end);
+  }
+
+  const tasks = seedTasks(strategy);
+
+  return { milestones, sprints, tasks };
+}
+


### PR DESCRIPTION
## Summary
- add roadmap engine with milestone, sprint, and task planning helpers
- include utilities for quarter planning, sprint creation, acceptance text, and task seeding
- add tests for quarter labels and seeded tasks

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689a4f18f084832682ad9dea46976be3