### PR TITLE
feat: add oauth integrations and data source consent

### DIFF
--- a/src/components/settings/DataSourcesPanel.tsx
+++ b/src/components/settings/DataSourcesPanel.tsx
@@ -1,0 +1,30 @@
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+
+export default function DataSourcesPanel() {
+  const [google, setGoogle] = useLocalStorage('consent.googleCalendar', false);
+  const [evernote, setEvernote] = useLocalStorage('consent.evernote', false);
+  const [notion, setNotion] = useLocalStorage('consent.notion', false);
+
+  return (
+    <div className="space-y-2">
+      <h2 className="text-lg font-semibold">Data Sources</h2>
+      <div className="flex items-center justify-between max-w-sm">
+        <Label htmlFor="consent-google">Google Calendar</Label>
+        <Switch id="consent-google" checked={google} onCheckedChange={setGoogle} />
+      </div>
+      <div className="flex items-center justify-between max-w-sm">
+        <Label htmlFor="consent-evernote">Evernote</Label>
+        <Switch id="consent-evernote" checked={evernote} onCheckedChange={setEvernote} />
+      </div>
+      <div className="flex items-center justify-between max-w-sm">
+        <Label htmlFor="consent-notion">Notion</Label>
+        <Switch id="consent-notion" checked={notion} onCheckedChange={setNotion} />
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Toggle access for each integration. Only enabled sources will sync into your memory.
+      </p>
+    </div>
+  );
+}

