### PR TITLE
Add safety agent to vet responses

### DIFF
--- a/src/agent/AuroraAgent.ts
+++ b/src/agent/AuroraAgent.ts
@@ -6,6 +6,9 @@ import {
   memoryStore,
   retrieveRelevantMemories,
 } from "@/memory/indexedDbMemory";
+import brain from "@/brain/Brain";
+import { filterRegistry } from "@/brain/filters";
+import { scanResponse, explainIssues } from "@/agent/safety";
 
 export type AgentEvents = {
   onPartial?: (text: string) => void;
@@ -14,6 +17,7 @@ export type AgentEvents = {
   onListeningChange?: (v: boolean) => void;
   onSpeakingChange?: (v: boolean) => void;
   onError?: (e: any) => void;
+  onSafetyViolation?: (text: string, issues: string[]) => boolean;
 };
 
 export class AuroraAgent {
@@ -130,11 +134,28 @@ export class AuroraAgent {
   }
 
     say(text: string) {
-      this.history.push({ role: 'assistant', content: text });
+      const { ok, issues } = scanResponse(text);
+      let output = text;
+      let skipSafety = false;
+      if (!ok) {
+        const allow = this.events.onSafetyViolation?.(text, issues) ?? false;
+        if (allow) {
+          skipSafety = true;
+        } else {
+          output = explainIssues(issues);
+        }
+      }
+
+      for (const filter of brain.filters) {
+        if (skipSafety && filter === filterRegistry.safety) continue;
+        output = filter(output);
+      }
+
+      this.history.push({ role: 'assistant', content: output });
       if (this.history.length > 20) this.history = this.history.slice(-20);
       // store assistant response asynchronously
-      memoryStore.add('episodic', 'assistant', text).catch(() => {});
-      this.events.onResponse?.(text);
-      void this.voice.speak(text);
+      memoryStore.add('episodic', 'assistant', output).catch(() => {});
+      this.events.onResponse?.(output);
+      void this.voice.speak(output);
     }
   }

--- a/src/agent/safety.ts
+++ b/src/agent/safety.ts
@@ -1,0 +1,28 @@
+const PATTERNS = [
+  { pattern: /(suicide|self-harm|kill myself)/i, issue: 'self-harm' },
+  { pattern: /(violence|attack|terror|bomb)/i, issue: 'violence' },
+  { pattern: /(hate speech|racial slur|bigot)/i, issue: 'hate' },
+];
+
+export interface SafetyResult {
+  ok: boolean;
+  issues: string[];
+}
+
+export function scanResponse(text: string): SafetyResult {
+  const issues: string[] = [];
+  for (const { pattern, issue } of PATTERNS) {
+    if (pattern.test(text)) issues.push(issue);
+  }
+  return { ok: issues.length === 0, issues };
+}
+
+export function explainIssues(issues: string[]): string {
+  return `Response blocked due to: ${issues.join(', ')}`;
+}
+
+export function safetyFilter(text: string): string {
+  const { ok, issues } = scanResponse(text);
+  return ok ? text : explainIssues(issues);
+}
+

--- a/src/brain/filters.ts
+++ b/src/brain/filters.ts
@@ -1,9 +1,12 @@
+import { safetyFilter } from '@/agent/safety'
+
 export type Filter = (text: string) => string
 
 export const filterRegistry: Record<string, Filter> = {
   trim: text => text.trim(),
   lowercase: text => text.toLowerCase(),
-  uppercase: text => text.toUpperCase()
+  uppercase: text => text.toUpperCase(),
+  safety: safetyFilter,
 }
 
 export type FilterName = keyof typeof filterRegistry
@@ -11,7 +14,7 @@ export type FilterName = keyof typeof filterRegistry
 /**
  * List of filters applied to every outgoing message.
  */
-export const filters: Filter[] = [filterRegistry.trim]
+export const filters: Filter[] = [filterRegistry.trim, filterRegistry.safety]
 
 export function getFilterByName(name: string): Filter | undefined {
   return filterRegistry[name as FilterName]


### PR DESCRIPTION
## Summary
- create safety module with basic policy checks
- integrate safety filter into brain and agent with optional override

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any ...)*

------
https://chatgpt.com/codex/tasks/task_e_689a777ec82883269519be1c942d1a0b