### PR TITLE
feat: add planner agent and plan storage

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,4 +1,5 @@
 """Specialized agent modules."""
 from .coaching import CoachingAgent
+from .planner import PlannerAgent
 
-__all__ = ["CoachingAgent"]
+__all__ = ["CoachingAgent", "PlannerAgent"]

--- a/agents/planner.py
+++ b/agents/planner.py
@@ -1,0 +1,46 @@
+"""Simple planning agent for breaking goals into steps.
+
+This module defines :class:`PlannerAgent` which can generate a small
+checklist for a given goal.  Plans are also persisted via the memory
+store using the ``plan`` tag so they can be retrieved later.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from memory import store
+
+
+@dataclass
+class PlannerAgent:
+    """Generate basic plans for user goals."""
+
+    def can_handle(self, message: str) -> bool:
+        """Return ``True`` if ``message`` appears to be a planning request."""
+
+        return message.lower().strip().startswith("plan")
+
+    def plan(self, goal: str) -> List[str]:
+        """Produce a list of steps for ``goal``."""
+
+        goal_phrase = goal.strip() or "the goal"
+        return [
+            f"Define what '{goal_phrase}' means to you",
+            "Break the outcome into actionable tasks",
+            "Schedule time blocks for each task",
+            "Review progress and adjust the plan",
+        ]
+
+    def handle(self, message: str, context: str) -> str:
+        """Generate a plan and persist it to memory."""
+
+        goal = message.split(" ", 1)[1] if " " in message else ""
+        goal = goal.strip() or "your goal"
+        steps = self.plan(goal)
+        store.save_plan(goal, steps)
+        numbered = "\n".join(
+            f"{i + 1}. {step}" for i, step in enumerate(steps)
+        )
+        return f"Plan for {goal}:\n{numbered}"
+

--- a/memory/store.py
+++ b/memory/store.py
@@ -49,6 +49,27 @@ def save_memory(text: str, metadata: Dict[str, Any] | None = None) -> int:
     return mem_id
 
 
+def save_plan(goal: str, steps: List[str]) -> int:
+    """Persist a plan in the memory database.
+
+    Parameters
+    ----------
+    goal:
+        Goal the plan addresses.
+    steps:
+        Ordered list of steps for achieving the goal.
+
+    Returns
+    -------
+    int
+        ID of the stored memory entry.
+    """
+
+    text = f"Plan for {goal}: " + " | ".join(steps)
+    metadata = {"tag": "plan", "goal": goal, "steps": steps}
+    return save_memory(text, metadata)
+
+
 def query_memory(query: str, k: int = 5) -> List[Dict[str, Any]]:
     if collection is None:
         return []


### PR DESCRIPTION
## Summary
- add `PlannerAgent` for generating and saving step-by-step plans
- persist plans with new `save_plan` helper tagged as `plan`
- export `PlannerAgent` through agents package

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a95d2d48883269a0ac5cb3bd3c11e