### PR TITLE
feat: persist onboarding profile and use in chat

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -224,6 +224,7 @@ export type Database = {
           onboarded_at: string | null
           role: string
           theme: Json | null
+          persona: Json | null
           updated_at: string
         }
         Insert: {
@@ -233,6 +234,7 @@ export type Database = {
           onboarded_at?: string | null
           role?: string
           theme?: Json | null
+          persona?: Json | null
           updated_at?: string
         }
         Update: {
@@ -242,6 +244,7 @@ export type Database = {
           onboarded_at?: string | null
           role?: string
           theme?: Json | null
+          persona?: Json | null
           updated_at?: string
         }
         Relationships: []

--- a/src/pages/OnboardingFlow.tsx
+++ b/src/pages/OnboardingFlow.tsx
@@ -270,7 +270,14 @@ export default function OnboardingFlow() {
           if (ans) responses.push({ question: q.prompt, answer: ans });
         });
       });
-      saveProfile(buildProfile(responses));
+      const profileData = buildProfile(responses);
+      saveProfile(profileData);
+      if (user) {
+        await supabase
+          .from("profiles")
+          .update({ persona: profileData })
+          .eq("id", user.id);
+      }
 
       if (currentModule === 0) {
         if (questionIndex === 0) setHeadline(userMsg.content);

--- a/src/utils/auroraChat.ts
+++ b/src/utils/auroraChat.ts
@@ -3,6 +3,7 @@ import brain from '@/brain/Brain';
 import { getFilterName } from '@/brain/filters';
 import { routeChat } from '@/agent/router';
 import type { ChatMessage, ChatOptions } from '@/types/chat';
+import { supabase } from '@/integrations/supabase/client';
 
 function buildSystemMessages(profile: UserProfile | null): ChatMessage[] {
   const systemMessages: ChatMessage[] = [
@@ -51,9 +52,17 @@ function buildSystemMessages(profile: UserProfile | null): ChatMessage[] {
 
 let cachedProfile: UserProfile | null | undefined;
 
-function getProfile(): UserProfile | null {
+async function getProfile(): Promise<UserProfile | null> {
   if (cachedProfile !== undefined) return cachedProfile;
-  cachedProfile = loadProfile();
+  try {
+    const { data } = await supabase
+      .from('profiles')
+      .select('persona')
+      .single();
+    cachedProfile = (data?.persona as UserProfile) ?? loadProfile();
+  } catch {
+    cachedProfile = loadProfile();
+  }
   return cachedProfile;
 }
 
@@ -61,7 +70,7 @@ export async function auroraChat(
   messages: ChatMessage[],
   options: ChatOptions = {},
 ): Promise<{ content: string }> {
-  const profile = getProfile();
+  const profile = await getProfile();
   const systemMessages = buildSystemMessages(profile);
   const { content } = await routeChat(
     [...systemMessages, ...messages],

--- a/supabase/functions/aurora-chat/index.ts
+++ b/supabase/functions/aurora-chat/index.ts
@@ -1,5 +1,6 @@
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
 import brain from "../../../src/brain/Brain.ts";
 import { getFilterName } from "../../../src/brain/filters.ts";
@@ -27,7 +28,27 @@ serve(async (req) => {
 
   try {
     const body = await req.json().catch(() => ({}));
-    const { messages, prompt, model, profile } = body ?? {};
+    const { messages, prompt, model } = body ?? {};
+
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const supabaseKey = Deno.env.get("SUPABASE_ANON_KEY");
+    if (!supabaseUrl || !supabaseKey) {
+      throw new Error("Missing Supabase env vars");
+    }
+    const supabase = createClient(supabaseUrl, supabaseKey, {
+      global: { headers: { Authorization: req.headers.get("Authorization") || "" } },
+    });
+
+    const { data: auth } = await supabase.auth.getUser();
+    let profile: UserProfile | null = null;
+    if (auth.user) {
+      const { data } = await supabase
+        .from("profiles")
+        .select("persona")
+        .eq("id", auth.user.id)
+        .single();
+      profile = (data?.persona as UserProfile) ?? null;
+    }
 
     const usedModel = model || "o4-mini-2025-04-16"; // cost-effective default
 
@@ -48,7 +69,7 @@ serve(async (req) => {
       systemMessages.push({ role: "system", content: `Available skills: ${skillPrompt}` });
     }
 
-    const profileSummary = summarizeProfile(profile as UserProfile | null);
+    const profileSummary = summarizeProfile(profile);
     if (profileSummary) {
       systemMessages.unshift({ role: "system", content: `User profile: ${profileSummary}` });
     }

--- a/supabase/migrations/20251201000000_add_persona_to_profiles.sql
+++ b/supabase/migrations/20251201000000_add_persona_to_profiles.sql
@@ -1,0 +1,1 @@
+alter table public.profiles add column if not exists persona jsonb;


### PR DESCRIPTION
## Summary
- persist onboarding answers into `profiles.persona` and local store
- fetch and cache user persona on the client for chat
- load persona in aurora-chat function to prepend system context

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, Empty block statement, A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689a8b2430848326ac2780fa4eb936b3