### PR TITLE
Add local LoRA fine-tuning with confidence-based model routing

### DIFF
--- a/scripts/fine_tune_lora.py
+++ b/scripts/fine_tune_lora.py
@@ -1,0 +1,52 @@
+import json
+import sys
+from datasets import Dataset
+from transformers import AutoTokenizer, AutoModelForCausalLM, TrainingArguments, Trainer
+from peft import LoraConfig, get_peft_model, prepare_model_for_int8_training
+
+
+def main(data_path: str, out_dir: str):
+    with open(data_path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    texts = data.get('transcripts', []) + data.get('personaNotes', [])
+    if not texts:
+        print('No training data provided', file=sys.stderr)
+        return
+
+    dataset = Dataset.from_dict({'text': texts})
+
+    model_name = 'meta-llama/Llama-3.1-8B-Instruct'
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForCausalLM.from_pretrained(model_name, load_in_8bit=True)
+
+    model = prepare_model_for_int8_training(model)
+    config = LoraConfig(r=8, lora_alpha=16, target_modules=['q_proj', 'v_proj'], lora_dropout=0.05,
+                        bias='none', task_type='CAUSAL_LM')
+    model = get_peft_model(model, config)
+
+    def tokenize(batch):
+        return tokenizer(batch['text'], truncation=True, padding='max_length', max_length=256)
+
+    tokenized = dataset.map(tokenize, batched=True, remove_columns=['text'])
+
+    args = TrainingArguments(
+        output_dir=out_dir,
+        per_device_train_batch_size=1,
+        num_train_epochs=1,
+        logging_steps=10,
+        save_strategy='epoch',
+    )
+
+    trainer = Trainer(model=model, args=args, train_dataset=tokenized)
+    trainer.train()
+
+    model.save_pretrained(out_dir)
+    tokenizer.save_pretrained(out_dir)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 3:
+        print('Usage: fine_tune_lora.py <data.json> <output_dir>')
+        sys.exit(1)
+    main(sys.argv[1], sys.argv[2])

--- a/src/agent/AuroraAgent.ts
+++ b/src/agent/AuroraAgent.ts
@@ -59,6 +59,8 @@ export class AuroraAgent {
       .map((m) => `${m.role}: ${m.content}`)
       .join('\n');
 
+    const confidence = memories.length > 2 ? 0.9 : 0.5;
+
     const userSummary = this.history
       .filter((m) => m.role === 'user')
       .map((m) => m.content)
@@ -81,7 +83,7 @@ export class AuroraAgent {
           },
           ...this.history,
         ];
-        const { content } = await auroraChat(messages);
+        const { content } = await auroraChat(messages, { confidence });
         this.say(content);
       } catch (e) {
         console.error('aurora-chat failed', e);
@@ -125,7 +127,7 @@ export class AuroraAgent {
           : []),
         ...this.history,
       ];
-      const { content } = await auroraChat(messages);
+      const { content } = await auroraChat(messages, { confidence });
       this.say(content);
     } catch (e) {
       console.error('aurora-chat failed', e);

--- a/src/agent/fineTune.ts
+++ b/src/agent/fineTune.ts
@@ -1,0 +1,66 @@
+import { memoryStore } from '@/memory/indexedDbMemory';
+import { loadProfile } from '@/data/profile';
+import type { MemoryEntry } from '@/memory/indexedDbMemory';
+
+export interface TrainingData {
+  transcripts: string[];
+  personaNotes: string[];
+}
+
+function isApproved(entry: MemoryEntry): boolean {
+  return entry.tags?.includes('approved') ?? false;
+}
+
+export function gatherApprovedTranscripts(): string[] {
+  return memoryStore
+    .list('episodic')
+    .filter((m) => m.role === 'user' && isApproved(m))
+    .map((m) => m.content);
+}
+
+export function gatherPersonaNotes(): string[] {
+  const profile = loadProfile();
+  if (!profile) return [];
+  const fields: (keyof typeof profile)[] = [
+    'goals',
+    'values',
+    'skills',
+    'habits',
+    'challenges',
+    'tones',
+    'quirks',
+  ];
+  const notes: string[] = [];
+  for (const f of fields) {
+    const v = profile[f];
+    if (typeof v === 'string' && v.trim()) notes.push(v);
+  }
+  return notes;
+}
+
+export function gatherTrainingData(): TrainingData {
+  return {
+    transcripts: gatherApprovedTranscripts(),
+    personaNotes: gatherPersonaNotes(),
+  };
+}
+
+export async function fineTuneLocalLoRA(outputDir = 'local-model') {
+  const data = gatherTrainingData();
+  const fs = await import('fs/promises');
+  const path = await import('path');
+  await fs.mkdir(outputDir, { recursive: true });
+  const datasetPath = path.join(outputDir, 'training_data.json');
+  await fs.writeFile(datasetPath, JSON.stringify(data, null, 2));
+
+  const { spawn } = await import('child_process');
+  await new Promise<void>((resolve, reject) => {
+    const proc = spawn('python', ['scripts/fine_tune_lora.py', datasetPath, outputDir], {
+      stdio: 'inherit',
+    });
+    proc.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`fine-tune failed: ${code}`));
+    });
+  });
+}

--- a/src/agent/localModel.ts
+++ b/src/agent/localModel.ts
@@ -1,6 +1,10 @@
 import type { ChatMessage, ChatOptions } from '@/types/chat';
 
-let engine: any;
+let baseEngine: any;
+let tunedEngine: any;
+
+const BASE_MODEL = 'Llama-3.1-8B-Instruct-q4f32_1-MLC';
+const TUNED_MODEL = 'Llama-3.1-8B-Instruct-q4f32_1-MLC-Aurora';
 
 export async function localChat(
   messages: ChatMessage[],
@@ -10,10 +14,30 @@ export async function localChat(
     throw new Error('Local model not available');
   }
 
+  const threshold = options.tunedThreshold ?? 0.8;
+  const confidence = options.confidence ?? 0;
+  let engine;
+
+  if (confidence >= threshold) {
+    if (!tunedEngine) {
+      try {
+        const { CreateMLCEngine } = await import('@mlc-ai/web-llm');
+        const model = options.model || TUNED_MODEL;
+        tunedEngine = await CreateMLCEngine(model);
+      } catch (e) {
+        console.warn('Tuned model unavailable, using base model', e);
+      }
+    }
+    engine = tunedEngine;
+  }
+
   if (!engine) {
-    const { CreateMLCEngine } = await import('@mlc-ai/web-llm');
-    const model = options.model || 'Llama-3.1-8B-Instruct-q4f32_1-MLC';
-    engine = await CreateMLCEngine(model);
+    if (!baseEngine) {
+      const { CreateMLCEngine } = await import('@mlc-ai/web-llm');
+      const model = BASE_MODEL;
+      baseEngine = await CreateMLCEngine(model);
+    }
+    engine = baseEngine;
   }
 
   const resp = await engine.chat.completions.create({ messages });

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -6,4 +6,11 @@ export type ChatMessage = {
 export interface ChatOptions {
   model?: string;
   depth?: number;
+  /**
+   * Confidence score for the current request (0-1). When this exceeds
+   * `tunedThreshold`, the router will prefer the fine-tuned local model.
+   */
+  confidence?: number;
+  /** Threshold above which the tuned model will be used. Default 0.8 */
+  tunedThreshold?: number;
 }


### PR DESCRIPTION
## Summary
- collect user-approved transcripts and persona notes for training
- add script to fine-tune a local LLaMA model with LoRA
- route chat to tuned model when confidence exceeds threshold

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a7be13248832681f49d28c4571544