### PR TITLE
feat: add local model fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@capacitor/core": "^6.2.1",
         "@capacitor/ios": "^6.2.1",
         "@hookform/resolvers": "^3.10.0",
+        "@mlc-ai/web-llm": "^0.2.79",
         "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-alert-dialog": "^1.1.14",
         "@radix-ui/react-aspect-ratio": "^1.1.7",
@@ -3987,6 +3988,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mlc-ai/web-llm": {
+      "version": "0.2.79",
+      "resolved": "https://registry.npmjs.org/@mlc-ai/web-llm/-/web-llm-0.2.79.tgz",
+      "integrity": "sha512-Hy1ZHQ0o2bZGZoVnGK48+fts/ZSKwLe96xjvqL/6C59Mem9HoHTcFE07NC2E23mRmhd01tL655N6CPeYmwWgwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "loglevel": "^1.9.1"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -11513,6 +11523,19 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "license": "MIT"
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@capacitor/core": "^6.2.1",
     "@capacitor/ios": "^6.2.1",
     "@hookform/resolvers": "^3.10.0",
+    "@mlc-ai/web-llm": "^0.2.79",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-aspect-ratio": "^1.1.7",

--- a/src/agent/localModel.ts
+++ b/src/agent/localModel.ts
@@ -1,0 +1,22 @@
+import type { ChatMessage, ChatOptions } from '@/types/chat';
+
+let engine: any;
+
+export async function localChat(
+  messages: ChatMessage[],
+  options: ChatOptions = {},
+): Promise<{ content: string }> {
+  if (typeof window === 'undefined') {
+    throw new Error('Local model not available');
+  }
+
+  if (!engine) {
+    const { CreateMLCEngine } = await import('@mlc-ai/web-llm');
+    const model = options.model || 'Llama-3.1-8B-Instruct-q4f32_1-MLC';
+    engine = await CreateMLCEngine(model);
+  }
+
+  const resp = await engine.chat.completions.create({ messages });
+  const content = resp?.choices?.[0]?.message?.content ?? '';
+  return { content };
+}

--- a/src/components/settings/ModelPanel.tsx
+++ b/src/components/settings/ModelPanel.tsx
@@ -1,0 +1,31 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Label } from '@/components/ui/label';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+
+export type ModelPreference = 'auto' | 'local' | 'remote';
+
+export default function ModelPanel() {
+  const [pref, setPref] = useLocalStorage<ModelPreference>('settings.modelPreference', 'auto');
+
+  return (
+    <div className="space-y-2">
+      <h2 className="text-lg font-semibold">Model Preference</h2>
+      <div className="flex flex-col gap-2 w-full max-w-sm">
+        <Label htmlFor="model-preference">Preferred model</Label>
+        <Select value={pref} onValueChange={(v) => setPref(v as ModelPreference)}>
+          <SelectTrigger id="model-preference">
+            <SelectValue placeholder="Choose" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="auto">Auto (remote with fallback)</SelectItem>
+            <SelectItem value="remote">Remote (Supabase)</SelectItem>
+            <SelectItem value="local">Local (on-device)</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Messages may use the local model when offline or on slow networks.
+      </p>
+    </div>
+  );
+}

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1,0 +1,8 @@
+export type ChatMessage = {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+};
+
+export interface ChatOptions {
+  model?: string;
+}

--- a/src/utils/auroraChat.ts
+++ b/src/utils/auroraChat.ts
@@ -1,13 +1,79 @@
 import { supabase } from '@/integrations/supabase/client';
-import { loadProfile, UserProfile } from '@/data/profile';
+import { loadProfile, UserProfile, summarizeProfile } from '@/data/profile';
+import brain from '@/brain/Brain';
+import { getFilterName } from '@/brain/filters';
+import { localChat } from '@/agent/localModel';
+import type { ChatMessage, ChatOptions } from '@/types/chat';
 
-export type ChatMessage = {
-  role: 'system' | 'user' | 'assistant';
-  content: string;
-};
+type ModelPreference = 'auto' | 'local' | 'remote';
+const MODEL_PREF_KEY = 'settings.modelPreference';
 
