### PR TITLE
Add hypnosis agent and command trigger

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,5 @@
+"""Agent package for specialized behaviors."""
+
+from .hypnosis import HypnosisAgent
+
+__all__ = ["HypnosisAgent"]

--- a/agents/hypnosis.py
+++ b/agents/hypnosis.py
@@ -1,0 +1,28 @@
+"""Hypnosis agent generating brief guided imagery scripts."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class HypnosisAgent:
+    """Generate guided imagery scripts with a positive anchor."""
+
+    @staticmethod
+    def generate(context: str, goal: str) -> str:
+        """Return a short hypnotic script.
+
+        Args:
+            context: Current user state or surroundings.
+            goal: Desired outcome for the session.
+
+        Returns:
+            A brief guided imagery script ending with a positive anchor.
+        """
+        context = context.strip()
+        goal = goal.strip()
+        return (
+            "Close your eyes and take a slow, deep breath. "
+            f"{context} As you relax, picture {goal} unfolding with ease. "
+            "With each breath, calm confidence spreads through you. "
+            "Whenever you press your thumb and forefinger together, this steady calm returns." 
+        )

--- a/src/agent/AuroraAgent.ts
+++ b/src/agent/AuroraAgent.ts
@@ -103,8 +103,23 @@ export class AuroraAgent {
       return;
     }
 
-    if (/\b(hypnosis|induction|calm|confidence|focus)\b/.test(lower)) {
-      const mode = /confidence/.test(lower) ? 'confidence' : /calm/.test(lower) ? 'calm' : 'focus';
+    if (/start\s+hypnosis\s+mode/.test(lower)) {
+      const mode = /confidence/.test(lower)
+        ? 'confidence'
+        : /calm/.test(lower)
+        ? 'calm'
+        : 'focus';
+      await ToolImpl.start_hypnosis({ mode: mode as any, duration: 60 });
+      this.say(`Running a short ${mode} induction.`);
+      return;
+    }
+
+    if (/\b(hypnosis|induction|calm|confidence)\b/.test(lower)) {
+      const mode = /confidence/.test(lower)
+        ? 'confidence'
+        : /calm/.test(lower)
+        ? 'calm'
+        : 'focus';
       await ToolImpl.start_hypnosis({ mode: mode as any, duration: 60 });
       this.say(`Running a short ${mode} induction.`);
       return;


### PR DESCRIPTION
## Summary
- add HypnosisAgent to craft guided imagery ending with a positive anchor
- wire up "start hypnosis mode" voice command to launch hypnosis session

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, Empty block statement, @typescript-eslint/no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_689a94aecc9083268e5cd72fc0844305