### PR TITLE
feat: track weekly kpi entries

### DIFF
--- a/app/types/mission.ts
+++ b/app/types/mission.ts
@@ -33,6 +33,17 @@ export interface KPI {
   updatedAt: Date;
 }
 
+export interface KPIRecord {
+  id: string;
+  userId: string;
+  missionId: string;
+  kpiId: string;
+  value: number;
+  recordedAt: Date;
+  source?: string;
+  createdAt: Date;
+}
+
 export interface Milestone {
   id: string;
   userId: string;

--- a/src/components/WeeklyKpiEntry.tsx
+++ b/src/components/WeeklyKpiEntry.tsx
@@ -1,0 +1,34 @@
+import { useState } from "react";
+import { useWeeklyKpiEntry } from "@/hooks/useWeeklyKpiEntry";
+
+interface Props {
+  userId: string;
+  missionId: string;
+  kpiId: string;
+  name: string;
+}
+
+export function WeeklyKpiEntry({ userId, missionId, kpiId, name }: Props) {
+  const { shouldPrompt, record } = useWeeklyKpiEntry(userId, missionId, kpiId);
+  const [value, setValue] = useState("");
+
+  if (!shouldPrompt) return null;
+
+  return (
+    <div className="p-4 border rounded-md space-y-2">
+      <div className="font-semibold">Update {name}</div>
+      <input
+        type="number"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        className="border p-1 rounded w-full"
+      />
+      <button
+        onClick={() => value && record(parseFloat(value), "manual")}
+        className="px-3 py-1 bg-blue-500 text-white rounded"
+      >
+        Save
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/useWeeklyKpiEntry.ts
+++ b/src/hooks/useWeeklyKpiEntry.ts
@@ -1,0 +1,64 @@
+import { useEffect, useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+
+/**
+ * Hook that determines whether a KPI should be updated this week
+ * and provides a function to record a new value. When a value is
+ * recorded a corresponding fact is written for review history.
+ */
+export function useWeeklyKpiEntry(
+  userId: string | null,
+  missionId: string | null,
+  kpiId: string | null
+) {
+  const [shouldPrompt, setShouldPrompt] = useState(false);
+
+  useEffect(() => {
+    async function check() {
+      if (!userId || !kpiId) return;
+      const { data, error } = await supabase
+        .from("kpi_records")
+        .select("recorded_at")
+        .eq("user_id", userId)
+        .eq("kpi_id", kpiId)
+        .order("recorded_at", { ascending: false })
+        .limit(1);
+      if (error) {
+        console.error(error);
+        return;
+      }
+      const last = data && data[0] ? new Date(data[0].recorded_at) : null;
+      if (!last) {
+        setShouldPrompt(true);
+      } else {
+        const diff = Date.now() - last.getTime();
+        setShouldPrompt(diff > 7 * 24 * 60 * 60 * 1000);
+      }
+    }
+    check();
+  }, [userId, kpiId]);
+
+  const record = async (value: number, source: string) => {
+    if (!userId || !missionId || !kpiId) return;
+    const { error } = await supabase.from("kpi_records").insert({
+      user_id: userId,
+      mission_id: missionId,
+      kpi_id: kpiId,
+      value,
+      source,
+    });
+    if (error) {
+      console.error(error);
+      return;
+    }
+    setShouldPrompt(false);
+    const { error: factErr } = await supabase.from("facts").insert({
+      user_id: userId,
+      task_id: null,
+      content: `Recorded KPI ${kpiId} = ${value}`,
+    });
+    if (factErr) console.error(factErr);
+  };
+
+  return { shouldPrompt, record } as const;
+}

--- a/supabase/migrations/20250812000000_add_kpi_records.sql
+++ b/supabase/migrations/20250812000000_add_kpi_records.sql
@@ -1,0 +1,33 @@
+-- KPI records for tracking progress over time
+create table if not exists public.kpi_records (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null,
+  mission_id uuid references public.missions(id) on delete cascade,
+  kpi_id uuid references public.kpis(id) on delete cascade,
+  value numeric not null,
+  recorded_at timestamptz not null default now(),
+  source text,
+  created_at timestamptz not null default now()
+);
+
+alter table public.kpi_records enable row level security;
+
+do $$
+begin
+  if not exists (select 1 from pg_policies where schemaname = 'public' and tablename = 'kpi_records' and policyname = 'kpi_records_select_own') then
+    create policy "kpi_records_select_own" on public.kpi_records
+      for select using (auth.uid() = user_id);
+  end if;
+  if not exists (select 1 from pg_policies where schemaname = 'public' and tablename = 'kpi_records' and policyname = 'kpi_records_insert_own') then
+    create policy "kpi_records_insert_own" on public.kpi_records
+      for insert with check (auth.uid() = user_id);
+  end if;
+  if not exists (select 1 from pg_policies where schemaname = 'public' and tablename = 'kpi_records' and policyname = 'kpi_records_update_own') then
+    create policy "kpi_records_update_own" on public.kpi_records
+      for update using (auth.uid() = user_id);
+  end if;
+  if not exists (select 1 from pg_policies where schemaname = 'public' and tablename = 'kpi_records' and policyname = 'kpi_records_delete_own') then
+    create policy "kpi_records_delete_own" on public.kpi_records
+      for delete using (auth.uid() = user_id);
+  end if;
+end$$;


### PR DESCRIPTION
## Summary
- add `kpi_records` table with row level security
- expose new `KPIRecord` type and hook to check and record weekly KPI values
- save KPI submissions as facts for review

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a56c94ea88326b12c754319c4e97e