### PR TITLE
feat: add persona interview and styling utilities

### DIFF
--- a/persona/interview.py
+++ b/persona/interview.py
@@ -1,0 +1,31 @@
+"""Simple CLI interview to capture a user's persona preferences."""
+import json
+from pathlib import Path
+
+QUESTIONS = [
+    ("tone", "How would you describe your preferred communication tone?"),
+    ("goals", "What personal goals should the AI keep in mind?"),
+    (
+        "catchphrases",
+        "List any catchphrases or phrases you often use (comma separated):",
+    ),
+]
+
+
+def run_interview() -> None:
+    """Prompt the user with questions and store answers in profile.json."""
+    profile = {}
+    for key, prompt in QUESTIONS:
+        answer = input(prompt + " ").strip()
+        if key == "catchphrases":
+            profile[key] = [p.strip() for p in answer.split(",") if p.strip()]
+        else:
+            profile[key] = answer
+
+    path = Path(__file__).with_name("profile.json")
+    path.write_text(json.dumps(profile, indent=2))
+    print(f"Profile saved to {path}")
+
+
+if __name__ == "__main__":
+    run_interview()

--- a/persona/profile.json
+++ b/persona/profile.json
@@ -1,0 +1,5 @@
+{
+  "tone": "",
+  "goals": "",
+  "catchphrases": []
+}

--- a/persona/style.py
+++ b/persona/style.py
@@ -1,0 +1,31 @@
+"""Utilities to adjust model output based on the saved persona profile."""
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def _load_profile() -> Dict[str, Any]:
+    """Load persona data from profile.json if it exists."""
+    path = Path(__file__).with_name("profile.json")
+    if not path.exists():
+        return {}
+    with path.open() as fh:
+        return json.load(fh)
+
+
+def apply_style(text: str) -> str:
+    """Return ``text`` adapted to the saved persona tone and catchphrases."""
+    profile = _load_profile()
+    tone = profile.get("tone")
+    catchphrases = profile.get("catchphrases", [])
+
+    result = text
+    if tone:
+        result = f"[{tone}] {result}"
+
+    if catchphrases:
+        prefix = catchphrases[0]
+        suffix = catchphrases[-1] if len(catchphrases) > 1 else catchphrases[0]
+        result = f"{prefix} {result} {suffix}"
+
+    return result


### PR DESCRIPTION
## Summary
- add CLI interview to collect tone, goals and catchphrases
- persist responses in a persona profile file
- provide helper to adapt model output to saved persona tone and catchphrases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a92e9c2fc8326ab1fdede5d6c183b