### PR TITLE
Validate focus and hypnosis durations

### DIFF
--- a/src/agent/tool-impl.test.ts
+++ b/src/agent/tool-impl.test.ts
@@ -1,0 +1,55 @@
+import { ToolImpl } from './tool-impl';
+import { toast } from '@/components/ui/use-toast';
+
+jest.mock('@/components/ui/use-toast', () => ({ toast: jest.fn() }));
+
+// minimal DOM stubs
+const dispatchEvent = jest.fn();
+(global as any).window = { dispatchEvent };
+class CustomEventMock<T> {
+  type: string;
+  detail: T;
+  constructor(type: string, params: { detail: T }) {
+    this.type = type;
+    this.detail = params.detail;
+  }
+}
+(global as any).CustomEvent = CustomEventMock;
+
+describe('ToolImpl.start_focus', () => {
+  beforeEach(() => {
+    dispatchEvent.mockClear();
+    (toast as jest.Mock).mockClear();
+  });
+
+  it('accepts minutes within range', async () => {
+    const res = await ToolImpl.start_focus({ minutes: 30 });
+    expect(res).toEqual({ ok: true });
+    expect(toast).toHaveBeenCalledWith(expect.objectContaining({ title: 'Focus started' }));
+  });
+
+  it('rejects minutes outside range', async () => {
+    const res = await ToolImpl.start_focus({ minutes: 0 });
+    expect(res).toEqual({ ok: false });
+    expect(toast).toHaveBeenCalledWith(expect.objectContaining({ title: 'Invalid duration' }));
+  });
+});
+
+describe('ToolImpl.start_hypnosis', () => {
+  beforeEach(() => {
+    dispatchEvent.mockClear();
+    (toast as jest.Mock).mockClear();
+  });
+
+  it('uses default duration when omitted', async () => {
+    const res = await ToolImpl.start_hypnosis({ mode: 'focus' });
+    expect(res).toEqual({ ok: true });
+    expect(toast).toHaveBeenCalledWith(expect.objectContaining({ description: '60s' }));
+  });
+
+  it('rejects invalid duration', async () => {
+    const res = await ToolImpl.start_hypnosis({ mode: 'calm', duration: 0 });
+    expect(res).toEqual({ ok: false });
+    expect(toast).toHaveBeenCalledWith(expect.objectContaining({ title: 'Invalid duration' }));
+  });
+});

--- a/src/agent/tool-impl.ts
+++ b/src/agent/tool-impl.ts
@@ -42,6 +42,11 @@ export const ToolImpl = {
   },
 
   async start_focus({ minutes = 25, hypnosis }: { minutes?: number; hypnosis?: 'focus' | 'calm' | 'confidence' | null }) {
+    minutes = Math.round(minutes);
+    if (!Number.isFinite(minutes) || minutes < 1 || minutes > 180) {
+      toast({ title: "Invalid duration", description: "Minutes must be between 1 and 180." });
+      return { ok: false } as any;
+    }
     if (hypnosis) {
       window.dispatchEvent(new CustomEvent('mos', { detail: { type: 'startHypnosis' } }));
     }
@@ -50,9 +55,14 @@ export const ToolImpl = {
     return { ok: true };
   },
 
-  async start_hypnosis({ mode, duration }: { mode: 'focus' | 'calm' | 'confidence' | 'reset'; duration?: number }) {
+  async start_hypnosis({ mode, duration = 60 }: { mode: 'focus' | 'calm' | 'confidence' | 'reset'; duration?: number }) {
+    duration = Math.round(duration);
+    if (!Number.isFinite(duration) || duration < 1 || duration > 600) {
+      toast({ title: "Invalid duration", description: "Duration must be between 1 and 600 seconds." });
+      return { ok: false } as any;
+    }
     window.dispatchEvent(new CustomEvent('mos', { detail: { type: 'startHypnosis' } }));
-    toast({ title: `Hypnosis: ${mode}`, description: duration ? `${duration}s` : undefined });
+    toast({ title: `Hypnosis: ${mode}`, description: `${duration}s` });
     return { ok: true };
   },
 


### PR DESCRIPTION
## Summary
- Clamp focus session minutes to 1–180 and error on invalid values
- Validate hypnosis duration, defaulting to 60s and rejecting out-of-range input
- Add unit tests for both functions covering valid and invalid inputs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a5f5058e88326b48961b166feb16a