### PR TITLE
feat: add global window types

### DIFF
--- a/src/components/live/FloatingAssistant.tsx
+++ b/src/components/live/FloatingAssistant.tsx
@@ -52,7 +52,7 @@ export function FloatingAssistant({
 
   useEffect(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const SR = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+    const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
     if (!SR) return;
     const rec: SpeechRecognition = new SR();
     rec.continuous = false;

--- a/src/components/share/ShareCard.tsx
+++ b/src/components/share/ShareCard.tsx
@@ -88,9 +88,9 @@ export default function ShareCard({ open, onOpenChange, progressPercent }: Props
       const res = await fetch(imgUrl);
       const blob = await res.blob();
       const navAny = navigator as any;
-      if (navAny.clipboard && navAny.clipboard.write && (window as any).ClipboardItem) {
+      if (navAny.clipboard && navAny.clipboard.write && window.ClipboardItem) {
         await navAny.clipboard.write([
-          new (window as any).ClipboardItem({ [blob.type]: blob })
+          new window.ClipboardItem({ [blob.type]: blob })
         ]);
         toast({ title: 'Copied', description: 'Image copied to clipboard.' });
       } else if (navigator.clipboard && (navigator as any).clipboard.writeText) {

--- a/src/hooks/useXPChime.ts
+++ b/src/hooks/useXPChime.ts
@@ -6,7 +6,7 @@ export function useXPChime() {
 
     const play = () => {
       try {
-        ctx = ctx || new (window.AudioContext || (window as any).webkitAudioContext)();
+        ctx = ctx || new (window.AudioContext || window.webkitAudioContext)();
         const now = ctx.currentTime;
         const osc = ctx.createOscillator();
         const gain = ctx.createGain();

--- a/src/nodes/CoachRunner.tsx
+++ b/src/nodes/CoachRunner.tsx
@@ -16,14 +16,14 @@ export default function CoachRunner({ node, onExit }: Props) {
       onFinal: (t: string) => setFinal((arr) => [...arr, t]),
       onResponse: (t: string) => setResponses((arr) => [...arr, t]),
     });
-    (window as any).__coachAgent = agent;
+    window.__coachAgent = agent;
     return () => {
       try { agent.stopPTT(); } catch {}
     };
   }, []);
 
-  const start = () => (window as any).__coachAgent?.startPTT();
-  const stop = () => (window as any).__coachAgent?.stopPTT();
+  const start = () => window.__coachAgent?.startPTT();
+  const stop = () => window.__coachAgent?.stopPTT();
 
   return (
     <main className="relative min-h-svh px-4 pt-10 pb-28 max-w-[760px] mx-auto">

--- a/src/pages/AgentRunner.tsx
+++ b/src/pages/AgentRunner.tsx
@@ -14,7 +14,7 @@ export default function AgentRunner() {
       onFinal: (t: string) => setFinal((a) => [...a, t]),
       onResponse: (t: string) => setResponses((a) => [...a, t]),
     });
-    (window as any).__agent = agent;
+    window.__agent = agent;
     return () => {
       try { agent.stopPTT(); } catch {}
     };
@@ -28,8 +28,8 @@ export default function AgentRunner() {
 
       <div className="rounded-lg border border-white/10 p-4 bg-white/5">
         <div className="flex items-center gap-3 mb-3">
-          <button className="btn" onClick={() => (window as any).__agent?.startPTT()} aria-pressed={listening}>🎤 {listening ? 'Listening…' : 'Push-to-talk'}</button>
-          {listening && <button className="btn" onClick={() => (window as any).__agent?.stopPTT()}>Stop</button>}
+          <button className="btn" onClick={() => window.__agent?.startPTT()} aria-pressed={listening}>🎤 {listening ? 'Listening…' : 'Push-to-talk'}</button>
+          {listening && <button className="btn" onClick={() => window.__agent?.stopPTT()}>Stop</button>}
         </div>
         {partial && <p className="text-sm opacity-80">{partial}</p>}
         <div className="mt-3 space-y-2">

--- a/src/pages/Stack.tsx
+++ b/src/pages/Stack.tsx
@@ -40,7 +40,10 @@ export default function StackPage() {
 
   const hasTTS = typeof window !== "undefined" && "speechSynthesis" in window;
   const hasSTT = typeof window !== "undefined" && ("webkitSpeechRecognition" in window || "SpeechRecognition" in window);
-  const hasExtension = typeof window !== "undefined" && typeof (window as any).chrome !== "undefined" && !!(window as any).chrome?.runtime?.id;
+  const hasExtension =
+    typeof window !== "undefined" &&
+    typeof window.chrome !== "undefined" &&
+    !!window.chrome?.runtime?.id;
   const online = typeof navigator !== "undefined" && navigator.onLine;
   const supabaseReady = !!supabase;
 

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,35 @@
+import type { AuroraAgent } from "@/agent/AuroraAgent";
+
+interface SpeechRecognitionEvent extends Event {
+  results: any;
+  resultIndex: number;
+}
+
+interface SpeechRecognition {
+  lang: string;
+  interimResults: boolean;
+  maxAlternatives: number;
+  onresult: ((event: SpeechRecognitionEvent) => void) | null;
+  onerror: ((event: any) => void) | null;
+  onend: (() => void) | null;
+  start(): void;
+  stop(): void;
+}
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognition;
+}
+
+declare global {
+  interface Window {
+    __agent?: AuroraAgent;
+    __coachAgent?: AuroraAgent;
+    chrome?: any;
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+    webkitAudioContext?: typeof AudioContext;
+    ClipboardItem?: typeof ClipboardItem;
+  }
+}
+
+export {};

--- a/src/voice/useVoiceInput.ts
+++ b/src/voice/useVoiceInput.ts
@@ -11,8 +11,8 @@ export function useVoiceInput() {
 
   const start = useCallback(async () => {
     if (isRecording) return
-    if ((window as any).SpeechRecognition || (window as any).webkitSpeechRecognition) {
-      const Rec = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition
+    if (window.SpeechRecognition || window.webkitSpeechRecognition) {
+      const Rec = (window.SpeechRecognition || window.webkitSpeechRecognition)!
       const recognition = new Rec()
       recognition.lang = 'en-US'
       recognition.interimResults = false

--- a/src/voice/voiceio.ts
+++ b/src/voice/voiceio.ts
@@ -17,7 +17,7 @@ export class VoiceIO {
   }
 
   startPushToTalk() {
-    const SR: any = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+    const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
     if (!SR) {
       this.callbacks.onError?.(new Error('Web Speech API not available'));
       return;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,7 +11,13 @@
     "noUnusedParameters": false,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
-    }
+      "@/*": [
+        "./src/*"
+      ]
+    },
+    "typeRoots": [
+      "./node_modules/@types",
+      "./src/types"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- declare custom window properties and extension APIs in `src/types/global.d.ts`
- include global types via `typeRoots`
- use typed `window` properties instead of `(window as any)` casts

## Testing
- `npm run lint` *(fails: Unexpected any, Empty block statement, etc.)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a627b49408326bb71036e8f92a425