--- a/src/integrations/google/calendar.ts
+++ b/src/integrations/google/calendar.ts
@@ -1,0 +1,31 @@
+import { authorize, extractTokenFromHash, getToken, storeToken, OAuthConfig } from '../oauth';
+
+const config: OAuthConfig = {
+  authEndpoint: 'https://accounts.google.com/o/oauth2/v2/auth',
+  clientId: import.meta.env.VITE_GOOGLE_CLIENT_ID || '',
+  redirectUri: import.meta.env.VITE_GOOGLE_REDIRECT || window.location.origin,
+  scope: 'https://www.googleapis.com/auth/calendar.readonly',
+};
+
+export function beginGoogleCalendarOAuth() {
+  authorize(config);
+}
+
+export function handleGoogleCalendarRedirect() {
+  const token = extractTokenFromHash();
+  if (token) {
+    storeToken('googleCalendar', token);
+  }
+  return token;
+}
+
+export async function fetchGoogleCalendarEvents() {
+  const token = getToken('googleCalendar');
+  if (!token) throw new Error('No Google Calendar token');
+  const res = await fetch('https://www.googleapis.com/calendar/v3/calendars/primary/events', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error('Failed to fetch events');
+  const data = await res.json();
+  return data.items || [];
+}

--- a/src/integrations/notes.ts
+++ b/src/integrations/notes.ts
@@ -1,0 +1,67 @@
+import { authorize, extractTokenFromHash, getToken, storeToken, OAuthConfig } from './oauth';
+
+const evernoteConfig: OAuthConfig = {
+  authEndpoint: 'https://www.evernote.com/oauth',
+  clientId: import.meta.env.VITE_EVERNOTE_CLIENT_ID || '',
+  redirectUri: import.meta.env.VITE_EVERNOTE_REDIRECT || window.location.origin,
+  scope: 'basic',
+};
+
+const notionConfig: OAuthConfig = {
+  authEndpoint: 'https://api.notion.com/v1/oauth/authorize',
+  clientId: import.meta.env.VITE_NOTION_CLIENT_ID || '',
+  redirectUri: import.meta.env.VITE_NOTION_REDIRECT || window.location.origin,
+  scope: 'read',
+};
+
+export function beginEvernoteOAuth() {
+  authorize(evernoteConfig);
+}
+
+export function handleEvernoteRedirect() {
+  const token = extractTokenFromHash();
+  if (token) {
+    storeToken('evernote', token);
+  }
+  return token;
+}
+
+export async function fetchEvernoteNotes() {
+  const token = getToken('evernote');
+  if (!token) throw new Error('No Evernote token');
+  const res = await fetch('https://api.evernote.com/v1/notes', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error('Failed to fetch notes');
+  const data = await res.json();
+  return data.notes || [];
+}
+
+export function beginNotionOAuth() {
+  authorize(notionConfig);
+}
+
+export function handleNotionRedirect() {
+  const token = extractTokenFromHash();
+  if (token) {
+    storeToken('notion', token);
+  }
+  return token;
+}
+
+export async function fetchNotionNotes() {
+  const token = getToken('notion');
+  if (!token) throw new Error('No Notion token');
+  const res = await fetch('https://api.notion.com/v1/search', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Notion-Version': '2022-06-28',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ filter: { property: 'object', value: 'page' } }),
+  });
+  if (!res.ok) throw new Error('Failed to fetch notes');
+  const data = await res.json();
+  return data.results || [];
+}

--- a/src/integrations/oauth.ts
+++ b/src/integrations/oauth.ts
@@ -1,0 +1,35 @@
+export interface OAuthConfig {
+  authEndpoint: string;
+  clientId: string;
+  redirectUri: string;
+  scope: string;
+}
+
+export function authorize(config: OAuthConfig) {
+  const params = new URLSearchParams({
+    client_id: config.clientId,
+    redirect_uri: config.redirectUri,
+    response_type: 'token',
+    scope: config.scope,
+  });
+  window.location.href = `${config.authEndpoint}?${params.toString()}`;
+}
+
+export function extractTokenFromHash(hash: string = window.location.hash) {
+  const match = hash.match(/access_token=([^&]+)/);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+export function storeToken(source: string, token: string) {
+  try {
+    localStorage.setItem(`oauth.${source}`, token);
+  } catch {}
+}
+
+export function getToken(source: string) {
+  try {
+    return localStorage.getItem(`oauth.${source}`);
+  } catch {
+    return null;
+  }
+}

--- a/src/integrations/sync.ts
+++ b/src/integrations/sync.ts
@@ -1,0 +1,40 @@
+import { memoryStore } from '@/memory/indexedDbMemory';
+import { getConsent } from '@/lib/consent';
+import { fetchGoogleCalendarEvents } from './google/calendar';
+import { fetchEvernoteNotes, fetchNotionNotes } from './notes';
+
+export async function syncGoogleCalendar() {
+  if (!getConsent('googleCalendar')) return;
+  const events = await fetchGoogleCalendarEvents();
+  for (const ev of events) {
+    const summary = ev.summary || 'Untitled event';
+    const start = ev.start?.dateTime || ev.start?.date || '';
+    const content = `Event: ${summary} @ ${start}`;
+    await memoryStore.add('episodic', 'user', content, {
+      tags: ['calendar', 'google'],
+    });
+  }
+}
+
+export async function syncEvernote() {
+  if (!getConsent('evernote')) return;
+  const notes = await fetchEvernoteNotes();
+  for (const n of notes) {
+    const content = `${n.title ?? 'Untitled'}\n${n.content ?? ''}`;
+    await memoryStore.add('semantic', 'user', content, {
+      tags: ['note', 'evernote'],
+    });
+  }
+}
+
+export async function syncNotion() {
+  if (!getConsent('notion')) return;
+  const pages = await fetchNotionNotes();
+  for (const p of pages) {
+    const title =
+      p.properties?.title?.title?.map((t: any) => t.plain_text).join('') || 'Untitled';
+    await memoryStore.add('semantic', 'user', title, {
+      tags: ['note', 'notion'],
+    });
+  }
+}

--- a/src/lib/consent.ts
+++ b/src/lib/consent.ts
@@ -1,0 +1,17 @@
+export type DataSource = 'googleCalendar' | 'evernote' | 'notion';
+
+const PREFIX = 'consent.';
+
+export function getConsent(source: DataSource): boolean {
+  try {
+    return JSON.parse(localStorage.getItem(PREFIX + source) || 'false') as boolean;
+  } catch {
+    return false;
+  }
+}
+
+export function setConsent(source: DataSource, value: boolean) {
+  try {
+    localStorage.setItem(PREFIX + source, JSON.stringify(value));
+  } catch {}
+}

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import TriggersPanel from "@/components/settings/TriggersPanel";
 import ModelPanel from "@/components/settings/ModelPanel";
+import DataSourcesPanel from "@/components/settings/DataSourcesPanel";
 
 
 export default function SettingsView() {
@@ -85,6 +86,7 @@ export default function SettingsView() {
               <Button variant="softPrimary" onClick={signOut}>Log out</Button>
             </div>
             </div>
+            <DataSourcesPanel />
             <TriggersPanel />
             <ModelPanel />
           </div>


### PR DESCRIPTION
## Summary
- add generic oauth helpers and integrations for Google Calendar, Evernote, and Notion
- parse synced calendar events and notes into the memory store with tags
- expose per-source consent switches in settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a78dfa6088326b386cdfefd5f3b13