-export interface AuroraChatOptions {
-  model?: string;
+function getModelPreference(): ModelPreference {
+  if (typeof window === 'undefined') return 'remote';
+  try {
+    const raw = localStorage.getItem(MODEL_PREF_KEY);
+    return raw ? (JSON.parse(raw) as ModelPreference) : 'auto';
+  } catch {
+    return 'auto';
+  }
+}
+
+function isLowBandwidth(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const conn = (navigator as any).connection;
+  return conn?.saveData || ['slow-2g', '2g'].includes(conn?.effectiveType);
+}
+
+function shouldUseLocal(pref: ModelPreference): boolean {
+  if (pref === 'local') return true;
+  if (pref === 'remote') return false;
+  const offline = typeof navigator !== 'undefined' && !navigator.onLine;
+  return offline || isLowBandwidth();
+}
+
+function buildSystemMessages(profile: UserProfile | null): ChatMessage[] {
+  const systemMessages: ChatMessage[] = [
+    { role: 'system', content: brain.cognition.systemPrompt },
+  ];
+
+  if (brain.cognition.contextPrompt) {
+    systemMessages.push({ role: 'system', content: brain.cognition.contextPrompt });
+  }
+
+  systemMessages.push({
+    role: 'system',
+    content: `Behavior style: ${brain.behavior.style}`,
+  });
+
+  const skillPrompt = brain.skills
+    .map((s) => `${s.name}: ${s.description}`)
+    .join('; ');
+  if (skillPrompt) {
+    systemMessages.push({
+      role: 'system',
+      content: `Available skills: ${skillPrompt}`,
+    });
+  }
+
+  const profileSummary = summarizeProfile(profile);
+  if (profileSummary) {
+    systemMessages.unshift({
+      role: 'system',
+      content: `User profile: ${profileSummary}`,
+    });
+  }
+
+  const filterNames = brain.filters
+    .map((f) => getFilterName(f))
+    .filter((n): n is string => Boolean(n));
+  if (filterNames.length > 0) {
+    systemMessages.push({
+      role: 'system',
+      content: `Applied filters: ${filterNames.join(', ')}`,
+    });
+  }
+
+  return systemMessages;
 }
 
 let cachedProfile: UserProfile | null | undefined;
@@ -20,24 +86,45 @@ function getProfile(): UserProfile | null {
 
 export async function auroraChat(
   messages: ChatMessage[],
-  options: AuroraChatOptions = {}
+  options: ChatOptions = {},
 ): Promise<{ content: string }> {
   const profile = getProfile();
-  const { data, error } = await supabase.functions.invoke<{ content: string }>(
-    'aurora-chat',
-    {
-      body: {
-        messages,
-        profile,
-        ...options,
-      },
-    }
-  );
+  const pref = getModelPreference();
+  const useLocal = shouldUseLocal(pref);
+  const systemMessages = buildSystemMessages(profile);
 
-  if (error) throw error;
-  if (!data || typeof data.content !== 'string') {
-    throw new Error('Invalid response from aurora-chat');
+  if (useLocal) {
+    const { content } = await localChat([...systemMessages, ...messages], options);
+    let filtered = content;
+    for (const filter of brain.filters) filtered = filter(filtered);
+    return { content: filtered };
   }
 
-  return data;
+  try {
+    const { data, error } = await supabase.functions.invoke<{ content: string }>(
+      'aurora-chat',
+      {
+        body: {
+          messages,
+          profile,
+          ...options,
+        },
+      },
+    );
+
+    if (error) throw error;
+    if (!data || typeof data.content !== 'string') {
+      throw new Error('Invalid response from aurora-chat');
+    }
+
+    return data;
+  } catch (e) {
+    if (pref !== 'remote') {
+      const { content } = await localChat([...systemMessages, ...messages], options);
+      let filtered = content;
+      for (const filter of brain.filters) filtered = filter(filtered);
+      return { content: filtered };
+    }
+    throw e;
+  }
 }

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -15,6 +15,7 @@ import {
   AlertDialogAction,
 } from "@/components/ui/alert-dialog";
 import TriggersPanel from "@/components/settings/TriggersPanel";
+import ModelPanel from "@/components/settings/ModelPanel";
 
 
 export default function SettingsView() {
@@ -83,41 +84,13 @@ export default function SettingsView() {
               </AlertDialog>
               <Button variant="softPrimary" onClick={signOut}>Log out</Button>
             </div>
+            </div>
+            <TriggersPanel />
+            <ModelPanel />
           </div>
-          <TriggersPanel />
-        <div className="space-y-2">
-          <div className="text-sm text-muted-foreground">{user.email}</div>
-          <div className="flex gap-2">
-            <Button variant="outline" onClick={handleExport}>
-              Export Profile
-            </Button>
-            <AlertDialog>
-              <AlertDialogTrigger asChild>
-                <Button variant="destructive">Delete Profile</Button>
-              </AlertDialogTrigger>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>Delete profile?</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    This will remove your profile data from this device. This action
-                    cannot be undone.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>Cancel</AlertDialogCancel>
-                  <AlertDialogAction onClick={handleDelete}>
-                    Delete
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
-          </div>
-          <Button variant="softPrimary" onClick={signOut}>Log out</Button>
-
-        </div>
-      ) : (
-        <p className="text-sm text-muted-foreground">You are not signed in.</p>
-      )}
-    </div>
-  );
+        ) : (
+          <p className="text-sm text-muted-foreground">You are not signed in.</p>
+        )}
+      </div>
+    );
 }


### PR DESCRIPTION
## Summary
- integrate @mlc-ai/web-llm local model module
- allow auroraChat to switch between local and supabase models based on user setting and network status
- add settings panel for model preference

## Testing
- `npm install --legacy-peer-deps`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a695a96ec832698d5c34521d53cae