### PR TITLE
feat: add motivational coaching agent

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,4 @@
+"""Specialized agent modules."""
+from .coaching import CoachingAgent
+
+__all__ = ["CoachingAgent"]

--- a/agents/coaching.py
+++ b/agents/coaching.py
@@ -1,0 +1,54 @@
+"""Motivational coaching agent for encouraging positive action.
+
+This lightweight agent synthesizes a short coaching message using
+pre-defined templates focused on micro-commitments and positive
+self-talk.  The goal is to provide gentle nudges that keep the user
+moving forward.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class CoachingAgent:
+    """Generate motivational snippets for the Brain agent.
+
+    The agent exposes :meth:`generate` which accepts a ``context`` string
+    (usually the master prompt assembled by :class:`core.brain.BrainAgent`) and
+    returns a short motivational reply.
+    """
+
+    micro_commitment_template: str = (
+        "Commit to one tiny action in the next few minutes: {step}."
+    )
+    positive_self_talk_template: str = (
+        "Tell yourself: \"{affirmation}\""
+    )
+
+    def generate(self, context: str) -> str:
+        """Craft a motivational reply from ``context``.
+
+        Parameters
+        ----------
+        context:
+            Full context string prepared by :class:`BrainAgent` which may
+            include persona and memory information.  The current
+            implementation does not parse the context deeply; it simply
+            uses it as inspiration for a generic but encouraging message.
+
+        Returns
+        -------
+        str
+            A coaching message combining a micro-commitment suggestion and
+            a line of positive self-talk.
+        """
+
+        step = "start with just two minutes of focused effort"
+        affirmation = "I am capable and every small step matters"
+
+        micro = self.micro_commitment_template.format(step=step)
+        positive = self.positive_self_talk_template.format(
+            affirmation=affirmation
+        )
+        return f"{micro} {positive}"

--- a/core/brain.py
+++ b/core/brain.py
@@ -7,7 +7,9 @@ dispatching a user message to a suitable sub-agent.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Callable, Iterable, List, Protocol, Sequence
+from typing import Callable, Iterable, Protocol, Sequence
+
+from agents.coaching import CoachingAgent
 
 
 class SupportsAgent(Protocol):
@@ -34,6 +36,10 @@ class BrainAgent:
     agents:
         Sequence of sub-agents responsible for specific tasks.  Each must
         implement :class:`SupportsAgent`.
+    coach:
+        Optional :class:`CoachingAgent` that always generates a short
+        motivational snippet which is appended to the chosen agent's
+        response.
     prompt_template:
         Format string used to build the master prompt.  ``{persona}`` and
         ``{memories}`` placeholders will be replaced prior to dispatch.
@@ -42,6 +48,7 @@ class BrainAgent:
     persona_store: Callable[[], str]
     memory_store: Callable[[str], Iterable[str]]
     agents: Sequence[SupportsAgent] = field(default_factory=list)
+    coach: CoachingAgent | None = None
     prompt_template: str = (
         "You are the idealized version of the user.\n"
         "Persona: {persona}\n"
@@ -62,13 +69,21 @@ class BrainAgent:
         memory_text = "\n".join(memories)
         context = self.prompt_template.format(persona=persona, memories=memory_text)
 
+        response = None
         for agent in self.agents:
             try:
                 if agent.can_handle(message):
-                    return agent.handle(message, context)
+                    response = agent.handle(message, context)
+                    break
             except Exception:
                 # A misbehaving agent should not crash the BrainAgent
                 continue
 
-        # No agent handled the message; fall back to returning context.
-        return context
+        if response is None:
+            response = context
+
+        if self.coach is not None:
+            coaching = self.coach.generate(context)
+            response = f"{response}\n\n{coaching}".strip()
+
+        return response


### PR DESCRIPTION
## Summary
- add `CoachingAgent` with micro-commitment and positive self-talk prompts
- let `BrainAgent` merge optional coaching output into final responses

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a94ad97b88326afd03befb0ab3859