### PR TITLE
feat: add lip-synced 3D avatar

### DIFF
--- a/src/components/avatar/LipSyncAvatar.tsx
+++ b/src/components/avatar/LipSyncAvatar.tsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useRef } from "react";
+import * as THREE from "three";
+import { useAvatarStore } from "@/state/avatar";
+import { useVoiceStore } from "@/state/voice";
+
+type Props = {
+  size?: number;
+};
+
+export function LipSyncAvatar({ size = 96 }: Props) {
+  const { enabled, color, audio } = useAvatarStore();
+  const emotion = useVoiceStore((s) => s.emotion);
+
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const mouthRef = useRef<THREE.Mesh | null>(null);
+  const matRef = useRef<THREE.MeshStandardMaterial | null>(null);
+
+  // Setup three.js scene
+  useEffect(() => {
+    if (!canvasRef.current) return;
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(45, 1, 0.1, 100);
+    camera.position.z = 2;
+    const renderer = new THREE.WebGLRenderer({ canvas: canvasRef.current, alpha: true, antialias: true });
+    renderer.setSize(size, size);
+
+    const headMat = new THREE.MeshStandardMaterial({ color });
+    matRef.current = headMat;
+    const head = new THREE.Mesh(new THREE.SphereGeometry(1, 32, 32), headMat);
+    scene.add(head);
+
+    const mouth = new THREE.Mesh(new THREE.BoxGeometry(0.6, 0.2, 0.1), new THREE.MeshStandardMaterial({ color: 0x000000 }));
+    mouth.position.y = -0.3;
+    head.add(mouth);
+    mouthRef.current = mouth;
+
+    const dir = new THREE.DirectionalLight(0xffffff, 1);
+    dir.position.set(0, 1, 2);
+    scene.add(dir);
+    scene.add(new THREE.AmbientLight(0xffffff, 0.6));
+
+    let frame: number;
+    const data = new Uint8Array(1024);
+    const animate = () => {
+      frame = requestAnimationFrame(animate);
+      const analyser = analyserRef.current;
+      if (analyser && mouthRef.current) {
+        analyser.getByteTimeDomainData(data);
+        let sum = 0;
+        for (let i = 0; i < data.length; i++) {
+          sum += Math.abs(data[i] - 128);
+        }
+        const level = sum / data.length / 128; // 0..1
+        mouthRef.current.scale.y = 1 + level * 2;
+      }
+      renderer.render(scene, camera);
+    };
+    animate();
+    return () => {
+      cancelAnimationFrame(frame);
+      renderer.dispose();
+    };
+  }, [color, size]);
+
+  // Attach audio analyser when audio changes
+  useEffect(() => {
+    if (!audio) {
+      analyserRef.current = null;
+      return;
+    }
+    const ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+    const source = ctx.createMediaElementSource(audio);
+    const analyser = ctx.createAnalyser();
+    analyser.fftSize = 2048;
+    source.connect(analyser);
+    analyser.connect(ctx.destination);
+    analyserRef.current = analyser;
+    return () => {
+      try { source.disconnect(); } catch {}
+      try { analyser.disconnect(); } catch {}
+      analyserRef.current = null;
+    };
+  }, [audio]);
+
+  // Update material color based on emotion
+  useEffect(() => {
+    if (!matRef.current) return;
+    const map: Record<string, string> = {
+      happy: "#ffe066",
+      sad: "#4d9bef",
+      angry: "#ff6b6b",
+    };
+    matRef.current.color.set(map[emotion] || color);
+  }, [emotion, color]);
+
+  if (!enabled) return null;
+  return <canvas ref={canvasRef} style={{ width: size, height: size }} />;
+}
+

