### PR TITLE
feat: add indexed memory for agent

### DIFF
--- a/src/agent/AuroraAgent.ts
+++ b/src/agent/AuroraAgent.ts
@@ -2,6 +2,10 @@ import { VoiceIO } from "@/voice/voiceio";
 import { ToolImpl } from "@/agent/tool-impl";
 import { validateAnswer } from "@/utils/validation";
 import { auroraChat } from "@/utils/auroraChat";
+import {
+  memoryStore,
+  retrieveRelevantMemories,
+} from "@/memory/indexedDbMemory";
 
 export type AgentEvents = {
   onPartial?: (text: string) => void;
@@ -43,6 +47,14 @@ export class AuroraAgent {
     this.history.push({ role: 'user', content: text });
     if (this.history.length > 20) this.history = this.history.slice(-20);
 
+    // persist user turn into long-term memory
+    await memoryStore.add('user', text);
+
+    const memories = await retrieveRelevantMemories(text);
+    const memoryContext = memories
+      .map((m) => `${m.role}: ${m.content}`)
+      .join('\n');
+
     const userSummary = this.history
       .filter((m) => m.role === 'user')
       .map((m) => m.content)
@@ -50,18 +62,22 @@ export class AuroraAgent {
 
     if (!validateAnswer(text)) {
       try {
-        const { content } = await auroraChat([
+        const messages = [
           {
             role: 'system',
             content: `Recent user statements: ${userSummary}`,
           },
+          ...(memoryContext
+            ? [{ role: 'system', content: `Relevant memories:\n${memoryContext}` }]
+            : []),
           {
             role: 'system',
             content:
               "The user's response was incomplete or unclear. Ask a follow-up question to clarify.",
           },
           ...this.history,
-        ]);
+        ];
+        const { content } = await auroraChat(messages);
         this.say(content);
       } catch (e) {
         console.error('aurora-chat failed', e);
@@ -95,13 +111,17 @@ export class AuroraAgent {
     }
 
     try {
-      const { content } = await auroraChat([
+      const messages = [
         {
           role: 'system',
           content: `Recent user statements: ${userSummary}. Use this context and reference earlier user comments when appropriate.`,
         },
+        ...(memoryContext
+          ? [{ role: 'system', content: `Relevant memories:\n${memoryContext}` }]
+          : []),
         ...this.history,
-      ]);
+      ];
+      const { content } = await auroraChat(messages);
       this.say(content);
     } catch (e) {
       console.error('aurora-chat failed', e);
@@ -112,6 +132,8 @@ export class AuroraAgent {
   say(text: string) {
     this.history.push({ role: 'assistant', content: text });
     if (this.history.length > 20) this.history = this.history.slice(-20);
+    // store assistant response asynchronously
+    memoryStore.add('assistant', text).catch(() => {});
     this.events.onResponse?.(text);
     this.voice.speak(text);
   }

--- a/src/memory/indexedDbMemory.ts
+++ b/src/memory/indexedDbMemory.ts
@@ -1,0 +1,135 @@
+import { auroraChat } from '@/utils/auroraChat';
+
+export interface MemoryEntry {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: number;
+  embedding: number[];
+}
+
+const STORAGE_KEY = 'aurora-memory-store';
+
+// basic storage wrapper that falls back to in-memory store when localStorage is unavailable
+const memoryStorage: Storage = typeof window !== 'undefined' && window.localStorage
+  ? window.localStorage
+  : {
+      _data: {} as Record<string, string>,
+      getItem(key: string) {
+        return (this._data as Record<string, string>)[key] ?? null;
+      },
+      setItem(key: string, value: string) {
+        (this._data as Record<string, string>)[key] = value;
+      },
+      removeItem(key: string) {
+        delete (this._data as Record<string, string>)[key];
+      },
+      clear() {
+        this._data = {};
+      },
+      key(i: number) {
+        return Object.keys(this._data)[i] ?? null;
+      },
+      get length() {
+        return Object.keys(this._data).length;
+      },
+    } as Storage;
+
+function cosineSimilarity(a: number[], b: number[]) {
+  if (a.length !== b.length || a.length === 0) return 0;
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    na += a[i] * a[i];
+    nb += b[i] * b[i];
+  }
+  return dot / (Math.sqrt(na) * Math.sqrt(nb));
+}
+
+export async function getEmbedding(text: string): Promise<number[]> {
+  try {
+    const { content } = await auroraChat(
+      [
+        {
+          role: 'system',
+          content:
+            'You are an embedding service. Return a JSON array of numbers representing the embedding of the user text.',
+        },
+        { role: 'user', content: text },
+      ],
+      { model: 'embedding' }
+    );
+    const parsed = JSON.parse(content);
+    if (Array.isArray(parsed)) return parsed.map((n: any) => Number(n));
+  } catch (e) {
+    // fall back to simple deterministic embedding when auroraChat is unavailable
+    return Array.from(text).map((c) => c.charCodeAt(0) / 255);
+  }
+  return [];
+}
+
+export class IndexedDbMemory {
+  private memories: MemoryEntry[] = [];
+
+  constructor() {
+    this.memories = this.load();
+  }
+
+  private load(): MemoryEntry[] {
+    try {
+      const raw = memoryStorage.getItem(STORAGE_KEY);
+      return raw ? (JSON.parse(raw) as MemoryEntry[]) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  private persist() {
+    try {
+      memoryStorage.setItem(STORAGE_KEY, JSON.stringify(this.memories));
+    } catch {
+      // ignore
+    }
+  }
+
+  private prune(limit = 200) {
+    if (this.memories.length > limit) {
+      this.memories = this.memories.slice(-limit);
+    }
+  }
+
+  async add(role: 'user' | 'assistant', content: string) {
+    const embedding = await getEmbedding(content);
+    this.memories.push({
+      id: Math.random().toString(36).slice(2),
+      role,
+      content,
+      timestamp: Date.now(),
+      embedding,
+    });
+    this.prune();
+    this.persist();
+  }
+
+  async search(text: string, topK = 5): Promise<MemoryEntry[]> {
+    if (!this.memories.length) return [];
+    const query = await getEmbedding(text);
+    const scored = this.memories.map((m) => ({
+      m,
+      score: cosineSimilarity(query, m.embedding),
+    }));
+    return scored
+      .sort((a, b) => b.score - a.score)
+      .slice(0, topK)
+      .map((s) => s.m);
+  }
+}
+
+export const memoryStore = new IndexedDbMemory();
+
+export async function retrieveRelevantMemories(text: string, k = 5) {
+  return memoryStore.search(text, k);
+}
+


### PR DESCRIPTION
## Summary
- store conversation turns with embeddings in a local IndexedDb-like memory
- persist user and assistant responses and retrieve similar memories for context
- inject relevant memories into auroraChat prompts for better recall

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a67925af08326a3295ee832c37eaf