### PR TITLE
feat: route chat requests between local and cloud

### DIFF
--- a/src/agent/router.ts
+++ b/src/agent/router.ts
@@ -1,0 +1,60 @@
+import { supabase } from '@/integrations/supabase/client';
+import { localChat } from '@/agent/localModel';
+import type { ChatMessage, ChatOptions } from '@/types/chat';
+import type { UserProfile } from '@/data/profile';
+
+// Simple token estimator: count whitespace-separated words
+function estimateTokens(messages: ChatMessage[]): number {
+  return messages
+    .map((m) => m.content)
+    .join(' ')
+    .split(/\s+/)
+    .filter(Boolean)
+    .length;
+}
+
+// Strip obvious sensitive data like emails or long numbers
+function stripSensitive(messages: ChatMessage[]): ChatMessage[] {
+  const emailRegex = /[\w.+-]+@[\w.-]+/g;
+  const longNumber = /\b\d{4,}\b/g;
+  return messages.map((m) => ({
+    ...m,
+    content: m.content.replace(emailRegex, '[REDACTED]').replace(longNumber, '[REDACTED]'),
+  }));
+}
+
+function sanitizeProfile(profile: UserProfile | null): Partial<UserProfile> | null {
+  if (!profile) return null;
+  const { history, ...rest } = profile;
+  return rest;
+}
+
+// Decide whether to use local or cloud model
+function chooseRoute(tokens: number, depth: number): 'local' | 'cloud' {
+  const offline = typeof navigator !== 'undefined' && !navigator.onLine;
+  if (offline) return 'local';
+  if (tokens > 200 || depth > 2) return 'cloud';
+  return 'local';
+}
+
+export async function routeChat(
+  messages: ChatMessage[],
+  profile: UserProfile | null,
+  options: ChatOptions = {},
+): Promise<{ content: string }> {
+  const tokens = estimateTokens(messages);
+  const depth = options.depth ?? 1;
+  const route = chooseRoute(tokens, depth);
+
+  if (route === 'local') {
+    return localChat(messages, options);
+  }
+
+  const safeMessages = stripSensitive(messages);
+  const safeProfile = sanitizeProfile(profile);
+  const { data, error } = await supabase.functions.invoke<{ content: string }>('aurora-chat', {
+    body: { messages: safeMessages, profile: safeProfile, ...options },
+  });
+  if (error) throw error;
+  return data ?? { content: '' };
+}

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -5,4 +5,5 @@ export type ChatMessage = {
 
 export interface ChatOptions {
   model?: string;
+  depth?: number;
 }

--- a/src/utils/auroraChat.ts
+++ b/src/utils/auroraChat.ts
@@ -1,35 +1,8 @@
-import { supabase } from '@/integrations/supabase/client';
 import { loadProfile, UserProfile, summarizeProfile } from '@/data/profile';
 import brain from '@/brain/Brain';
 import { getFilterName } from '@/brain/filters';
-import { localChat } from '@/agent/localModel';
+import { routeChat } from '@/agent/router';
 import type { ChatMessage, ChatOptions } from '@/types/chat';
-
-type ModelPreference = 'auto' | 'local' | 'remote';
-const MODEL_PREF_KEY = 'settings.modelPreference';
-
-function getModelPreference(): ModelPreference {
-  if (typeof window === 'undefined') return 'remote';
-  try {
-    const raw = localStorage.getItem(MODEL_PREF_KEY);
-    return raw ? (JSON.parse(raw) as ModelPreference) : 'auto';
-  } catch {
-    return 'auto';
-  }
-}
-
-function isLowBandwidth(): boolean {
-  if (typeof navigator === 'undefined') return false;
-  const conn = (navigator as any).connection;
-  return conn?.saveData || ['slow-2g', '2g'].includes(conn?.effectiveType);
-}
-
-function shouldUseLocal(pref: ModelPreference): boolean {
-  if (pref === 'local') return true;
-  if (pref === 'remote') return false;
-  const offline = typeof navigator !== 'undefined' && !navigator.onLine;
-  return offline || isLowBandwidth();
-}
 
 function buildSystemMessages(profile: UserProfile | null): ChatMessage[] {
   const systemMessages: ChatMessage[] = [
@@ -89,42 +62,13 @@ export async function auroraChat(
   options: ChatOptions = {},
 ): Promise<{ content: string }> {
   const profile = getProfile();
-  const pref = getModelPreference();
-  const useLocal = shouldUseLocal(pref);
   const systemMessages = buildSystemMessages(profile);
-
-  if (useLocal) {
-    const { content } = await localChat([...systemMessages, ...messages], options);
-    let filtered = content;
-    for (const filter of brain.filters) filtered = filter(filtered);
-    return { content: filtered };
-  }
-
-  try {
-    const { data, error } = await supabase.functions.invoke<{ content: string }>(
-      'aurora-chat',
-      {
-        body: {
-          messages,
-          profile,
-          ...options,
-        },
-      },
-    );
-
-    if (error) throw error;
-    if (!data || typeof data.content !== 'string') {
-      throw new Error('Invalid response from aurora-chat');
-    }
-
-    return data;
-  } catch (e) {
-    if (pref !== 'remote') {
-      const { content } = await localChat([...systemMessages, ...messages], options);
-      let filtered = content;
-      for (const filter of brain.filters) filtered = filter(filtered);
-      return { content: filtered };
-    }
-    throw e;
-  }
+  const { content } = await routeChat(
+    [...systemMessages, ...messages],
+    profile,
+    options,
+  );
+  let filtered = content;
+  for (const filter of brain.filters) filtered = filter(filtered);
+  return { content: filtered };
 }


### PR DESCRIPTION
## Summary
- add router that chooses between local model and cloud API based on token count and depth
- sanitize messages and profile before cloud calls
- wire auroraChat through new routing logic and support `depth` option

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any / no-empty in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689a7779d6d48326afc9eb9a3b6f817e