### PR TITLE
refactor: use built in speech recognition

### DIFF
--- a/src/components/live/FloatingAssistant.tsx
+++ b/src/components/live/FloatingAssistant.tsx
@@ -14,12 +14,6 @@ import { useLocation } from 'react-router-dom';
 import type { Task } from '@/state/task';
 import { validateAnswer } from '@/utils/validation';
 
-// Minimal typings for browsers without built-in Web Speech definitions
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type SpeechRecognition = any;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type SpeechRecognitionEvent = any;
-
 type ChatMessage = {
   id: string;
   role: 'assistant' | 'user';

--- a/src/voice/voiceio.ts
+++ b/src/voice/voiceio.ts
@@ -7,10 +7,8 @@ export type VoiceCallbacks = {
   onError?: (err: any) => void;
 };
 
-type SpeechRec = any;
-
 export class VoiceIO {
-  private recognition: SpeechRec | null = null;
+  private recognition: SpeechRecognition | null = null;
   private utter: SpeechSynthesisUtterance | null = null;
   private callbacks: VoiceCallbacks;
 
@@ -43,7 +41,8 @@ export class VoiceIO {
 
     this.recognition.onerror = (e: any) => this.callbacks.onError?.(e);
     this.recognition.onend = () => {
-      // auto-stop on end (push-to-talk style)
+      this.callbacks.onSpeakingChange?.(false);
+      this.recognition = null;
     };
 
     try {


### PR DESCRIPTION
## Summary
- use built-in `SpeechRecognition` type in voice utilities
- reset voice recognition and notify when speech ends
- rely on native Web Speech types in floating assistant

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: Cannot find module 'vite')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_689a5b5812c48326be5ec7b70f55dad6