### PR TITLE
feat: add persona setup page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import ExtensionPage from "@/pages/Extension";
 import StackPage from "./pages/Stack";
 import AppShell from "@/routes/AppShell";
 import OnboardingFlow from "./pages/OnboardingFlow";
+import PersonaSetup from "./pages/PersonaSetup";
 const queryClient = new QueryClient();
 
 const App = () => (
@@ -32,6 +33,7 @@ const App = () => (
           <Route path="/hypno" element={<HypnoShell />} />
           <Route path="/extension" element={<ExtensionPage />} />
           <Route path="/stack" element={<StackPage />} />
+          <Route path="/persona-setup" element={<PersonaSetup />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/data/profile.ts
+++ b/src/data/profile.ts
@@ -17,6 +17,7 @@ export interface UserProfile {
   habits?: string;
   challenges?: string;
   tones?: string;
+  quirks?: string;
   history: ProfileHistoryItem[];
 }
 
@@ -27,6 +28,7 @@ const FIELD_KEYWORDS: Record<keyof Omit<UserProfile, 'history'>, string> = {
   habits: 'habit',
   challenges: 'challenge',
   tones: 'tone',
+  quirks: 'quirk',
 };
 
 export function buildHistory(
@@ -90,6 +92,7 @@ export function summarizeProfile(profile: UserProfile | null): string {
   if (profile.goals) parts.push(`Goals: ${profile.goals}`);
   if (profile.values) parts.push(`Values: ${profile.values}`);
   if (profile.tones) parts.push(`Tone: ${profile.tones}`);
+  if (profile.quirks) parts.push(`Quirks: ${profile.quirks}`);
   return parts.join('; ');
 }
 

--- a/src/pages/PersonaSetup.tsx
+++ b/src/pages/PersonaSetup.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { memoryStore } from "@/memory/indexedDbMemory";
+import { usePersonaStore } from "@/state/persona";
+
+export default function PersonaSetup() {
+  const { profile, updateProfile } = usePersonaStore();
+  const [goals, setGoals] = useState(profile.goals || "");
+  const [values, setValues] = useState(profile.values || "");
+  const [tone, setTone] = useState(profile.tones || "");
+  const [quirks, setQuirks] = useState(profile.quirks || "");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const updates = { goals, values, tones: tone, quirks };
+    updateProfile(updates);
+    await Promise.all([
+      goals
+        ? memoryStore.add("semantic", "user", `Goals: ${goals}`, {
+            tags: ["persona", "goals"],
+          })
+        : Promise.resolve(),
+      values
+        ? memoryStore.add("semantic", "user", `Values: ${values}`, {
+            tags: ["persona", "values"],
+          })
+        : Promise.resolve(),
+      tone
+        ? memoryStore.add("semantic", "user", `Tone: ${tone}`, {
+            tags: ["persona", "tone"],
+          })
+        : Promise.resolve(),
+      quirks
+        ? memoryStore.add("semantic", "user", `Quirks: ${quirks}`, {
+            tags: ["persona", "quirks"],
+          })
+        : Promise.resolve(),
+    ]);
+  };
+
+  return (
+    <div className="p-4 max-w-xl mx-auto">
+      <h1 className="text-2xl font-semibold mb-4">Persona Setup</h1>
+      <form className="space-y-4" onSubmit={handleSubmit}>
+        <div className="space-y-2">
+          <Label htmlFor="goals">Goals</Label>
+          <Textarea
+            id="goals"
+            value={goals}
+            onChange={(e) => setGoals(e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="values">Values</Label>
+          <Textarea
+            id="values"
+            value={values}
+            onChange={(e) => setValues(e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="tone">Tone</Label>
+          <Textarea
+            id="tone"
+            value={tone}
+            onChange={(e) => setTone(e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="quirks">Quirks</Label>
+          <Textarea
+            id="quirks"
+            value={quirks}
+            onChange={(e) => setQuirks(e.target.value)}
+          />
+        </div>
+        <Button type="submit">Save Persona</Button>
+      </form>
+    </div>
+  );
+}

--- a/src/state/persona.ts
+++ b/src/state/persona.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+import { loadProfile, saveProfile, UserProfile } from "@/data/profile";
+
+interface PersonaState {
+  profile: UserProfile;
+  updateProfile: (updates: Partial<UserProfile>) => void;
+}
+
+export const usePersonaStore = create<PersonaState>((set) => ({
+  profile: loadProfile() ?? { history: [] },
+  updateProfile: (updates) =>
+    set((state) => {
+      const profile = { ...state.profile, ...updates };
+      saveProfile(profile);
+      return { profile };
+    }),
+}));


### PR DESCRIPTION
## Summary
- add persona setup screen to capture goals, values, tone and quirks
- persist persona data with zustand and local profile storage
- route new page and enrich profile with quirks field

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, Empty block statements, A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689a7639f44c8326812742be8c292fae