### PR TITLE
feat: add persistent memory store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+memory/*.db
+memory/chroma_db/

--- a/memory/store.py
+++ b/memory/store.py
@@ -1,0 +1,91 @@
+import os
+import json
+import sqlite3
+from typing import Any, Dict, List
+
+try:
+    import chromadb
+    from chromadb.utils import embedding_functions
+except Exception:  # pragma: no cover - chromadb optional
+    chromadb = None
+
+DB_PATH = os.path.join(os.path.dirname(__file__), "memory.db")
+CHROMA_PATH = os.path.join(os.path.dirname(__file__), "chroma_db")
+
+conn = sqlite3.connect(DB_PATH)
+cur = conn.cursor()
+cur.execute(
+    """
+    CREATE TABLE IF NOT EXISTS memories (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        text TEXT NOT NULL,
+        metadata TEXT
+    )
+    """
+)
+conn.commit()
+
+collection = None
+if chromadb is not None:
+    client = chromadb.PersistentClient(path=CHROMA_PATH)
+    embed_fn = embedding_functions.SentenceTransformerEmbeddingFunction(
+        model_name="all-MiniLM-L6-v2"
+    )
+    collection = client.get_or_create_collection(
+        "memories", embedding_function=embed_fn
+    )
+
+
+def save_memory(text: str, metadata: Dict[str, Any] | None = None) -> int:
+    metadata = metadata or {}
+    cur.execute(
+        "INSERT INTO memories (text, metadata) VALUES (?, ?)",
+        (text, json.dumps(metadata)),
+    )
+    mem_id = cur.lastrowid
+    conn.commit()
+    if collection is not None:
+        collection.add(documents=[text], metadatas=[metadata], ids=[str(mem_id)])
+    return mem_id
+
+
+def query_memory(query: str, k: int = 5) -> List[Dict[str, Any]]:
+    if collection is None:
+        return []
+    results = collection.query(query_texts=[query], n_results=k)
+    ids = [int(i) for i in results.get("ids", [[""]])[0] if i]
+    if not ids:
+        return []
+    placeholders = ",".join(["?"] * len(ids))
+    cur.execute(
+        f"SELECT id, text, metadata FROM memories WHERE id IN ({placeholders})",
+        ids,
+    )
+    rows = cur.fetchall()
+    output: List[Dict[str, Any]] = []
+    for row in rows:
+        mid, text, meta_json = row
+        try:
+            meta = json.loads(meta_json) if meta_json else {}
+        except Exception:
+            meta = {}
+        output.append({"id": mid, "text": text, "metadata": meta})
+    return output
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) < 2:
+        print("{}", end="")
+        sys.exit(0)
+    cmd = sys.argv[1]
+    if cmd == "save":
+        text = sys.argv[2] if len(sys.argv) > 2 else ""
+        meta = json.loads(sys.argv[3]) if len(sys.argv) > 3 else {}
+        save_memory(text, meta)
+    elif cmd == "query":
+        query = sys.argv[2] if len(sys.argv) > 2 else ""
+        k = int(sys.argv[3]) if len(sys.argv) > 3 else 5
+        res = query_memory(query, k)
+        print(json.dumps(res))

--- a/src/agent/AuroraAgent.ts
+++ b/src/agent/AuroraAgent.ts
@@ -6,6 +6,7 @@ import {
   memoryStore,
   retrieveRelevantMemories,
 } from "@/memory/indexedDbMemory";
+import { saveMemory, queryMemory } from "@/memory/store";
 import brain from "@/brain/Brain";
 import { filterRegistry } from "@/brain/filters";
 import { scanResponse, explainIssues } from "@/agent/safety";
@@ -53,13 +54,18 @@ export class AuroraAgent {
 
     // persist user turn into long-term memory
     await memoryStore.add('episodic', 'user', text);
+    await saveMemory(text, { role: 'user' });
 
-    const memories = await retrieveRelevantMemories(text);
-    const memoryContext = memories
-      .map((m) => `${m.role}: ${m.content}`)
-      .join('\n');
+    const [memories, longTerm] = await Promise.all([
+      retrieveRelevantMemories(text),
+      queryMemory(text, 5),
+    ]);
+    const memoryContext = [
+      ...memories.map((m) => `${m.role}: ${m.content}`),
+      ...longTerm.map((m) => `${m.metadata?.role ?? 'memory'}: ${m.text}`),
+    ].join('\n');
 
-    const confidence = memories.length > 2 ? 0.9 : 0.5;
+    const confidence = memories.length + longTerm.length > 2 ? 0.9 : 0.5;
 
     const userSummary = this.history
       .filter((m) => m.role === 'user')
@@ -157,6 +163,7 @@ export class AuroraAgent {
       if (this.history.length > 20) this.history = this.history.slice(-20);
       // store assistant response asynchronously
       memoryStore.add('episodic', 'assistant', output).catch(() => {});
+      saveMemory(output, { role: 'assistant' }).catch(() => {});
       this.events.onResponse?.(output);
       void this.voice.speak(output);
     }

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -1,0 +1,32 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const execFileAsync = promisify(execFile);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const STORE_PY = path.resolve(__dirname, '../../memory/store.py');
+
+export interface MemoryRecord {
+  id: number;
+  text: string;
+  metadata: Record<string, any>;
+}
+
+export async function saveMemory(text: string, metadata: Record<string, any> = {}): Promise<void> {
+  try {
+    await execFileAsync('python', [STORE_PY, 'save', text, JSON.stringify(metadata)]);
+  } catch (e) {
+    console.error('saveMemory failed', e);
+  }
+}
+
+export async function queryMemory(query: string, k = 5): Promise<MemoryRecord[]> {
+  try {
+    const { stdout } = await execFileAsync('python', [STORE_PY, 'query', query, String(k)]);
+    return JSON.parse(stdout || '[]');
+  } catch (e) {
+    console.error('queryMemory failed', e);
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- add Python memory store backed by SQLite and Chroma
- expose Node wrapper and connect to BrainAgent for saving and querying long-term memory
- ignore generated memory database files

## Testing
- `python memory/store.py save "Hello world" '{"role":"user"}'`
- `python memory/store.py query "Hello" 1`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a929a475083269939067f3cfd8a8c