### PR TITLE
feat: apply persona profile to aurora chat

### DIFF
--- a/src/data/profile.ts
+++ b/src/data/profile.ts
@@ -16,6 +16,7 @@ export interface UserProfile {
   skills?: string;
   habits?: string;
   challenges?: string;
+  tones?: string;
   history: ProfileHistoryItem[];
 }
 
@@ -25,6 +26,7 @@ const FIELD_KEYWORDS: Record<keyof Omit<UserProfile, 'history'>, string> = {
   skills: 'skill',
   habits: 'habit',
   challenges: 'challenge',
+  tones: 'tone',
 };
 
 export function buildHistory(
@@ -59,5 +61,35 @@ export function buildProfile(
 
 export function buildAnswers(responses: ConversationResponse[]) {
   return responses.map((r) => ({ question: r.question, answer: r.answer }));
+}
+
+const PROFILE_STORAGE_KEY = 'aurora_user_profile_v1';
+
+export function saveProfile(profile: UserProfile) {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(PROFILE_STORAGE_KEY, JSON.stringify(profile));
+  } catch {
+    // ignore storage errors
+  }
+}
+
+export function loadProfile(): UserProfile | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(PROFILE_STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as UserProfile) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function summarizeProfile(profile: UserProfile | null): string {
+  if (!profile) return '';
+  const parts: string[] = [];
+  if (profile.goals) parts.push(`Goals: ${profile.goals}`);
+  if (profile.values) parts.push(`Values: ${profile.values}`);
+  if (profile.tones) parts.push(`Tone: ${profile.tones}`);
+  return parts.join('; ');
 }
 

--- a/src/pages/OnboardingFlow.tsx
+++ b/src/pages/OnboardingFlow.tsx
@@ -9,6 +9,11 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { EvolvingSphere } from "@/components/effects/EvolvingSphere";
 import { useTextToSpeech } from "@/voice/useTextToSpeech";
+import {
+  buildProfile,
+  ConversationResponse,
+  saveProfile,
+} from "@/data/profile";
 
 
 type Msg = { role: "assistant" | "user"; content: string };
@@ -252,6 +257,15 @@ export default function OnboardingFlow() {
       if (!updatedAnswers[currentModule]) updatedAnswers[currentModule] = [];
       updatedAnswers[currentModule][questionIndex] = userMsg.content;
       setAnswers(updatedAnswers);
+
+      const responses: ConversationResponse[] = [];
+      MODULES.forEach((mod, mi) => {
+        mod.questions.forEach((q, qi) => {
+          const ans = updatedAnswers[mi]?.[qi];
+          if (ans) responses.push({ question: q.prompt, answer: ans });
+        });
+      });
+      saveProfile(buildProfile(responses));
 
       if (currentModule === 0) {
         if (questionIndex === 0) setHeadline(userMsg.content);

--- a/src/utils/auroraChat.ts
+++ b/src/utils/auroraChat.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@/integrations/supabase/client';
+import { loadProfile, UserProfile } from '@/data/profile';
 
 export type ChatMessage = {
   role: 'system' | 'user' | 'assistant';
@@ -9,15 +10,25 @@ export interface AuroraChatOptions {
   model?: string;
 }
 
+let cachedProfile: UserProfile | null | undefined;
+
+function getProfile(): UserProfile | null {
+  if (cachedProfile !== undefined) return cachedProfile;
+  cachedProfile = loadProfile();
+  return cachedProfile;
+}
+
 export async function auroraChat(
   messages: ChatMessage[],
   options: AuroraChatOptions = {}
 ): Promise<{ content: string }> {
+  const profile = getProfile();
   const { data, error } = await supabase.functions.invoke<{ content: string }>(
     'aurora-chat',
     {
       body: {
         messages,
+        profile,
         ...options,
       },
     }

--- a/supabase/functions/aurora-chat/index.ts
+++ b/supabase/functions/aurora-chat/index.ts
@@ -3,6 +3,7 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 
 import brain from "../../../src/brain/Brain.ts";
 import { getFilterName } from "../../../src/brain/filters.ts";
+import { summarizeProfile, UserProfile } from "../../../src/data/profile.ts";
 
 
 const corsHeaders = {
@@ -26,7 +27,7 @@ serve(async (req) => {
 
   try {
     const body = await req.json().catch(() => ({}));
-    const { messages, prompt, model } = body ?? {};
+    const { messages, prompt, model, profile } = body ?? {};
 
     const usedModel = model || "o4-mini-2025-04-16"; // cost-effective default
 
@@ -45,6 +46,11 @@ serve(async (req) => {
       .join("; ");
     if (skillPrompt) {
       systemMessages.push({ role: "system", content: `Available skills: ${skillPrompt}` });
+    }
+
+    const profileSummary = summarizeProfile(profile as UserProfile | null);
+    if (profileSummary) {
+      systemMessages.unshift({ role: "system", content: `User profile: ${profileSummary}` });
     }
 
     const filterNames = brain.filters


### PR DESCRIPTION
## Summary
- store onboarding answers into local user profile
- cache and send profile with chat requests
- include profile summary in aurora-chat system messages

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a67cdca248326be6288bba78490f7