### PR TITLE
feat: support user voice cloning across app

### DIFF
--- a/src/components/VoiceSetup.tsx
+++ b/src/components/VoiceSetup.tsx
@@ -4,6 +4,7 @@ import { useVoiceStore } from "@/state/voice";
 import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
 import { Mic, Square } from "lucide-react";
+import { supabase } from "@/integrations/supabase/client";
 
 export default function VoiceSetup() {
   const {
@@ -39,6 +40,24 @@ export default function VoiceSetup() {
       const json = await resp.json();
       if (json?.voice_id) {
         setVoiceId(json.voice_id);
+        try {
+          const { data: auth } = await supabase.auth.getUser();
+          const uid = auth.user?.id;
+          if (uid) {
+            const { data: prof } = await supabase
+              .from("profiles")
+              .select("persona")
+              .eq("id", uid)
+              .single();
+            const persona = (prof?.persona as any) || {};
+            await supabase
+              .from("profiles")
+              .update({ persona: { ...persona, voiceId: json.voice_id } })
+              .eq("id", uid);
+          }
+        } catch (e) {
+          console.warn("Failed to save voiceId to profile", e);
+        }
         toast({ title: "Voice saved", description: "Custom voice ready." });
       } else {
         throw new Error("No voice id returned");

--- a/src/voice/voiceio.ts
+++ b/src/voice/voiceio.ts
@@ -63,36 +63,34 @@ export class VoiceIO {
   async speak(text: string) {
     const { voiceId, speed, pitch, expression, emotion } =
       useVoiceStore.getState();
-    if (voiceId) {
-      try {
-        const { data, error } = await supabase.functions.invoke("tts-generate", {
-          body: { text, voiceId, emotion, speed, pitch, expression },
-        });
-        if (!error && data?.audioBase64) {
-          const src = `data:${data.contentType};base64,${data.audioBase64}`;
-          const audio = new Audio(src);
-          this.audio = audio;
-          useAvatarStore.getState().setAudio(audio);
-          audio.onplay = () => {
-            useVoiceStore.getState().setSpeaking(true);
-            this.callbacks.onSpeakingChange?.(true);
-          };
-          const end = () => {
-            useVoiceStore.getState().setSpeaking(false);
-            this.callbacks.onSpeakingChange?.(false);
-            useAvatarStore.getState().setAudio(null);
-          };
-          audio.onended = end;
-          audio.onerror = (e) => {
-            end();
-            this.callbacks.onError?.(e);
-          };
-          await audio.play();
-          return;
-        }
-      } catch (e) {
-        this.callbacks.onError?.(e);
+    try {
+      const { data, error } = await supabase.functions.invoke("tts-generate", {
+        body: { text, voiceId, emotion, speed, pitch, expression },
+      });
+      if (!error && data?.audioBase64) {
+        const src = `data:${data.contentType};base64,${data.audioBase64}`;
+        const audio = new Audio(src);
+        this.audio = audio;
+        useAvatarStore.getState().setAudio(audio);
+        audio.onplay = () => {
+          useVoiceStore.getState().setSpeaking(true);
+          this.callbacks.onSpeakingChange?.(true);
+        };
+        const end = () => {
+          useVoiceStore.getState().setSpeaking(false);
+          this.callbacks.onSpeakingChange?.(false);
+          useAvatarStore.getState().setAudio(null);
+        };
+        audio.onended = end;
+        audio.onerror = (e) => {
+          end();
+          this.callbacks.onError?.(e);
+        };
+        await audio.play();
+        return;
       }
+    } catch (e) {
+      this.callbacks.onError?.(e);
     }
 
     if (!('speechSynthesis' in window)) return;

--- a/supabase/functions/tts-generate/index.ts
+++ b/supabase/functions/tts-generate/index.ts
@@ -23,16 +23,18 @@ serve(async (req) => {
   }
 
   try {
-      const body = await req.json();
-      const {
-        text,
-        voiceId: reqVoiceId,
-        modelId = "eleven_turbo_v2_5",
-        outputFormat = "mp3_44100_128",
-      } = body ?? {};
-      const voiceId = typeof reqVoiceId === "string" && reqVoiceId.length
-        ? reqVoiceId
-        : "9BWtsMINqrJLrRacOk9x"; // Aria (default voice)
+    const { searchParams } = new URL(req.url);
+    const queryVoiceId = searchParams.get("voiceId") ?? undefined;
+    const body = (await req.json().catch(() => ({}))) as any;
+    const {
+      text,
+      voiceId: bodyVoiceId,
+      modelId = "eleven_turbo_v2_5",
+      outputFormat = "mp3_44100_128",
+    } = body;
+    const voiceId = [bodyVoiceId, queryVoiceId].find(
+      (v): v is string => typeof v === "string" && v.length > 0,
+    ) ?? "9BWtsMINqrJLrRacOk9x"; // Aria (default voice)
 
     if (!text || typeof text !== "string") {
       return new Response(JSON.stringify({ error: "Missing text" }), {


### PR DESCRIPTION
## Summary
- save custom ElevenLabs voice IDs to the user's Supabase profile
- forward optional `voiceId` to the ElevenLabs TTS endpoint and support query params
- route VoiceIO speech through the Supabase TTS function for cloned voice playback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a8ce73fc8832698d16c2f01baa016