### PR TITLE
Add onboarding flow with voice sample

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import HypnoShell from "@/routes/hypno/HypnoShell";
 import ExtensionPage from "@/pages/Extension";
 import StackPage from "./pages/Stack";
 import AppShell from "@/routes/AppShell";
-import OnboardingFlow from "./pages/OnboardingFlow";
+import Onboarding from "./pages/Onboarding";
 import PersonaSetup from "./pages/PersonaSetup";
 const queryClient = new QueryClient();
 
@@ -28,7 +28,7 @@ const App = () => (
           <Route path="/world" element={<MindWorldDashboard />} />
           <Route path="/home" element={<Index />} />
           <Route path="/auth" element={<AuthPage />} />
-          <Route path="/onboarding" element={<OnboardingFlow />} />
+          <Route path="/onboarding" element={<Onboarding />} />
           <Route path="/browser" element={<Navigate to="/app/browser" replace />} />
           <Route path="/hypno" element={<HypnoShell />} />
           <Route path="/extension" element={<ExtensionPage />} />

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import VoiceSetup from "@/components/VoiceSetup";
+import { useVoiceStore } from "@/state/voice";
+import { supabase } from "@/integrations/supabase/client";
+import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
+
+export default function Onboarding() {
+  const navigate = useNavigate();
+  const { user } = useSupabaseAuth();
+  const voiceId = useVoiceStore((s) => s.voiceId);
+  const [step, setStep] = useState(0);
+  const [name, setName] = useState("");
+  const [goals, setGoals] = useState("");
+
+  const saveProfile = async () => {
+    const data = { name, goals, voiceId };
+    try {
+      const fs = await import("fs");
+      const path = await import("path");
+      const filePath = path.resolve("persona", "profile.json");
+      await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.promises.writeFile(filePath, JSON.stringify(data, null, 2));
+    } catch (err) {
+      console.error("Failed to save profile.json", err);
+    }
+    if (user) {
+      await supabase
+        .from("profiles")
+        .update({
+          persona: { name, goals, voiceId },
+          onboarded_at: new Date().toISOString(),
+        })
+        .eq("id", user.id);
+    }
+  };
+
+  const next = async () => {
+    if (step === 2) {
+      await saveProfile();
+      navigate("/app");
+    } else {
+      setStep((s) => s + 1);
+    }
+  };
+
+  const disabled =
+    (step === 0 && !name.trim()) ||
+    (step === 1 && !goals.trim()) ||
+    (step === 2 && !voiceId);
+
+  return (
+    <div className="min-h-svh flex flex-col items-center justify-center gap-4 p-4">
+      {step === 0 && (
+        <div className="w-full max-w-sm space-y-2">
+          <p className="text-sm">What's your name?</p>
+          <Input value={name} onChange={(e) => setName(e.target.value)} />
+        </div>
+      )}
+      {step === 1 && (
+        <div className="w-full max-w-sm space-y-2">
+          <p className="text-sm">What are your goals?</p>
+          <Textarea
+            value={goals}
+            onChange={(e) => setGoals(e.target.value)}
+            className="resize-none"
+          />
+        </div>
+      )}
+      {step === 2 && (
+        <div className="w-full max-w-sm space-y-2">
+          <p className="text-sm">Record a short voice sample.</p>
+          <VoiceSetup />
+        </div>
+      )}
+      <Button onClick={next} disabled={disabled}>
+        {step < 2 ? "Next" : "Finish"}
+      </Button>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- replace /onboarding route with new multi-step onboarding
- collect user's name, goals, and voice sample
- save onboarding data to persona/profile.json and supabase
- redirect to main chat after onboarding completes

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, Empty block statement, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689aca2a73708326b2f634856fea9b2b