### PR TITLE
feat: add sentiment-driven avatar sphere

### DIFF
--- a/src/agent/AuroraAgent.ts
+++ b/src/agent/AuroraAgent.ts
@@ -10,6 +10,7 @@ import { saveMemory, queryMemory } from "@/memory/store";
 import brain from "@/brain/Brain";
 import { filterRegistry } from "@/brain/filters";
 import { scanResponse, explainIssues } from "@/agent/safety";
+import { useAvatarStore } from "@/state/avatar";
 
 export type AgentEvents = {
   onPartial?: (text: string) => void;
@@ -89,8 +90,8 @@ export class AuroraAgent {
           },
           ...this.history,
         ];
-        const { content } = await auroraChat(messages, { confidence });
-        this.say(content);
+        const { content, sentiment } = await auroraChat(messages, { confidence });
+        this.say(content, sentiment);
       } catch (e) {
         console.error('aurora-chat failed', e);
         this.say('Could you elaborate?');
@@ -133,15 +134,15 @@ export class AuroraAgent {
           : []),
         ...this.history,
       ];
-      const { content } = await auroraChat(messages, { confidence });
-      this.say(content);
+      const { content, sentiment } = await auroraChat(messages, { confidence });
+      this.say(content, sentiment);
     } catch (e) {
       console.error('aurora-chat failed', e);
       this.say('Okay.');
     }
   }
 
-    say(text: string) {
+    say(text: string, sentiment = 0) {
       const { ok, issues } = scanResponse(text);
       let output = text;
       let skipSafety = false;
@@ -165,6 +166,7 @@ export class AuroraAgent {
       memoryStore.add('episodic', 'assistant', output).catch(() => {});
       saveMemory(output, { role: 'assistant' }).catch(() => {});
       this.events.onResponse?.(output);
+      useAvatarStore.getState().setSentiment(sentiment);
       void this.voice.speak(output);
     }
   }

--- a/src/agent/localModel.ts
+++ b/src/agent/localModel.ts
@@ -1,4 +1,5 @@
 import type { ChatMessage, ChatOptions } from '@/types/chat';
+import { analyzeSentiment } from '@/utils/sentiment';
 
 let baseEngine: any;
 let tunedEngine: any;
@@ -9,7 +10,7 @@ const TUNED_MODEL = 'Llama-3.1-8B-Instruct-q4f32_1-MLC-Aurora';
 export async function localChat(
   messages: ChatMessage[],
   options: ChatOptions = {},
-): Promise<{ content: string }> {
+): Promise<{ content: string; sentiment: number }> {
   if (typeof window === 'undefined') {
     throw new Error('Local model not available');
   }
@@ -42,7 +43,8 @@ export async function localChat(
 
   const resp = await engine.chat.completions.create({ messages });
   const content = resp?.choices?.[0]?.message?.content ?? '';
-  return { content };
+  const sentiment = analyzeSentiment(content);
+  return { content, sentiment };
 }
 
 export function resetLocalEngines() {

--- a/src/agent/router.ts
+++ b/src/agent/router.ts
@@ -41,7 +41,7 @@ export async function routeChat(
   messages: ChatMessage[],
   profile: UserProfile | null,
   options: ChatOptions = {},
-): Promise<{ content: string }> {
+): Promise<{ content: string; sentiment: number }> {
   const tokens = estimateTokens(messages);
   const depth = options.depth ?? 1;
   const chosen = chooseRoute(tokens, depth);
@@ -58,10 +58,12 @@ export async function routeChat(
 
   const safeMessages = stripSensitive(messages);
   const safeProfile = sanitizeProfile(profile);
-  const { data, error } = await supabase.functions.invoke<{ content: string }>(
-    'aurora-chat',
-    { body: { messages: safeMessages, profile: safeProfile, ...options } },
-  );
+  const { data, error } = await supabase.functions.invoke<{
+    content: string;
+    sentiment: number;
+  }>('aurora-chat', {
+    body: { messages: safeMessages, profile: safeProfile, ...options },
+  });
   if (error) throw error;
-  return data ?? { content: '' };
+  return data ?? { content: '', sentiment: 0 };
 }

--- a/src/components/avatar/AvatarSphere.tsx
+++ b/src/components/avatar/AvatarSphere.tsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+import { useAvatarStore } from '@/state/avatar';
+
+interface Props {
+  size?: number;
+}
+
+export function AvatarSphere({ size = 96 }: Props) {
+  const { enabled, sentiment, audio } = useAvatarStore();
+  const mountRef = useRef<HTMLDivElement | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const meshRef = useRef<THREE.Mesh | null>(null);
+  const matRef = useRef<THREE.MeshStandardMaterial | null>(null);
+  const geomRef = useRef<THREE.IcosahedronGeometry | null>(null);
+  const basePositions = useRef<Float32Array | null>(null);
+
+  // Setup scene
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount || !enabled) return;
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(45, 1, 0.1, 100);
+    camera.position.z = 3;
+    const renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true });
+    renderer.setSize(size, size);
+    mount.appendChild(renderer.domElement);
+
+    const geometry = new THREE.IcosahedronGeometry(1, 5);
+    geomRef.current = geometry;
+    basePositions.current = geometry.attributes.position.array.slice() as Float32Array;
+    const material = new THREE.MeshStandardMaterial({ color: 0xffffff, flatShading: true });
+    matRef.current = material;
+    const mesh = new THREE.Mesh(geometry, material);
+    meshRef.current = mesh;
+    scene.add(mesh);
+
+    const dir = new THREE.DirectionalLight(0xffffff, 1);
+    dir.position.set(0, 0, 4);
+    scene.add(dir);
+    scene.add(new THREE.AmbientLight(0xffffff, 0.4));
+
+    const data = new Uint8Array(1024);
+    let frame: number;
+    const animate = () => {
+      frame = requestAnimationFrame(animate);
+      if (analyserRef.current && meshRef.current) {
+        analyserRef.current.getByteTimeDomainData(data);
+        let sum = 0;
+        for (let i = 0; i < data.length; i++) sum += Math.abs(data[i] - 128);
+        const level = sum / data.length / 128;
+        meshRef.current.scale.setScalar(1 + level * 0.3);
+      }
+      renderer.render(scene, camera);
+    };
+    animate();
+
+    return () => {
+      cancelAnimationFrame(frame);
+      renderer.dispose();
+      mount.removeChild(renderer.domElement);
+    };
+  }, [enabled, size]);
+
+  // Attach audio analyser
+  useEffect(() => {
+    if (!audio) {
+      analyserRef.current = null;
+      return;
+    }
+    const ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+    const src = ctx.createMediaElementSource(audio);
+    const analyser = ctx.createAnalyser();
+    analyser.fftSize = 2048;
+    src.connect(analyser);
+    analyser.connect(ctx.destination);
+    analyserRef.current = analyser;
+    return () => {
+      try { src.disconnect(); } catch {}
+      try { analyser.disconnect(); } catch {}
+      analyserRef.current = null;
+    };
+  }, [audio]);
+
+  // Update color based on sentiment
+  useEffect(() => {
+    if (!matRef.current) return;
+    const neg = new THREE.Color('#ff4d4d');
+    const pos = new THREE.Color('#4dff4d');
+    const t = (sentiment + 1) / 2; // -1..1 -> 0..1
+    const color = new THREE.Color().lerpColors(neg, pos, t);
+    matRef.current.color.copy(color);
+  }, [sentiment]);
+
+  // Distort geometry based on sentiment
+  useEffect(() => {
+    const geom = geomRef.current;
+    const base = basePositions.current;
+    if (!geom || !base) return;
+    const pos = geom.attributes.position.array as Float32Array;
+    const amt = sentiment * 0.3;
+    for (let i = 0; i < pos.length; i += 3) {
+      const nx = base[i];
+      const ny = base[i + 1];
+      const nz = base[i + 2];
+      const noise = Math.sin(nx * 3) + Math.sin(ny * 3) + Math.sin(nz * 3);
+      const factor = 1 + amt * noise;
+      pos[i] = nx * factor;
+      pos[i + 1] = ny * factor;
+      pos[i + 2] = nz * factor;
+    }
+    geom.computeVertexNormals();
+    geom.attributes.position.needsUpdate = true;
+  }, [sentiment]);
+
+  if (!enabled) return null;
+  return <div ref={mountRef} style={{ width: size, height: size }} />;
+}
+
+export default AvatarSphere;

