### PR TITLE
feat: add webrtc voice streaming

### DIFF
--- a/src/voice/useVoiceInput.ts
+++ b/src/voice/useVoiceInput.ts
@@ -1,79 +1,61 @@
 import { useState, useRef, useCallback } from 'react'
 
-const OPENAI_API_KEY = import.meta.env.VITE_OPENAI_API_KEY as string | undefined
-
 export function useVoiceInput() {
   const [isRecording, setIsRecording] = useState(false)
   const [transcript, setTranscript] = useState('')
-  const recognitionRef = useRef<any>(null)
-  const mediaRecorderRef = useRef<MediaRecorder | null>(null)
-  const chunksRef = useRef<Blob[]>([])
+  const pcRef = useRef<RTCPeerConnection | null>(null)
+  const channelRef = useRef<RTCDataChannel | null>(null)
+  const audioRef = useRef<HTMLAudioElement | null>(null)
 
   const start = useCallback(async () => {
     if (isRecording) return
-    if (window.SpeechRecognition || window.webkitSpeechRecognition) {
-      const Rec = (window.SpeechRecognition || window.webkitSpeechRecognition)!
-      const recognition = new Rec()
-      recognition.lang = 'en-US'
-      recognition.interimResults = false
-      recognition.onresult = e => {
-        const text = Array.from(e.results).map(r => r[0].transcript).join(' ')
-        setTranscript(text)
-      }
-      recognition.onend = () => setIsRecording(false)
-      recognition.onerror = () => setIsRecording(false)
-      recognition.start()
-      recognitionRef.current = recognition
-      setIsRecording(true)
-    } else {
-      try {
-        const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
-        const recorder = new MediaRecorder(stream)
-        chunksRef.current = []
-        recorder.ondataavailable = e => {
-          if (e.data.size > 0) chunksRef.current.push(e.data)
-        }
-        recorder.onstop = async () => {
-          const blob = new Blob(chunksRef.current, { type: 'audio/webm' })
-          try {
-            const formData = new FormData()
-            formData.append('file', blob, 'recording.webm')
-            formData.append('model', 'whisper-1')
+    const pc = new RTCPeerConnection()
+    pcRef.current = pc
 
-            const apiKey = OPENAI_API_KEY
-            if (!apiKey) throw new Error('Missing OpenAI API key')
-
-            const res = await fetch('https://api.openai.com/v1/audio/transcriptions', {
-              method: 'POST',
-              headers: {
-                Authorization: `Bearer ${apiKey}`
-              },
-              body: formData
-            })
-            const data = await res.json()
-            if (data?.text) setTranscript(data.text)
-          } catch (err) {
-            console.error('Whisper transcription failed', err)
+    pc.ondatachannel = e => {
+      channelRef.current = e.channel
+      e.channel.onmessage = ev => {
+        try {
+          const msg = JSON.parse(ev.data)
+          if (msg.transcript) setTranscript(msg.transcript)
+          if (msg.audio) {
+            const audio = new Audio('data:audio/wav;base64,' + msg.audio)
+            audio.play()
+            audioRef.current = audio
           }
-          setIsRecording(false)
-        }
-        recorder.start()
-        mediaRecorderRef.current = recorder
-        setIsRecording(true)
-      } catch (err) {
-        console.error('Unable to access microphone', err)
+        } catch { /* ignore */ }
       }
     }
+
+    pc.ontrack = ev => {
+      const audio = new Audio()
+      audio.srcObject = ev.streams[0]
+      audio.play()
+      audioRef.current = audio
+    }
+
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+    stream.getTracks().forEach(t => pc.addTrack(t, stream))
+
+    const offer = await pc.createOffer()
+    await pc.setLocalDescription(offer)
+    const res = await fetch('/voice', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sdp: offer.sdp, type: offer.type })
+    })
+    const answer = await res.json()
+    await pc.setRemoteDescription(answer)
+    setIsRecording(true)
   }, [isRecording])
 
   const stop = useCallback(() => {
-    recognitionRef.current?.stop()
-    recognitionRef.current = null
-    if (mediaRecorderRef.current) {
-      mediaRecorderRef.current.stop()
-      mediaRecorderRef.current = null
-    }
+    channelRef.current?.close()
+    pcRef.current?.getSenders().forEach(s => s.track?.stop())
+    pcRef.current?.close()
+    pcRef.current = null
+    setIsRecording(false)
   }, [])
 
-  return { startRecording: start, stopRecording: stop, transcript, setTranscript, isRecording }
+  return { startRecording: start, stopRecording: stop, transcript, setTranscript, isRecording, audioRef }
 }

--- a/voice/__init__.py
+++ b/voice/__init__.py
@@ -1,0 +1,6 @@
+"""Voice processing utilities including speech recognition and synthesis."""
+
+from .stt import transcribe_audio
+from .tts import synthesize_reply
+
+__all__ = ["transcribe_audio", "synthesize_reply"]

--- a/voice/requirements.txt
+++ b/voice/requirements.txt
@@ -1,0 +1,6 @@
+faster-whisper
+TTS
+soundfile
+fastapi
+aiohttp
+aiortc

