### PR TITLE
feat: add voice emotion and tuning controls

### DIFF
--- a/src/components/VoiceSetup.tsx
+++ b/src/components/VoiceSetup.tsx
@@ -2,10 +2,20 @@ import { useRef, useState } from "react";
 import { toast } from "@/hooks/use-toast";
 import { useVoiceStore } from "@/state/voice";
 import { Button } from "@/components/ui/button";
+import { Slider } from "@/components/ui/slider";
 import { Mic, Square } from "lucide-react";
 
 export default function VoiceSetup() {
-  const { voiceId, setVoiceId } = useVoiceStore();
+  const {
+    voiceId,
+    setVoiceId,
+    speed,
+    setSpeed,
+    pitch,
+    setPitch,
+    expression,
+    setExpression,
+  } = useVoiceStore();
   const [uploading, setUploading] = useState(false);
   const [recording, setRecording] = useState(false);
   const mediaRef = useRef<MediaRecorder | null>(null);
@@ -107,6 +117,48 @@ export default function VoiceSetup() {
       {voiceId && (
         <div className="text-xs text-muted-foreground break-all">Voice ID: {voiceId}</div>
       )}
+
+      <div className="mt-4 space-y-4">
+        <div>
+          <div className="flex justify-between text-xs mb-1">
+            <span>Speed</span>
+            <span>{speed.toFixed(2)}</span>
+          </div>
+          <Slider
+            min={0.5}
+            max={2}
+            step={0.1}
+            value={[speed]}
+            onValueChange={(v) => setSpeed(v[0])}
+          />
+        </div>
+        <div>
+          <div className="flex justify-between text-xs mb-1">
+            <span>Pitch</span>
+            <span>{pitch.toFixed(2)}</span>
+          </div>
+          <Slider
+            min={0.5}
+            max={2}
+            step={0.1}
+            value={[pitch]}
+            onValueChange={(v) => setPitch(v[0])}
+          />
+        </div>
+        <div>
+          <div className="flex justify-between text-xs mb-1">
+            <span>Expression</span>
+            <span>{expression.toFixed(2)}</span>
+          </div>
+          <Slider
+            min={0}
+            max={2}
+            step={0.1}
+            value={[expression]}
+            onValueChange={(v) => setExpression(v[0])}
+          />
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/state/voice.ts
+++ b/src/state/voice.ts
@@ -1,12 +1,24 @@
 import { create } from "zustand";
 
 const VOICE_ID_KEY = "aurora.voiceId";
+const VOICE_SPEED_KEY = "aurora.voiceSpeed";
+const VOICE_PITCH_KEY = "aurora.voicePitch";
+const VOICE_EXPR_KEY = "aurora.voiceExpression";
+const VOICE_EMOTION_KEY = "aurora.voiceEmotion";
 
 type VoiceState = {
   isSpeaking: boolean;
   voiceId: string | null;
+  speed: number;
+  pitch: number;
+  expression: number;
+  emotion: string;
   setSpeaking: (v: boolean) => void;
   setVoiceId: (id: string | null) => void;
+  setSpeed: (v: number) => void;
+  setPitch: (v: number) => void;
+  setExpression: (v: number) => void;
+  setEmotion: (v: string) => void;
 };
 
 export const useVoiceStore = create<VoiceState>((set) => ({
@@ -15,6 +27,22 @@ export const useVoiceStore = create<VoiceState>((set) => ({
     typeof window !== "undefined"
       ? window.localStorage.getItem(VOICE_ID_KEY)
       : null,
+  speed:
+    typeof window !== "undefined"
+      ? Number(window.localStorage.getItem(VOICE_SPEED_KEY) || 1)
+      : 1,
+  pitch:
+    typeof window !== "undefined"
+      ? Number(window.localStorage.getItem(VOICE_PITCH_KEY) || 1)
+      : 1,
+  expression:
+    typeof window !== "undefined"
+      ? Number(window.localStorage.getItem(VOICE_EXPR_KEY) || 1)
+      : 1,
+  emotion:
+    typeof window !== "undefined"
+      ? window.localStorage.getItem(VOICE_EMOTION_KEY) || "neutral"
+      : "neutral",
   setSpeaking: (v) => set({ isSpeaking: v }),
   setVoiceId: (id) => {
     try {
@@ -24,5 +52,37 @@ export const useVoiceStore = create<VoiceState>((set) => ({
       /* ignore storage errors */
     }
     set({ voiceId: id });
+  },
+  setSpeed: (speed) => {
+    try {
+      window.localStorage.setItem(VOICE_SPEED_KEY, String(speed));
+    } catch {
+      /* ignore */
+    }
+    set({ speed });
+  },
+  setPitch: (pitch) => {
+    try {
+      window.localStorage.setItem(VOICE_PITCH_KEY, String(pitch));
+    } catch {
+      /* ignore */
+    }
+    set({ pitch });
+  },
+  setExpression: (expression) => {
+    try {
+      window.localStorage.setItem(VOICE_EXPR_KEY, String(expression));
+    } catch {
+      /* ignore */
+    }
+    set({ expression });
+  },
+  setEmotion: (emotion) => {
+    try {
+      window.localStorage.setItem(VOICE_EMOTION_KEY, emotion);
+    } catch {
+      /* ignore */
+    }
+    set({ emotion });
   },
 }));

--- a/src/voice/useTextToSpeech.ts
+++ b/src/voice/useTextToSpeech.ts
@@ -9,7 +9,13 @@ export function useTextToSpeech() {
   });
   const utterRef = useRef<SpeechSynthesisUtterance | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
-  const voiceId = useVoiceStore((s) => s.voiceId);
+  const { voiceId, speed, pitch, expression, emotion } = useVoiceStore((s) => ({
+    voiceId: s.voiceId,
+    speed: s.speed,
+    pitch: s.pitch,
+    expression: s.expression,
+    emotion: s.emotion,
+  }));
 
   // Allow enabling via first user gesture (click/keydown) OR explicit call
   useEffect(() => {
@@ -37,6 +43,10 @@ export function useTextToSpeech() {
       // Try cloned voice via Supabase when a voiceId is configured
       if (voiceId) {
         const audio = await playClonedVoice(text, voiceId, {
+          emotion,
+          speed,
+          pitch,
+          expression,
           onStart: () => setIsSpeaking(true),
           onEnd: () => setIsSpeaking(false),
         });
@@ -51,6 +61,8 @@ export function useTextToSpeech() {
         window.speechSynthesis.cancel();
         const u = new SpeechSynthesisUtterance(text);
         utterRef.current = u;
+        u.rate = speed;
+        u.pitch = pitch;
         u.onstart = () => setIsSpeaking(true);
         u.onend = () => setIsSpeaking(false);
         u.onerror = () => setIsSpeaking(false);
@@ -59,7 +71,7 @@ export function useTextToSpeech() {
         setIsSpeaking(false);
       }
     },
-    [enabled, voiceId],
+    [enabled, voiceId, speed, pitch, expression, emotion],
   );
 
   const cancel = useCallback(() => {

--- a/src/voice/voiceClone.ts
+++ b/src/voice/voiceClone.ts
@@ -1,25 +1,91 @@
 import { supabase } from "@/integrations/supabase/client";
 
+async function cacheVoiceModel(voiceId: string) {
+  if (typeof window === "undefined") return;
+  const key = `aurora_voice_model_${voiceId}`;
+  if (localStorage.getItem(key)) return;
+  try {
+    const { data } = await supabase.storage
+      .from("voice-models")
+      .download(`${voiceId}.bin`);
+    if (data) {
+      const base64 = await blobToBase64(data);
+      localStorage.setItem(key, base64);
+    }
+  } catch {
+    /* ignore caching errors */
+  }
+}
+
+function blobToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      const res = reader.result?.toString() || "";
+      resolve(res.split(",")[1] || "");
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+}
+
 /**
  * Try to synthesize speech using the user's cloned voice via Supabase edge function.
+ * Supports emotion, speed, pitch and expression parameters. Audio is cached for
+ * offline reuse and the voice model is cached locally the first time it is used.
  * Returns the HTMLAudioElement if playback was started, otherwise null.
  */
 export async function playClonedVoice(
   text: string,
   voiceId: string,
-  callbacks: { onStart?: () => void; onEnd?: () => void } = {},
+  options: {
+    emotion?: string;
+    speed?: number;
+    pitch?: number;
+    expression?: number;
+    onStart?: () => void;
+    onEnd?: () => void;
+  } = {},
 ): Promise<HTMLAudioElement | null> {
+  const { emotion, speed, pitch, expression, onStart, onEnd } = options;
+
+  const cacheKey = `aurora_voice_cache:${voiceId}:${emotion || "neutral"}:${
+    speed ?? 1
+  }:${pitch ?? 1}:${expression ?? 1}:${text}`;
+
   try {
+    await cacheVoiceModel(voiceId);
+
+    const cachedSrc =
+      typeof window !== "undefined" ? localStorage.getItem(cacheKey) : null;
+    if (cachedSrc) {
+      const audio = new Audio(cachedSrc);
+      if (onStart) audio.onplay = onStart;
+      if (onEnd) {
+        audio.onended = onEnd;
+        audio.onerror = onEnd;
+      }
+      await audio.play();
+      return audio;
+    }
+
     const { data, error } = await supabase.functions.invoke("tts-generate", {
-      body: { text, voiceId },
+      body: { text, voiceId, emotion, speed, pitch, expression },
     });
     if (!error && data?.audioBase64) {
       const src = `data:${data.contentType};base64,${data.audioBase64}`;
+      if (typeof window !== "undefined") {
+        try {
+          localStorage.setItem(cacheKey, src);
+        } catch {
+          /* ignore */
+        }
+      }
       const audio = new Audio(src);
-      if (callbacks.onStart) audio.onplay = callbacks.onStart;
-      if (callbacks.onEnd) {
-        audio.onended = callbacks.onEnd;
-        audio.onerror = callbacks.onEnd;
+      if (onStart) audio.onplay = onStart;
+      if (onEnd) {
+        audio.onended = onEnd;
+        audio.onerror = onEnd;
       }
       await audio.play();
       return audio;

--- a/src/voice/voiceio.ts
+++ b/src/voice/voiceio.ts
@@ -60,11 +60,12 @@ export class VoiceIO {
   }
 
   async speak(text: string) {
-    const voiceId = useVoiceStore.getState().voiceId;
+    const { voiceId, speed, pitch, expression, emotion } =
+      useVoiceStore.getState();
     if (voiceId) {
       try {
         const { data, error } = await supabase.functions.invoke("tts-generate", {
-          body: { text, voiceId },
+          body: { text, voiceId, emotion, speed, pitch, expression },
         });
         if (!error && data?.audioBase64) {
           const src = `data:${data.contentType};base64,${data.audioBase64}`;
@@ -93,6 +94,8 @@ export class VoiceIO {
 
     if (!('speechSynthesis' in window)) return;
     const u = new SpeechSynthesisUtterance(text);
+    u.rate = speed;
+    u.pitch = pitch;
     u.onstart = () => {
       useVoiceStore.getState().setSpeaking(true);
       this.callbacks.onSpeakingChange?.(true);


### PR DESCRIPTION
## Summary
- expand `playClonedVoice` with emotion, speed, pitch and expression options
- cache voice model and generated audio locally for offline reuse
- add UI sliders for speed, pitch and expression in voice setup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a7be43bd88326a8b8dce1d2bc9f3a