### PR TITLE
Encrypt memory and add sync and device management

### DIFF
--- a/src/components/settings/DeviceManagerPanel.tsx
+++ b/src/components/settings/DeviceManagerPanel.tsx
@@ -1,0 +1,52 @@
+import { Button } from '@/components/ui/button';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table';
+
+interface Device { id: string; name: string }
+
+export default function DeviceManagerPanel() {
+  const [devices, setDevices] = useLocalStorage<Device[]>(
+    'aurora.trustedDevices',
+    [],
+  );
+
+  const revoke = (id: string) => {
+    setDevices(devices.filter((d) => d.id !== id));
+  };
+
+  return (
+    <div className="space-y-2">
+      <h2 className="text-lg font-semibold">Devices</h2>
+      {devices.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No devices have access.
+        </p>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead className="w-[120px]">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {devices.map((d) => (
+              <TableRow key={d.id}>
+                <TableCell>{d.name}</TableCell>
+                <TableCell>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => revoke(d.id)}
+                  >
+                    Revoke
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+}

--- a/src/data/profile.ts
+++ b/src/data/profile.ts
@@ -67,20 +67,61 @@ export function buildAnswers(responses: ConversationResponse[]) {
 
 const PROFILE_STORAGE_KEY = 'aurora_user_profile_v1';
 
+import { randomBytes, pbkdf2Sync, createCipheriv, createDecipheriv } from 'crypto';
+
+let profileKey: string | null = null;
+
+export function setProfileKey(key: string) {
+  profileKey = key;
+}
+
 export function saveProfile(profile: UserProfile) {
-  if (typeof window === 'undefined') return;
+  if (typeof window === 'undefined' || !profileKey) return;
   try {
-    localStorage.setItem(PROFILE_STORAGE_KEY, JSON.stringify(profile));
+    const salt = randomBytes(16);
+    const iv = randomBytes(12);
+    const key = pbkdf2Sync(profileKey, salt, 100000, 32, 'sha256');
+    const cipher = createCipheriv('aes-256-gcm', key, iv);
+    const data = Buffer.concat([
+      cipher.update(JSON.stringify(profile), 'utf8'),
+      cipher.final(),
+    ]);
+    const tag = cipher.getAuthTag();
+    const payload = {
+      salt: salt.toString('base64'),
+      iv: iv.toString('base64'),
+      tag: tag.toString('base64'),
+      data: data.toString('base64'),
+    };
+    localStorage.setItem(PROFILE_STORAGE_KEY, JSON.stringify(payload));
   } catch {
     // ignore storage errors
   }
 }
 
 export function loadProfile(): UserProfile | null {
-  if (typeof window === 'undefined') return null;
+  if (typeof window === 'undefined' || !profileKey) return null;
   try {
     const raw = localStorage.getItem(PROFILE_STORAGE_KEY);
-    return raw ? (JSON.parse(raw) as UserProfile) : null;
+    if (!raw) return null;
+    const payload = JSON.parse(raw) as {
+      salt: string;
+      iv: string;
+      tag: string;
+      data: string;
+    };
+    const key = pbkdf2Sync(profileKey, Buffer.from(payload.salt, 'base64'), 100000, 32, 'sha256');
+    const decipher = createDecipheriv(
+      'aes-256-gcm',
+      key,
+      Buffer.from(payload.iv, 'base64'),
+    );
+    decipher.setAuthTag(Buffer.from(payload.tag, 'base64'));
+    const decrypted = Buffer.concat([
+      decipher.update(Buffer.from(payload.data, 'base64')),
+      decipher.final(),
+    ]);
+    return JSON.parse(decrypted.toString('utf8')) as UserProfile;
   } catch {
     return null;
   }

--- a/src/memory/indexedDbMemory.ts
+++ b/src/memory/indexedDbMemory.ts
@@ -1,4 +1,10 @@
 import { auroraChat } from '@/utils/auroraChat';
+import {
+  randomBytes,
+  pbkdf2Sync,
+  createCipheriv,
+  createDecipheriv,
+} from 'crypto';
 
 export type MemoryBucket = 'semantic' | 'episodic' | 'procedural';
 
@@ -15,6 +21,45 @@ export interface MemoryEntry {
 }
 
 const STORAGE_KEY = 'aurora-memory-store';
+
+let encryptionKey: string | null = null;
+
+export function setMemoryKey(key: string) {
+  encryptionKey = key;
+}
+
+function encrypt(data: string): string {
+  if (!encryptionKey) return data;
+  const salt = randomBytes(16);
+  const iv = randomBytes(12);
+  const key = pbkdf2Sync(encryptionKey, salt, 100000, 32, 'sha256');
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const ciphertext = Buffer.concat([cipher.update(data, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return JSON.stringify({
+    salt: salt.toString('base64'),
+    iv: iv.toString('base64'),
+    tag: tag.toString('base64'),
+    data: ciphertext.toString('base64'),
+  });
+}
+
+function decrypt(payload: string): string {
+  if (!encryptionKey) return payload;
+  const { salt, iv, tag, data } = JSON.parse(payload);
+  const key = pbkdf2Sync(encryptionKey, Buffer.from(salt, 'base64'), 100000, 32, 'sha256');
+  const decipher = createDecipheriv(
+    'aes-256-gcm',
+    key,
+    Buffer.from(iv, 'base64'),
+  );
+  decipher.setAuthTag(Buffer.from(tag, 'base64'));
+  const decrypted = Buffer.concat([
+    decipher.update(Buffer.from(data, 'base64')),
+    decipher.final(),
+  ]);
+  return decrypted.toString('utf8');
+}
 
 // basic storage wrapper that falls back to in-memory store when localStorage is unavailable
 const memoryStorage: Storage = typeof window !== 'undefined' && window.localStorage
@@ -90,11 +135,11 @@ export class IndexedDbMemory {
   private load(): Record<MemoryBucket, MemoryEntry[]> {
     try {
       const raw = memoryStorage.getItem(STORAGE_KEY);
-      const parsed = raw ? (JSON.parse(raw) as Record<string, MemoryEntry[]>) : {};
+      const data = raw ? JSON.parse(decrypt(raw)) : {};
       return {
-        semantic: parsed.semantic ?? [],
-        episodic: parsed.episodic ?? [],
-        procedural: parsed.procedural ?? [],
+        semantic: data.semantic ?? [],
+        episodic: data.episodic ?? [],
+        procedural: data.procedural ?? [],
       };
     } catch {
       return { semantic: [], episodic: [], procedural: [] };
@@ -103,7 +148,8 @@ export class IndexedDbMemory {
 
   private persist() {
     try {
-      memoryStorage.setItem(STORAGE_KEY, JSON.stringify(this.memories));
+      const data = JSON.stringify(this.memories);
+      memoryStorage.setItem(STORAGE_KEY, encrypt(data));
     } catch {
       // ignore
     }
@@ -113,6 +159,15 @@ export class IndexedDbMemory {
     if (this.memories[bucket].length > limit) {
       this.memories[bucket] = this.memories[bucket].slice(-limit);
     }
+  }
+
+  importAll(data: Record<MemoryBucket, MemoryEntry[]>) {
+    this.memories = {
+      semantic: data.semantic ?? [],
+      episodic: data.episodic ?? [],
+      procedural: data.procedural ?? [],
+    };
+    this.persist();
   }
 
   async add(

--- a/src/memory/sync.test.ts
+++ b/src/memory/sync.test.ts
@@ -1,0 +1,20 @@
+import { resolveConflicts } from './sync';
+import type { MemoryEntry } from './indexedDbMemory';
+
+describe('resolveConflicts', () => {
+  it('prefers newer entries and merges unique ones', () => {
+    const local: MemoryEntry[] = [
+      { id: '1', role: 'user', content: 'old', timestamp: 1, embedding: [] },
+      { id: '2', role: 'user', content: 'local', timestamp: 2, embedding: [] },
+    ];
+    const remote: MemoryEntry[] = [
+      { id: '1', role: 'user', content: 'new', timestamp: 5, embedding: [] },
+      { id: '3', role: 'user', content: 'remote', timestamp: 1, embedding: [] },
+    ];
+    const merged = resolveConflicts(local, remote);
+    const byId = Object.fromEntries(merged.map((m) => [m.id, m]));
+    expect(byId['1'].content).toBe('new');
+    expect(byId['2'].content).toBe('local');
+    expect(byId['3'].content).toBe('remote');
+  });
+});

--- a/src/memory/sync.ts
+++ b/src/memory/sync.ts
@@ -1,0 +1,86 @@
+import type { MemoryBucket, MemoryEntry } from './indexedDbMemory';
+
+export interface SyncAdapter {
+  pull(): Promise<Record<MemoryBucket, MemoryEntry[]>>;
+  push(data: Record<MemoryBucket, MemoryEntry[]>): Promise<void>;
+}
+
+export function resolveConflicts(
+  local: MemoryEntry[],
+  remote: MemoryEntry[],
+): MemoryEntry[] {
+  const map = new Map<string, MemoryEntry>();
+  for (const entry of [...local, ...remote]) {
+    const existing = map.get(entry.id);
+    if (!existing || existing.timestamp < entry.timestamp) {
+      map.set(entry.id, entry);
+    }
+  }
+  return Array.from(map.values());
+}
+
+function merge(
+  local: Record<MemoryBucket, MemoryEntry[]>,
+  remote: Record<MemoryBucket, MemoryEntry[]>,
+): Record<MemoryBucket, MemoryEntry[]> {
+  return {
+    semantic: resolveConflicts(local.semantic || [], remote.semantic || []),
+    episodic: resolveConflicts(local.episodic || [], remote.episodic || []),
+    procedural: resolveConflicts(local.procedural || [], remote.procedural || []),
+  };
+}
+
+export async function syncWithAdapter(adapter: SyncAdapter) {
+  const { memoryStore } = await import('./indexedDbMemory');
+  const remote = await adapter.pull();
+  const local = memoryStore.exportAll();
+  const merged = merge(local, remote);
+  memoryStore.importAll(merged);
+  await adapter.push(merged);
+}
+
+export class CloudSyncAdapter implements SyncAdapter {
+  constructor(private endpoint: string) {}
+
+  async pull() {
+    try {
+      const res = await fetch(this.endpoint);
+      if (!res.ok) throw new Error('failed');
+      return (await res.json()) as Record<MemoryBucket, MemoryEntry[]>;
+    } catch {
+      return { semantic: [], episodic: [], procedural: [] };
+    }
+  }
+
+  async push(data: Record<MemoryBucket, MemoryEntry[]>) {
+    try {
+      await fetch(this.endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+    } catch {
+      // ignore
+    }
+  }
+}
+
+export class PeerSyncAdapter implements SyncAdapter {
+  constructor(private channel: RTCDataChannel) {}
+
+  pull(): Promise<Record<MemoryBucket, MemoryEntry[]>> {
+    return new Promise((resolve) => {
+      const handler = (ev: MessageEvent) => {
+        this.channel.removeEventListener('message', handler);
+        resolve(JSON.parse(ev.data));
+      };
+      this.channel.addEventListener('message', handler);
+      this.channel.send('pull');
+    });
+  }
+
+  async push(data: Record<MemoryBucket, MemoryEntry[]>) {
+    this.channel.send(JSON.stringify(data));
+  }
+}
+

--- a/src/pages/OnboardingFlow.tsx
+++ b/src/pages/OnboardingFlow.tsx
@@ -14,6 +14,7 @@ import {
   ConversationResponse,
   saveProfile,
 } from "@/data/profile";
+import { setEncryptionKey } from "@/state/encryption";
 
 
 type Msg = { role: "assistant" | "user"; content: string };
@@ -105,6 +106,10 @@ export default function OnboardingFlow() {
   const [scopes, setScopes] = useState<string[]>([]);
   const [missionPreview, setMissionPreview] = useState<any>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (user) setEncryptionKey(user.id);
+  }, [user]);
 
   const total = MODULES.reduce((sum, module) => sum + module.questions.length, 0);
 

--- a/src/state/encryption.ts
+++ b/src/state/encryption.ts
@@ -1,0 +1,8 @@
+import { setProfileKey } from '@/data/profile';
+import { setMemoryKey } from '@/memory/indexedDbMemory';
+
+export function setEncryptionKey(key: string) {
+  setProfileKey(key);
+  setMemoryKey(key);
+}
+

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -20,6 +20,7 @@ import DataSourcesPanel from "@/components/settings/DataSourcesPanel";
 import MemoryPanel from "@/components/settings/MemoryPanel";
 import ApiCallLogPanel from "@/components/settings/ApiCallLogPanel";
 import FeatureFlagsPanel from "@/components/settings/FeatureFlagsPanel";
+import DeviceManagerPanel from "@/components/settings/DeviceManagerPanel";
 
 
 export default function SettingsView() {
@@ -93,6 +94,7 @@ export default function SettingsView() {
             <TriggersPanel />
             <ModelPanel />
             <MemoryPanel />
+            <DeviceManagerPanel />
             <ApiCallLogPanel />
             <FeatureFlagsPanel />
           </div>


### PR DESCRIPTION
## Summary
- encrypt memory with user key and load/persist helper
- protect persona profile with same key and initialize on onboarding
- add sync adapters for cloud and P2P with conflict resolution
- include device management panel in settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a8180a2e8832682308d8d1d5954e0