### PR TITLE
Guard auto scroll hook for SSR safety

### DIFF
--- a/src/hooks/useAutoScrollOnFocus.ts
+++ b/src/hooks/useAutoScrollOnFocus.ts
@@ -1,9 +1,12 @@
 import { useEffect } from "react";
 
 // Ensures focused inputs scroll into view (useful on mobile keyboards)
+// Browser-only: relies on window and document objects
 export function useAutoScrollOnFocus(container?: HTMLElement | null) {
   useEffect(() => {
-    const root = container ?? document.body;
+    if (typeof window === 'undefined') return;
+    const root = container ?? document?.body;
+    if (!root) return;
     const selector = 'input, textarea, [contenteditable="true"], select';
     const elements = Array.from(root.querySelectorAll<HTMLElement>(selector));
 


### PR DESCRIPTION
## Summary
- guard `useAutoScrollOnFocus` against non-browser environments
- note DOM dependency and use optional chaining for document access

## Testing
- `npm test`
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a625f31188326a84ff2393cde6bdf