### PR TITLE
Add voice cloning utility and setup UI

### DIFF
--- a/src/components/VoiceSetup.tsx
+++ b/src/components/VoiceSetup.tsx
@@ -1,19 +1,23 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { toast } from "@/hooks/use-toast";
 import { useVoiceStore } from "@/state/voice";
+import { Button } from "@/components/ui/button";
+import { Mic, Square } from "lucide-react";
 
 export default function VoiceSetup() {
   const { voiceId, setVoiceId } = useVoiceStore();
   const [uploading, setUploading] = useState(false);
+  const [recording, setRecording] = useState(false);
+  const mediaRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
 
-  const onFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
+  const uploadSample = async (file: Blob | File) => {
     setUploading(true);
     try {
       const form = new FormData();
       form.append("name", "user-voice");
-      form.append("files", file);
+      const f = file instanceof File ? file : new File([file], "sample.webm", { type: file.type || "audio/webm" });
+      form.append("files", f);
       const resp = await fetch("https://api.elevenlabs.io/v1/voices/add", {
         method: "POST",
         headers: {
@@ -31,31 +35,75 @@ export default function VoiceSetup() {
       }
     } catch (err) {
       console.error("voice upload", err);
-      toast({
-        title: "Upload failed",
-        description: String(err),
-        variant: "destructive" as any,
-      });
+        toast({
+          title: "Upload failed",
+          description: String(err),
+          variant: "destructive" as const,
+        });
     } finally {
       setUploading(false);
-      if (e.target) e.target.value = "";
     }
+  };
+
+  const onFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    await uploadSample(file);
+    if (e.target) e.target.value = "";
+  };
+
+  const startRecording = async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const mr = new MediaRecorder(stream);
+      chunksRef.current = [];
+      mr.ondataavailable = (e) => {
+        if (e.data.size > 0) chunksRef.current.push(e.data);
+      };
+      mr.onstop = () => {
+        const blob = new Blob(chunksRef.current, { type: "audio/webm" });
+        uploadSample(blob);
+        stream.getTracks().forEach((t) => t.stop());
+      };
+      mr.start();
+      mediaRef.current = mr;
+      setRecording(true);
+    } catch (err) {
+      toast({ title: "Mic access denied", description: String(err), variant: "destructive" as const });
+    }
+  };
+
+  const stopRecording = () => {
+    mediaRef.current?.stop();
+    setRecording(false);
   };
 
   return (
     <div className="glass-panel rounded-xl p-4">
       <p className="text-sm mb-2">
         {voiceId
-          ? "Custom voice configured. Upload again to replace."
-          : "Upload a short voice sample to clone your voice."}
+          ? "Custom voice configured. Upload or record again to replace."
+          : "Record or upload a short sample to clone your voice."}
       </p>
-      <input
-        type="file"
-        accept="audio/*"
-        onChange={onFileChange}
-        disabled={uploading}
-        className="mb-2"
-      />
+      <div className="flex items-center gap-2 mb-2">
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={recording ? stopRecording : startRecording}
+          disabled={uploading}
+          className="gap-2"
+        >
+          {recording ? <Square className="w-4 h-4" /> : <Mic className="w-4 h-4" />}
+          {recording ? "Stop" : "Record"}
+        </Button>
+        <input
+          type="file"
+          accept="audio/*"
+          onChange={onFileChange}
+          disabled={uploading}
+        />
+      </div>
       {voiceId && (
         <div className="text-xs text-muted-foreground break-all">Voice ID: {voiceId}</div>
       )}

--- a/src/voice/useTextToSpeech.ts
+++ b/src/voice/useTextToSpeech.ts
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useVoiceStore } from "@/state/voice";
+import { playClonedVoice } from "./voiceClone";
 
 export function useTextToSpeech() {
   const [isSpeaking, setIsSpeaking] = useState(false);
@@ -6,6 +8,8 @@ export function useTextToSpeech() {
     return localStorage.getItem("aurora_voice_enabled") === "1";
   });
   const utterRef = useRef<SpeechSynthesisUtterance | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const voiceId = useVoiceStore((s) => s.voiceId);
 
   // Allow enabling via first user gesture (click/keydown) OR explicit call
   useEffect(() => {
@@ -28,8 +32,21 @@ export function useTextToSpeech() {
   }, [enabled]);
 
   const speak = useCallback(
-    (text: string) => {
+    async (text: string) => {
       if (!enabled || !text?.trim()) return; // <- gate prevents NotAllowedError
+      // Try cloned voice via Supabase when a voiceId is configured
+      if (voiceId) {
+        const audio = await playClonedVoice(text, voiceId, {
+          onStart: () => setIsSpeaking(true),
+          onEnd: () => setIsSpeaking(false),
+        });
+        if (audio) {
+          audioRef.current = audio;
+          return;
+        }
+      }
+
+      // Fallback to Web Speech API
       try {
         window.speechSynthesis.cancel();
         const u = new SpeechSynthesisUtterance(text);
@@ -42,10 +59,12 @@ export function useTextToSpeech() {
         setIsSpeaking(false);
       }
     },
-    [enabled],
+    [enabled, voiceId],
   );
 
   const cancel = useCallback(() => {
+    try { audioRef.current?.pause(); } catch { /* ignore */ }
+    audioRef.current = null;
     try {
       window.speechSynthesis.cancel();
     } catch {

--- a/src/voice/voiceClone.ts
+++ b/src/voice/voiceClone.ts
@@ -1,0 +1,31 @@
+import { supabase } from "@/integrations/supabase/client";
+
+/**
+ * Try to synthesize speech using the user's cloned voice via Supabase edge function.
+ * Returns the HTMLAudioElement if playback was started, otherwise null.
+ */
+export async function playClonedVoice(
+  text: string,
+  voiceId: string,
+  callbacks: { onStart?: () => void; onEnd?: () => void } = {},
+): Promise<HTMLAudioElement | null> {
+  try {
+    const { data, error } = await supabase.functions.invoke("tts-generate", {
+      body: { text, voiceId },
+    });
+    if (!error && data?.audioBase64) {
+      const src = `data:${data.contentType};base64,${data.audioBase64}`;
+      const audio = new Audio(src);
+      if (callbacks.onStart) audio.onplay = callbacks.onStart;
+      if (callbacks.onEnd) {
+        audio.onended = callbacks.onEnd;
+        audio.onerror = callbacks.onEnd;
+      }
+      await audio.play();
+      return audio;
+    }
+  } catch (e) {
+    console.error("[voiceClone] tts-generate failed", e);
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- add `playClonedVoice` utility to generate speech with user voice via Supabase
- update `useTextToSpeech` to use cloned voice when available and fall back to Web Speech API
- extend voice setup UI with recording/upload flow to capture a voice sample and store `voiceId`

## Testing
- `npm test`
- `npm run lint` *(fails: various pre-existing lint errors)*
- `npx eslint src/voice/useTextToSpeech.ts src/voice/voiceClone.ts src/components/VoiceSetup.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689a77760d4883269ef42dd848712d31