### PR TITLE
feat(hypno): add hypnosis script runners with consent checks

### DIFF
--- a/src/hypno/index.ts
+++ b/src/hypno/index.ts
@@ -1,0 +1,2 @@
+export * from "./tts";
+export * from "./scripts";

--- a/src/hypno/scripts.ts
+++ b/src/hypno/scripts.ts
@@ -1,0 +1,52 @@
+import { playHypno, type PlaybackHandle } from "./tts";
+
+/**
+ * Ensure the user has opted in and is in a comfortable state
+ * before running any hypnosis-related script.
+ */
+function ensureOptInAndComfort(): boolean {
+  if (typeof window === "undefined") return false;
+
+  try {
+    const key = "hypno.optIn";
+    const storage = window.localStorage;
+    if (storage.getItem(key) !== "yes") {
+      const consent = window.confirm(
+        "These hypnosis scripts are optional. Do you consent to continue?"
+      );
+      if (!consent) return false;
+      storage.setItem(key, "yes");
+    }
+
+    const comfortable = window.confirm(
+      "Are you in a comfortable, safe place and ready to proceed?"
+    );
+    return comfortable;
+  } catch {
+    return false;
+  }
+}
+
+async function runScript(text: string): Promise<PlaybackHandle | null> {
+  if (!ensureOptInAndComfort()) return null;
+  return playHypno(text, () => {});
+}
+
+export async function runMicroInduction(
+  text: string
+): Promise<PlaybackHandle | null> {
+  return runScript(text);
+}
+
+export async function runVisualization(
+  text: string
+): Promise<PlaybackHandle | null> {
+  return runScript(text);
+}
+
+export async function runAffirmation(
+  text: string
+): Promise<PlaybackHandle | null> {
+  return runScript(text);
+}
+


### PR DESCRIPTION
## Summary
- add script runners for micro inductions, visualizations, and affirmations
- ensure opt-in and comfort confirmations before playback
- export hypnosis utilities from central index

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and other lint errors across repo)*

------
https://chatgpt.com/codex/tasks/task_e_689a76404350832692d6d14f0b10bbb4