--- a/src/components/game/GameHUD.tsx
+++ b/src/components/game/GameHUD.tsx
@@ -2,10 +2,10 @@ import React, { useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import { useGameStore } from "@/game/store";
 import { quickSlots } from "@/game/hud/hud.data";
-import { EvolvingSphere } from "@/components/effects/EvolvingSphere";
+import { LipSyncAvatar } from "@/components/avatar/LipSyncAvatar";
 import { Mic, ChevronDown, ChevronUp } from "lucide-react";
 import { useHUDActions } from "@/game/hud/useHUDActions";
-import { useVoiceStore } from "@/state/voice";
+import { useAvatarStore } from "@/state/avatar";
 
 function fire(type: string, payload?: any) {
   window.dispatchEvent(new CustomEvent('mos', { detail: { type, payload } }));
@@ -14,7 +14,7 @@ function fire(type: string, payload?: any) {
 export function GameHUD() {
   const stats = useGameStore((s) => s.stats);
   const { run } = useHUDActions();
-  const isSpeaking = useVoiceStore((s) => s.isSpeaking);
+  const avatarEnabled = useAvatarStore((s) => s.enabled);
 
   // Mobile collapse state
   const isMobile = window.innerWidth <= 768;
@@ -58,7 +58,9 @@ export function GameHUD() {
         <div className="flex items-center gap-3 min-w-0 flex-wrap">
           {/* Identity */}
           <div className="flex items-center gap-3 min-w-0 shrink">
-            <EvolvingSphere size={44} level={stats.level} xpPct={stats.xp} mood="focused" speaking={isSpeaking} />
+            {avatarEnabled && (
+              <LipSyncAvatar size={44} />
+            )}
             <div className="min-w-0">
               <div className="text-[13px] opacity-90 truncate">
                 Lv. {stats.level} • Streak {stats.streak}

--- a/src/pages/Stack.tsx
+++ b/src/pages/Stack.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo } from "react";
 import AppHeader from "@/components/layout/AppHeader";
 import { Capacitor } from "@capacitor/core";
 import { supabase } from "@/integrations/supabase/client";
+import { useAvatarStore } from "@/state/avatar";
 
 const setMeta = (name: string, content: string) => {
   let el = document.querySelector(`meta[name="${name}"]`) as HTMLMetaElement | null;
@@ -46,6 +47,7 @@ export default function StackPage() {
     !!window.chrome?.runtime?.id;
   const online = typeof navigator !== "undefined" && navigator.onLine;
   const supabaseReady = !!supabase;
+  const { enabled, color, setEnabled, setColor } = useAvatarStore();
 
   useEffect(() => {
     const title = "Aurora OS Tech Stack & Runtime"; // <60 chars
@@ -107,6 +109,30 @@ export default function StackPage() {
                 <dd className="font-medium">{online ? "online" : "offline"}</dd>
               </div>
             </dl>
+          </section>
+
+          <section aria-labelledby="avatar" className="glass-panel rounded-xl p-4 elev">
+            <h2 id="avatar" className="text-lg font-medium mb-3">Avatar</h2>
+            <div className="flex items-center gap-4 text-sm">
+              <label className="flex items-center gap-2">
+                <span>Enable</span>
+                <input
+                  type="checkbox"
+                  checked={enabled}
+                  onChange={(e) => setEnabled(e.target.checked)}
+                />
+              </label>
+              {enabled && (
+                <label className="flex items-center gap-2">
+                  <span>Color</span>
+                  <input
+                    type="color"
+                    value={color}
+                    onChange={(e) => setColor(e.target.value)}
+                  />
+                </label>
+              )}
+            </div>
           </section>
 
           <section aria-labelledby="core" className="glass-panel rounded-xl p-4 elev">

--- a/src/state/avatar.ts
+++ b/src/state/avatar.ts
@@ -1,0 +1,43 @@
+import { create } from "zustand";
+
+const AVATAR_ENABLE_KEY = "aurora.avatar.enabled";
+const AVATAR_COLOR_KEY = "aurora.avatar.color";
+
+type AvatarState = {
+  enabled: boolean;
+  color: string;
+  audio: HTMLAudioElement | null;
+  setEnabled: (v: boolean) => void;
+  setColor: (c: string) => void;
+  setAudio: (a: HTMLAudioElement | null) => void;
+};
+
+export const useAvatarStore = create<AvatarState>((set) => ({
+  enabled:
+    typeof window !== "undefined"
+      ? localStorage.getItem(AVATAR_ENABLE_KEY) !== "false"
+      : true,
+  color:
+    typeof window !== "undefined"
+      ? localStorage.getItem(AVATAR_COLOR_KEY) || "#ffcc99"
+      : "#ffcc99",
+  audio: null,
+  setEnabled: (v) => {
+    try {
+      localStorage.setItem(AVATAR_ENABLE_KEY, String(v));
+    } catch {
+      /* ignore */
+    }
+    set({ enabled: v });
+  },
+  setColor: (color) => {
+    try {
+      localStorage.setItem(AVATAR_COLOR_KEY, color);
+    } catch {
+      /* ignore */
+    }
+    set({ color });
+  },
+  setAudio: (audio) => set({ audio }),
+}));
+

--- a/src/voice/voiceio.ts
+++ b/src/voice/voiceio.ts
@@ -1,5 +1,6 @@
 import { useVoiceStore } from "@/state/voice";
 import { supabase } from "@/integrations/supabase/client";
+import { useAvatarStore } from "@/state/avatar";
 
 export type VoiceCallbacks = {
   onPartial?: (text: string) => void;
@@ -71,6 +72,7 @@ export class VoiceIO {
           const src = `data:${data.contentType};base64,${data.audioBase64}`;
           const audio = new Audio(src);
           this.audio = audio;
+          useAvatarStore.getState().setAudio(audio);
           audio.onplay = () => {
             useVoiceStore.getState().setSpeaking(true);
             this.callbacks.onSpeakingChange?.(true);
@@ -78,6 +80,7 @@ export class VoiceIO {
           const end = () => {
             useVoiceStore.getState().setSpeaking(false);
             this.callbacks.onSpeakingChange?.(false);
+            useAvatarStore.getState().setAudio(null);
           };
           audio.onended = end;
           audio.onerror = (e) => {
@@ -113,6 +116,7 @@ export class VoiceIO {
   stopSpeaking() {
     try { this.audio?.pause(); } catch {}
     this.audio = null;
+    useAvatarStore.getState().setAudio(null);
     try { window.speechSynthesis.cancel(); } catch {}
     useVoiceStore.getState().setSpeaking(false);
     this.callbacks.onSpeakingChange?.(false);


### PR DESCRIPTION
## Summary
- add zustand store for avatar preferences and audio tracking
- render WebGL avatar that lip-syncs to generated audio and reflects emotion
- expose avatar enable and color controls in settings page and use avatar in HUD

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a817c64708326a3b39b1b669eacfe