--- a/voice/server.py
+++ b/voice/server.py
@@ -1,0 +1,59 @@
+"""FastAPI application providing a WebRTC `/voice` endpoint."""
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import tempfile
+
+from fastapi import FastAPI, Request
+from aiortc import RTCPeerConnection, RTCSessionDescription
+from aiortc.contrib.media import MediaRecorder
+
+from .stt import transcribe_audio
+from .tts import synthesize_reply
+
+app = FastAPI()
+
+
+@app.post("/voice")
+async def voice_endpoint(request: Request):
+    """Handle a WebRTC offer from the frontend.
+
+    The client should POST an RTCSessionDescription and will receive an
+    answer.  Once the incoming audio track ends, the server transcribes it
+    with Whisper and returns a spoken reply over a data channel named
+    ``results``.  The reply is sent as base64-encoded WAV audio alongside
+    the transcript.
+    """
+    params = await request.json()
+    offer = RTCSessionDescription(sdp=params["sdp"], type=params["type"])
+
+    pc = RTCPeerConnection()
+    recorder_file = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+    recorder = MediaRecorder(recorder_file.name)
+
+    channel = pc.createDataChannel("results")
+
+    @pc.on("track")
+    async def on_track(track):
+        if track.kind == "audio":
+            recorder.addTrack(track)
+            await recorder.start()
+            await track.recv()  # wait for at least one frame
+            await asyncio.sleep(0.1)
+            await recorder.stop()
+            with open(recorder_file.name, "rb") as f:
+                audio_bytes = f.read()
+            text = transcribe_audio(audio_bytes)
+            reply_audio = synthesize_reply(f"You said: {text}")
+            message = {
+                "transcript": text,
+                "audio": base64.b64encode(reply_audio).decode(),
+            }
+            channel.send(json.dumps(message))
+
+    await pc.setRemoteDescription(offer)
+    answer = await pc.createAnswer()
+    await pc.setLocalDescription(answer)
+    return {"sdp": pc.localDescription.sdp, "type": pc.localDescription.type}

--- a/voice/stt.py
+++ b/voice/stt.py
@@ -1,0 +1,40 @@
+"""Speech-to-text utilities using Whisper models."""
+from __future__ import annotations
+
+import io
+import tempfile
+from typing import Optional
+
+try:
+    from faster_whisper import WhisperModel
+    _MODEL: Optional[WhisperModel] = WhisperModel("base")
+    def _run_model(path: str, language: str | None) -> str:
+        segments, _ = _MODEL.transcribe(path, language=language)
+        return "".join(seg.text for seg in segments).strip()
+except Exception:  # pragma: no cover - fallback to openai whisper
+    import whisper
+    _MODEL = whisper.load_model("base")
+    def _run_model(path: str, language: str | None) -> str:
+        result = _MODEL.transcribe(path, language=language)
+        return result["text"].strip()
+
+
+def transcribe_audio(data: bytes, language: str | None = "en") -> str:
+    """Transcribe an audio byte stream to text.
+
+    Parameters
+    ----------
+    data:
+        Raw audio bytes encoded in WAV/WebM/MP3 format.
+    language:
+        Optional language hint for the model.
+
+    Returns
+    -------
+    str
+        The transcribed text.
+    """
+    with tempfile.NamedTemporaryFile(suffix=".wav") as tmp:
+        tmp.write(data)
+        tmp.flush()
+        return _run_model(tmp.name, language)

--- a/voice/tts.py
+++ b/voice/tts.py
@@ -1,0 +1,42 @@
+"""Text-to-speech utilities using Coqui TTS."""
+from __future__ import annotations
+
+import io
+from typing import Optional
+
+import soundfile as sf
+from TTS.api import TTS
+
+
+_TTS: TTS | None = None
+
+def _get_tts() -> TTS:
+    global _TTS
+    if _TTS is None:
+        _TTS = TTS(model_name="tts_models/en/vctk/vits")
+    return _TTS
+
+
+def synthesize_reply(text: str, *, voice_clone: Optional[str] = None) -> bytes:
+    """Generate speech audio for ``text``.
+
+    Parameters
+    ----------
+    text:
+        Text to be spoken.
+    voice_clone:
+        Optional path to a WAV file for voice cloning.
+
+    Returns
+    -------
+    bytes
+        WAV-encoded audio data.
+    """
+    tts = _get_tts()
+    if voice_clone:
+        audio = tts.tts(text, speaker_wav=voice_clone)
+    else:
+        audio = tts.tts(text)
+    buf = io.BytesIO()
+    sf.write(buf, audio, samplerate=tts.synthesizer.output_sample_rate, format="WAV")
+    return buf.getvalue()


### PR DESCRIPTION
## Summary
- stream microphone audio to backend `/voice` via WebRTC
- transcribe audio with Whisper/faster-whisper
- synthesize replies using Coqui TTS and respond over WebRTC

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, Empty block statement, A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689a95cd69e88326a84e675791e66a3f