### PR TITLE
Add safety filter and hypnosis consent checks

### DIFF
--- a/core/brain.py
+++ b/core/brain.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from typing import Callable, Iterable, Protocol, Sequence
 
 from agents.coaching import CoachingAgent
+from safety.filter import filter_output
 
 
 class SupportsAgent(Protocol):
@@ -86,4 +87,4 @@ class BrainAgent:
             coaching = self.coach.generate(context)
             response = f"{response}\n\n{coaching}".strip()
 
-        return response
+        return filter_output(response)

--- a/safety/__init__.py
+++ b/safety/__init__.py
@@ -1,0 +1,1 @@
+"""Safety package providing moderation utilities."""

--- a/safety/filter.py
+++ b/safety/filter.py
@@ -1,0 +1,67 @@
+"""Basic content moderation filter.
+
+This module provides :func:`filter_output` which scans text for harmful
+content using simple keyword checks and, when available, an open-source
+moderation model from Hugging Face's ``transformers`` library. If harmful
+content is detected, the text is replaced with a gentle warning and the
+incident is logged to ``filter.log``.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Iterable
+
+# Configure logger
+_LOG_PATH = Path(__file__).with_name("filter.log")
+logger = logging.getLogger("aurora.safety")
+if not logger.handlers:
+    _handler = logging.FileHandler(_LOG_PATH)
+    _handler.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(message)s"))
+    logger.addHandler(_handler)
+logger.setLevel(logging.INFO)
+
+# Simple keyword list as a fallback moderation mechanism
+KEYWORDS: Iterable[str] = {
+    "self-harm",
+    "suicide",
+    "kill myself",
+    "murder",
+    "hate",
+    "violence",
+}
+
+# Attempt to load an open-source moderation model if available
+try:  # pragma: no cover - optional dependency
+    from transformers import pipeline  # type: ignore
+
+    _moderator = pipeline("text-classification", model="unitary/toxic-bert")
+except Exception:  # pragma: no cover - runtime failure is acceptable
+    _moderator = None
+
+WARNING_MESSAGE = "\u26a0\ufe0f Content removed for safety."
+
+
+def _is_harmful(text: str) -> bool:
+    """Return ``True`` if ``text`` appears harmful."""
+    lower = text.lower()
+    if any(kw in lower for kw in KEYWORDS):
+        return True
+    if _moderator is not None:
+        try:
+            result = _moderator(text, truncation=True)[0]
+            label = result.get("label", "").lower()
+            score = float(result.get("score", 0))
+            if label in {"toxic", "harmful"} and score >= 0.5:
+                return True
+        except Exception:
+            pass
+    return False
+
+
+def filter_output(text: str) -> str:
+    """Filter ``text`` returning a safe alternative if necessary."""
+    if _is_harmful(text):
+        logger.warning("blocked: %s", text.replace("\n", " ")[:200])
+        return WARNING_MESSAGE
+    return text

--- a/src/agent/tool-impl.test.ts
+++ b/src/agent/tool-impl.test.ts
@@ -5,7 +5,8 @@ jest.mock('@/components/ui/use-toast', () => ({ toast: jest.fn() }));
 
 // minimal DOM stubs
 const dispatchEvent = jest.fn();
-(global as any).window = { dispatchEvent };
+const confirm = jest.fn(() => true);
+(global as any).window = { dispatchEvent, confirm };
 class CustomEventMock<T> {
   type: string;
   detail: T;
@@ -19,6 +20,8 @@ class CustomEventMock<T> {
 describe('ToolImpl.start_focus', () => {
   beforeEach(() => {
     dispatchEvent.mockClear();
+    confirm.mockClear();
+    confirm.mockReturnValue(true);
     (toast as jest.Mock).mockClear();
   });
 
@@ -38,6 +41,8 @@ describe('ToolImpl.start_focus', () => {
 describe('ToolImpl.start_hypnosis', () => {
   beforeEach(() => {
     dispatchEvent.mockClear();
+    confirm.mockClear();
+    confirm.mockReturnValue(true);
     (toast as jest.Mock).mockClear();
   });
 
@@ -51,5 +56,12 @@ describe('ToolImpl.start_hypnosis', () => {
     const res = await ToolImpl.start_hypnosis({ mode: 'calm', duration: 0 });
     expect(res).toEqual({ ok: false });
     expect(toast).toHaveBeenCalledWith(expect.objectContaining({ title: 'Invalid duration' }));
+  });
+
+  it('requires user confirmation', async () => {
+    confirm.mockReturnValueOnce(false);
+    const res = await ToolImpl.start_hypnosis({ mode: 'focus' });
+    expect(res).toEqual({ ok: false });
+    expect(toast).toHaveBeenCalledWith(expect.objectContaining({ title: 'Hypnosis cancelled' }));
   });
 });

--- a/src/agent/tool-impl.ts
+++ b/src/agent/tool-impl.ts
@@ -48,7 +48,15 @@ export const ToolImpl = {
       return { ok: false } as any;
     }
     if (hypnosis) {
-      window.dispatchEvent(new CustomEvent('mos', { detail: { type: 'startHypnosis' } }));
+      const consent = typeof window !== 'undefined' && typeof window.confirm === 'function'
+        ? window.confirm('Begin hypnosis session?')
+        : false;
+      if (consent) {
+        window.dispatchEvent(new CustomEvent('mos', { detail: { type: 'startHypnosis' } }));
+      } else {
+        toast({ title: 'Hypnosis cancelled' });
+        hypnosis = null;
+      }
     }
     window.dispatchEvent(new CustomEvent('mos', { detail: { type: 'startFocus' } }));
     toast({ title: `Focus started`, description: `${minutes} minutes${hypnosis ? ` · with ${hypnosis}` : ''}` });
@@ -59,6 +67,13 @@ export const ToolImpl = {
     duration = Math.round(duration);
     if (!Number.isFinite(duration) || duration < 1 || duration > 600) {
       toast({ title: "Invalid duration", description: "Duration must be between 1 and 600 seconds." });
+      return { ok: false } as any;
+    }
+    const consent = typeof window !== 'undefined' && typeof window.confirm === 'function'
+      ? window.confirm('Begin hypnosis session?')
+      : false;
+    if (!consent) {
+      toast({ title: 'Hypnosis cancelled' });
       return { ok: false } as any;
     }
     window.dispatchEvent(new CustomEvent('mos', { detail: { type: 'startHypnosis' } }));


### PR DESCRIPTION
## Summary
- add Python safety filter with keyword and optional transformer moderation, logging flagged output
- route BrainAgent responses through safety filter
- prompt for user confirmation before starting hypnosis sessions and test cancellation path

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any, no-empty)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689aa5fc17088326bba26ab09557646c