### PR TITLE
feat: add local model routing and preferences

### DIFF
--- a/src/agent/localModel.ts
+++ b/src/agent/localModel.ts
@@ -44,3 +44,8 @@ export async function localChat(
   const content = resp?.choices?.[0]?.message?.content ?? '';
   return { content };
 }
+
+export function resetLocalEngines() {
+  baseEngine = undefined;
+  tunedEngine = undefined;
+}

--- a/src/agent/router.ts
+++ b/src/agent/router.ts
@@ -44,17 +44,24 @@ export async function routeChat(
 ): Promise<{ content: string }> {
   const tokens = estimateTokens(messages);
   const depth = options.depth ?? 1;
-  const route = chooseRoute(tokens, depth);
+  const chosen = chooseRoute(tokens, depth);
+  const route = options.route ?? chosen;
 
   if (route === 'local') {
-    return localChat(messages, options);
+    try {
+      return await localChat(messages, options);
+    } catch (e) {
+      if (!options.fallbackToCloud) throw e;
+      console.warn('Local model failed, falling back to cloud', e);
+    }
   }
 
   const safeMessages = stripSensitive(messages);
   const safeProfile = sanitizeProfile(profile);
-  const { data, error } = await supabase.functions.invoke<{ content: string }>('aurora-chat', {
-    body: { messages: safeMessages, profile: safeProfile, ...options },
-  });
+  const { data, error } = await supabase.functions.invoke<{ content: string }>(
+    'aurora-chat',
+    { body: { messages: safeMessages, profile: safeProfile, ...options } },
+  );
   if (error) throw error;
   return data ?? { content: '' };
 }

--- a/src/state/modelPreference.ts
+++ b/src/state/modelPreference.ts
@@ -1,0 +1,47 @@
+import { create } from 'zustand';
+
+export type ModelPreference = 'auto' | 'local' | 'cloud';
+
+interface ModelState {
+  preference: ModelPreference;
+  fallbackToCloud: boolean;
+  setPreference: (p: ModelPreference) => void;
+  setFallback: (f: boolean) => void;
+}
+
+const STORAGE_KEY = 'modelPreference';
+
+export const useModelPreference = create<ModelState>((set) => {
+  const raw =
+    typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null;
+  const initial = raw
+    ? (JSON.parse(raw) as { preference: ModelPreference; fallbackToCloud: boolean })
+    : { preference: 'auto', fallbackToCloud: true };
+  return {
+    ...initial,
+    setPreference: (p) =>
+      set((state) => {
+        const next = { ...state, preference: p } as ModelState;
+        try {
+          const { preference, fallbackToCloud } = next;
+          localStorage.setItem(
+            STORAGE_KEY,
+            JSON.stringify({ preference, fallbackToCloud }),
+          );
+        } catch {}
+        return next;
+      }),
+    setFallback: (f) =>
+      set((state) => {
+        const next = { ...state, fallbackToCloud: f } as ModelState;
+        try {
+          const { preference, fallbackToCloud } = next;
+          localStorage.setItem(
+            STORAGE_KEY,
+            JSON.stringify({ preference, fallbackToCloud }),
+          );
+        } catch {}
+        return next;
+      }),
+  };
+});

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -13,4 +13,8 @@ export interface ChatOptions {
   confidence?: number;
   /** Threshold above which the tuned model will be used. Default 0.8 */
   tunedThreshold?: number;
+  /** Force routing to a specific model */
+  route?: 'local' | 'cloud';
+  /** When routing to local fails, allow fallback to cloud */
+  fallbackToCloud?: boolean;
 }

--- a/src/utils/auroraChat.ts
+++ b/src/utils/auroraChat.ts
@@ -4,6 +4,7 @@ import { getFilterName } from '@/brain/filters';
 import { routeChat } from '@/agent/router';
 import type { ChatMessage, ChatOptions } from '@/types/chat';
 import { supabase } from '@/integrations/supabase/client';
+import { useModelPreference } from '@/state/modelPreference';
 
 function buildSystemMessages(profile: UserProfile | null): ChatMessage[] {
   const systemMessages: ChatMessage[] = [
@@ -72,10 +73,21 @@ export async function auroraChat(
 ): Promise<{ content: string }> {
   const profile = await getProfile();
   const systemMessages = buildSystemMessages(profile);
+
+  const { preference, fallbackToCloud } = useModelPreference.getState();
+  const offline = typeof navigator !== 'undefined' && !navigator.onLine;
+  const conn = typeof navigator !== 'undefined' ? (navigator as any).connection : undefined;
+  const lowBandwidth = !!conn && (conn.saveData || ['slow-2g', '2g'].includes(conn.effectiveType || ''));
+
+  let route: 'local' | 'cloud' | undefined;
+  if (preference === 'local') route = 'local';
+  else if (preference === 'cloud') route = 'cloud';
+  else if (offline || lowBandwidth) route = 'local';
+
   const { content } = await routeChat(
     [...systemMessages, ...messages],
     profile,
-    options,
+    { ...options, route, fallbackToCloud },
   );
   let filtered = content;
   for (const filter of brain.filters) filtered = filter(filtered);


### PR DESCRIPTION
## Summary
- add Zustand store to track user's preferred model and cloud fallback
- route auroraChat to local or cloud models based on preference and network conditions
- allow router to override model choice and fall back to cloud when local fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a8ceb10f083268c5e46f02d8fd6ab