### PR TITLE
feat: add BrainAgent orchestrator

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,4 @@
+"""Core package for brain agents."""
+from .brain import BrainAgent
+
+__all__ = ["BrainAgent"]

--- a/core/brain.py
+++ b/core/brain.py
@@ -1,0 +1,74 @@
+"""Central Brain agent for orchestrating specialized sub-agents.
+
+This module defines :class:`BrainAgent`, the primary coordinator of the
+personal AI Brain system.  It retrieves persona and memory context before
+dispatching a user message to a suitable sub-agent.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Iterable, List, Protocol, Sequence
+
+
+class SupportsAgent(Protocol):
+    """Protocol each specialized agent must follow."""
+
+    def can_handle(self, message: str) -> bool:
+        """Return ``True`` if the agent is able to handle ``message``."""
+
+    def handle(self, message: str, context: str) -> str:
+        """Return a response for ``message`` using extra ``context``."""
+
+
+@dataclass
+class BrainAgent:
+    """High level orchestrator that delegates work to specialized agents.
+
+    Parameters
+    ----------
+    persona_store:
+        Callable returning a short string describing the user's ideal persona.
+    memory_store:
+        Callable accepting a message and returning an iterable of memory
+        snippets relevant to that message.
+    agents:
+        Sequence of sub-agents responsible for specific tasks.  Each must
+        implement :class:`SupportsAgent`.
+    prompt_template:
+        Format string used to build the master prompt.  ``{persona}`` and
+        ``{memories}`` placeholders will be replaced prior to dispatch.
+    """
+
+    persona_store: Callable[[], str]
+    memory_store: Callable[[str], Iterable[str]]
+    agents: Sequence[SupportsAgent] = field(default_factory=list)
+    prompt_template: str = (
+        "You are the idealized version of the user.\n"
+        "Persona: {persona}\n"
+        "Relevant memories:\n{memories}\n"
+    )
+
+    def process(self, message: str) -> str:
+        """Process a user ``message`` by delegating to a sub-agent.
+
+        The method retrieves persona and memory snippets, constructs the
+        master prompt, and invokes the first agent capable of handling the
+        message.  If no agent accepts the message, the composed prompt is
+        returned so callers can decide how to handle it.
+        """
+
+        persona = self.persona_store() or ""
+        memories = list(self.memory_store(message))
+        memory_text = "\n".join(memories)
+        context = self.prompt_template.format(persona=persona, memories=memory_text)
+
+        for agent in self.agents:
+            try:
+                if agent.can_handle(message):
+                    return agent.handle(message, context)
+            except Exception:
+                # A misbehaving agent should not crash the BrainAgent
+                continue
+
+        # No agent handled the message; fall back to returning context.
+        return context


### PR DESCRIPTION
## Summary
- add core BrainAgent class to orchestrate persona, memory and sub-agent delegation
- expose BrainAgent in new core package

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a91fa45288326bb8ea24b2bb994f4