### PR TITLE
feat: centralize aurora chat calls

### DIFF
--- a/src/agent/AuroraAgent.ts
+++ b/src/agent/AuroraAgent.ts
@@ -1,7 +1,7 @@
 import { VoiceIO } from "@/voice/voiceio";
 import { ToolImpl } from "@/agent/tool-impl";
-import { supabase } from "@/integrations/supabase/client";
 import { validateAnswer } from "@/utils/validation";
+import { auroraChat } from "@/utils/auroraChat";
 
 export type AgentEvents = {
   onPartial?: (text: string) => void;
@@ -50,24 +50,19 @@ export class AuroraAgent {
 
     if (!validateAnswer(text)) {
       try {
-        const { data } = await supabase.functions.invoke('aurora-chat', {
-          body: {
-            messages: [
-              {
-                role: 'system',
-                content: `Recent user statements: ${userSummary}`,
-              },
-              {
-                role: 'system',
-                content:
-                  "The user's response was incomplete or unclear. Ask a follow-up question to clarify.",
-              },
-              ...this.history,
-            ],
+        const { content } = await auroraChat([
+          {
+            role: 'system',
+            content: `Recent user statements: ${userSummary}`,
           },
-        });
-        const reply = (data as any)?.content ?? 'Could you elaborate?';
-        this.say(reply);
+          {
+            role: 'system',
+            content:
+              "The user's response was incomplete or unclear. Ask a follow-up question to clarify.",
+          },
+          ...this.history,
+        ]);
+        this.say(content);
       } catch (e) {
         console.error('aurora-chat failed', e);
         this.say('Could you elaborate?');
@@ -100,20 +95,17 @@ export class AuroraAgent {
     }
 
     try {
-      const { data, error } = await supabase.functions.invoke('aurora-chat', {
-        body: {
-          messages: [
-            { role: 'system', content: `Recent user statements: ${userSummary}. Use this context and reference earlier user comments when appropriate.` },
-            ...this.history,
-          ],
+      const { content } = await auroraChat([
+        {
+          role: 'system',
+          content: `Recent user statements: ${userSummary}. Use this context and reference earlier user comments when appropriate.`,
         },
-      });
-      if (error) throw error;
-      const reply = (data as any)?.content ?? 'Okay.';
-      this.say(reply);
+        ...this.history,
+      ]);
+      this.say(content);
     } catch (e) {
       console.error('aurora-chat failed', e);
-      this.say("Okay.");
+      this.say('Okay.');
     }
   }
 

--- a/src/components/live/FloatingAssistant.tsx
+++ b/src/components/live/FloatingAssistant.tsx
@@ -9,10 +9,10 @@ import {
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Input } from '@/components/ui/input';
 import { MessageSquare, Send, X, Bot, Minimize2, Mic, Volume2 } from 'lucide-react';
-import { supabase } from '@/integrations/supabase/client';
 import { useLocation } from 'react-router-dom';
 import type { Task } from '@/state/task';
 import { validateAnswer } from '@/utils/validation';
+import { auroraChat } from '@/utils/auroraChat';
 
 type ChatMessage = {
   id: string;
@@ -113,14 +113,10 @@ export function FloatingAssistant({
             "The user's last message was incomplete or uninformative. Ask a follow-up question to clarify.",
         });
       }
-      const { data, error } = await supabase.functions.invoke('aurora-chat', {
-        body: {
-          model: 'o4-mini-2025-04-16',
-          messages: [...systemMessages, ...history],
-        },
-      });
-      if (error) throw error;
-      const replyText = (data as { content?: string } | null)?.content ?? 'Okay.';
+      const { content: replyText } = await auroraChat(
+        [...systemMessages, ...history],
+        { model: 'o4-mini-2025-04-16' }
+      );
       const reply: ChatMessage = {
         id: crypto.randomUUID(),
         role: 'assistant',

--- a/src/utils/auroraChat.ts
+++ b/src/utils/auroraChat.ts
@@ -1,0 +1,32 @@
+import { supabase } from '@/integrations/supabase/client';
+
+export type ChatMessage = {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+};
+
+export interface AuroraChatOptions {
+  model?: string;
+}
+
+export async function auroraChat(
+  messages: ChatMessage[],
+  options: AuroraChatOptions = {}
+): Promise<{ content: string }> {
+  const { data, error } = await supabase.functions.invoke<{ content: string }>(
+    'aurora-chat',
+    {
+      body: {
+        messages,
+        ...options,
+      },
+    }
+  );
+
+  if (error) throw error;
+  if (!data || typeof data.content !== 'string') {
+    throw new Error('Invalid response from aurora-chat');
+  }
+
+  return data;
+}


### PR DESCRIPTION
## Summary
- add reusable `auroraChat` utility to call Supabase function
- refactor `AuroraAgent` and `FloatingAssistant` to use the utility

## Testing
- `npm test`
- `npm run lint` *(fails: numerous existing eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a613bf8d4832699f3a6ff947448f1