### PR TITLE
Add update engine and master plan tests

### DIFF
--- a/src/brain/__tests__/updateEngine.test.ts
+++ b/src/brain/__tests__/updateEngine.test.ts
@@ -37,6 +37,23 @@ describe('diffUserProfile', () => {
   });
 });
 
+describe('generateGoalStructure', () => {
+  it('creates full goal entries when new goals are added', () => {
+    const oldProfile: UserProfile = { goals: '', habits: '', history: [] };
+    const newProfile: UserProfile = { goals: 'Write a novel', habits: '', history: [] };
+
+    const initialPlan: MasterPlan = { goals: [], habits: [], plan_versions: [] };
+    const updated = updatePlan(oldProfile, newProfile, initialPlan);
+
+    const goal = updated.goals[0];
+    expect(goal.name).toBe('Write a novel');
+    expect(goal.milestones.annual).toEqual(['Write a novel annual milestone']);
+    expect(goal.milestones.quarterly).toEqual(['Write a novel quarterly milestone']);
+    expect(goal.tasks.daily[0].title).toBe('Daily progress for Write a novel');
+    expect(goal.tasks.weekly[0].title).toBe('Weekly review of Write a novel');
+  });
+});
+
 describe('updatePlan', () => {
   it('applies profile diff and records version history', () => {
     const oldProfile: UserProfile = {


### PR DESCRIPTION
## Summary
- test diffUserProfile handles added and removed goals and habits
- test goal generation and plan versioning in updatePlan
- test habit streak calculations and trigger attachment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a8cee865c8326a95d1987a9634eb6