--- a/src/components/game/GameHUD.tsx
+++ b/src/components/game/GameHUD.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import { useGameStore } from "@/game/store";
 import { quickSlots } from "@/game/hud/hud.data";
-import { LipSyncAvatar } from "@/components/avatar/LipSyncAvatar";
+import { AvatarSphere } from "@/components/avatar/AvatarSphere";
 import { Mic, ChevronDown, ChevronUp } from "lucide-react";
 import { useHUDActions } from "@/game/hud/useHUDActions";
 import { useAvatarStore } from "@/state/avatar";
@@ -59,7 +59,7 @@ export function GameHUD() {
           {/* Identity */}
           <div className="flex items-center gap-3 min-w-0 shrink">
             {avatarEnabled && (
-              <LipSyncAvatar size={44} />
+              <AvatarSphere size={44} />
             )}
             <div className="min-w-0">
               <div className="text-[13px] opacity-90 truncate">

--- a/src/components/live/FloatingAssistant.tsx
+++ b/src/components/live/FloatingAssistant.tsx
@@ -13,6 +13,7 @@ import { useLocation } from 'react-router-dom';
 import type { Task } from '@/state/task';
 import { validateAnswer } from '@/utils/validation';
 import { auroraChat } from '@/utils/auroraChat';
+import { useAvatarStore } from '@/state/avatar';
 
 type ChatMessage = {
   id: string;
@@ -113,10 +114,11 @@ export function FloatingAssistant({
             "The user's last message was incomplete or uninformative. Ask a follow-up question to clarify.",
         });
       }
-      const { content: replyText } = await auroraChat(
+      const { content: replyText, sentiment } = await auroraChat(
         [...systemMessages, ...history],
         { model: 'o4-mini-2025-04-16' }
       );
+      useAvatarStore.getState().setSentiment(sentiment);
       const reply: ChatMessage = {
         id: crypto.randomUUID(),
         role: 'assistant',

--- a/src/state/avatar.ts
+++ b/src/state/avatar.ts
@@ -7,9 +7,11 @@ type AvatarState = {
   enabled: boolean;
   color: string;
   audio: HTMLAudioElement | null;
+  sentiment: number;
   setEnabled: (v: boolean) => void;
   setColor: (c: string) => void;
   setAudio: (a: HTMLAudioElement | null) => void;
+  setSentiment: (s: number) => void;
 };
 
 export const useAvatarStore = create<AvatarState>((set) => ({
@@ -22,6 +24,7 @@ export const useAvatarStore = create<AvatarState>((set) => ({
       ? localStorage.getItem(AVATAR_COLOR_KEY) || "#ffcc99"
       : "#ffcc99",
   audio: null,
+  sentiment: 0,
   setEnabled: (v) => {
     try {
       localStorage.setItem(AVATAR_ENABLE_KEY, String(v));
@@ -39,5 +42,6 @@ export const useAvatarStore = create<AvatarState>((set) => ({
     set({ color });
   },
   setAudio: (audio) => set({ audio }),
+  setSentiment: (sentiment) => set({ sentiment }),
 }));
 

--- a/src/utils/auroraChat.ts
+++ b/src/utils/auroraChat.ts
@@ -70,7 +70,7 @@ async function getProfile(): Promise<UserProfile | null> {
 export async function auroraChat(
   messages: ChatMessage[],
   options: ChatOptions = {},
-): Promise<{ content: string }> {
+): Promise<{ content: string; sentiment: number }> {
   const profile = await getProfile();
   const systemMessages = buildSystemMessages(profile);
 
@@ -84,12 +84,12 @@ export async function auroraChat(
   else if (preference === 'cloud') route = 'cloud';
   else if (offline || lowBandwidth) route = 'local';
 
-  const { content } = await routeChat(
+  const { content, sentiment } = await routeChat(
     [...systemMessages, ...messages],
     profile,
     { ...options, route, fallbackToCloud },
   );
   let filtered = content;
   for (const filter of brain.filters) filtered = filter(filtered);
-  return { content: filtered };
+  return { content: filtered, sentiment };
 }

--- a/src/utils/sentiment.ts
+++ b/src/utils/sentiment.ts
@@ -1,0 +1,15 @@
+export function analyzeSentiment(text: string): number {
+  const positive = ['good', 'great', 'happy', 'love', 'wonderful', 'excellent', 'fantastic', 'positive', 'amazing'];
+  const negative = ['bad', 'sad', 'angry', 'hate', 'terrible', 'awful', 'horrible', 'negative', 'upset'];
+  const words = text.toLowerCase().split(/\W+/);
+  let score = 0;
+  for (const w of words) {
+    if (positive.includes(w)) score++;
+    if (negative.includes(w)) score--;
+  }
+  if (words.length === 0) return 0;
+  const normalized = score / words.length;
+  if (normalized > 1) return 1;
+  if (normalized < -1) return -1;
+  return normalized;
+}

--- a/src/voice/voiceio.ts
+++ b/src/voice/voiceio.ts
@@ -80,6 +80,7 @@ export class VoiceIO {
           useVoiceStore.getState().setSpeaking(false);
           this.callbacks.onSpeakingChange?.(false);
           useAvatarStore.getState().setAudio(null);
+          useAvatarStore.getState().setSentiment(0);
         };
         audio.onended = end;
         audio.onerror = (e) => {
@@ -115,6 +116,7 @@ export class VoiceIO {
     try { this.audio?.pause(); } catch {}
     this.audio = null;
     useAvatarStore.getState().setAudio(null);
+    useAvatarStore.getState().setSentiment(0);
     try { window.speechSynthesis.cancel(); } catch {}
     useVoiceStore.getState().setSpeaking(false);
     this.callbacks.onSpeakingChange?.(false);

--- a/supabase/functions/aurora-chat/index.ts
+++ b/supabase/functions/aurora-chat/index.ts
@@ -5,6 +5,7 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import brain from "../../../src/brain/Brain.ts";
 import { getFilterName } from "../../../src/brain/filters.ts";
 import { summarizeProfile, UserProfile } from "../../../src/data/profile.ts";
+import { analyzeSentiment } from "../../../src/utils/sentiment.ts";
 
 
 const corsHeaders = {
@@ -116,7 +117,9 @@ serve(async (req) => {
       content = filter(content);
     }
 
-    return new Response(JSON.stringify({ content }), {
+    const sentiment = analyzeSentiment(content);
+
+    return new Response(JSON.stringify({ content, sentiment }), {
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- add AvatarSphere Three.js component reacting to sentiment and audio
- expose sentiment score from chat backend and route through front-end
- update avatar state and agent to drive real-time visual changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a95d043508326acc7075522100db4