### PR TITLE
load brain policy as system prompt

### DIFF
--- a/src/brain/cognition.ts
+++ b/src/brain/cognition.ts
@@ -1,3 +1,5 @@
+import brainPolicy from '../../BRAIN_POLICY.md?raw';
+
 export interface CognitionConfig {
   /**
    * System prompt used for all chat interactions.
@@ -10,7 +12,7 @@ export interface CognitionConfig {
 }
 
 export const cognition: CognitionConfig = {
-  systemPrompt: 'You are Aura, a friendly life coach AI who gives concise and actionable advice.',
+  systemPrompt: brainPolicy,
   contextPrompt: 'Respond in a warm and supportive tone.'
 };
 

--- a/src/types/raw.d.ts
+++ b/src/types/raw.d.ts
@@ -1,0 +1,4 @@
+declare module '*.md?raw' {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
## Summary
- import BRAIN_POLICY.md into cognition config to supply the system prompt
- add type declaration so markdown `?raw` imports work in TypeScript

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, Empty block statement, and other existing errors)*
- `npm run build` *(fails: JSX expressions must have one parent element and other TypeScript errors in MasterPlanView.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689a7474a2008326807000fc1c848a0e