### PR TITLE
Handle audio playback failures gracefully

### DIFF
--- a/src/hypno/tts.ts
+++ b/src/hypno/tts.ts
@@ -1,4 +1,5 @@
 import { supabase } from "@/integrations/supabase/client";
+import { toast } from "@/hooks/use-toast";
 
 export type PlaybackHandle = {
   stop: () => void;
@@ -8,7 +9,11 @@ export type PlaybackHandle = {
  * Play hypnosis text using high quality audio when available.
  * Falls back to the Web Speech API if the Supabase function fails.
  */
-export async function playHypno(text: string, onEnd: () => void): Promise<PlaybackHandle | null> {
+export async function playHypno(
+  text: string,
+  onEnd: () => void,
+  onError?: (err: unknown) => void
+): Promise<PlaybackHandle | null> {
   // Try ElevenLabs via Supabase function
   try {
     const { data, error } = await supabase.functions.invoke("tts-generate", {
@@ -18,13 +23,21 @@ export async function playHypno(text: string, onEnd: () => void): Promise<Playba
       const src = `data:${data.contentType};base64,${data.audioBase64}`;
       const audio = new Audio(src);
       audio.onended = onEnd;
-      await audio.play();
-      return {
-        stop: () => {
-          audio.pause();
-          audio.currentTime = 0;
-        },
+
+      const stop = () => {
+        audio.pause();
+        audio.currentTime = 0;
       };
+
+      const playPromise = audio.play();
+      playPromise.catch((err) => {
+        console.error("[hypno] playback failed", err);
+        stop();
+        onError?.(err);
+        toast({ title: "Playback failed", description: "Unable to start hypnosis audio." });
+        onEnd();
+      });
+      return { stop };
     }
   } catch (e) {
     console.error("[hypno] tts-generate failed", e);
@@ -32,7 +45,7 @@ export async function playHypno(text: string, onEnd: () => void): Promise<Playba
 
   // Fallback to Web Speech API
   if (typeof window !== "undefined" && "speechSynthesis" in window) {
-    try { window.speechSynthesis.cancel(); } catch {}
+    try { window.speechSynthesis.cancel(); } catch { /* ignore */ }
     const utter = new SpeechSynthesisUtterance(text);
     utter.rate = 0.95;
     utter.pitch = 1.0;
@@ -40,7 +53,7 @@ export async function playHypno(text: string, onEnd: () => void): Promise<Playba
     window.speechSynthesis.speak(utter);
     return {
       stop: () => {
-        try { window.speechSynthesis.cancel(); } catch {}
+        try { window.speechSynthesis.cancel(); } catch { /* ignore */ }
       },
     };
   }


### PR DESCRIPTION
## Summary
- handle `audio.play()` promise rejections in hypnosis TTS playback
- notify users when hypnosis audio fails to play and invoke `onEnd`
- document ignored speech synthesis errors

## Testing
- `npm test`
- `npm run lint` *(fails: unexpected any, empty block statements, etc.)*
- `npm run build` *(fails: TypeScript errors in views/MasterPlanView.tsx, SettingsView.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689a5fbbb7508326a5d81465b87d66fa