### PR TITLE
feat: add encrypted memory backup

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -1,0 +1,20 @@
+# Data Backup
+
+Aurora can create an encrypted archive of the local memory database so that your information can be preserved or migrated.
+
+## Create a backup
+
+1. Open **Settings** in the app.
+2. Choose **Backup Data**.
+3. Enter a passphrase and select where to save the file. An encrypted `.bin` archive will be written.
+
+## Restore a backup
+
+1. Ensure Aurora is closed.
+2. Run the helper script, providing the path to the backup and the passphrase used during export:
+
+```bash
+python -m memory.backup import /path/to/backup.bin --passphrase "your-passphrase"
+```
+
+The command decrypts the archive and restores `memory.db` and `chroma_db` in the `memory/` directory.

--- a/memory/backup.py
+++ b/memory/backup.py
@@ -1,0 +1,80 @@
+import os
+import io
+import tarfile
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+from cryptography.hazmat.primitives import hashes
+
+from .store import DB_PATH, CHROMA_PATH
+
+
+def _derive_key(passphrase: str, salt: bytes) -> bytes:
+    """Derive a 32-byte AES key from the provided passphrase."""
+    kdf = PBKDF2HMAC(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=salt,
+        iterations=200_000,
+    )
+    return kdf.derive(passphrase.encode("utf-8"))
+
+
+def export_backup(path: str, passphrase: str) -> None:
+    """Export the memory database and embeddings as an encrypted archive."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        if os.path.exists(DB_PATH):
+            tar.add(DB_PATH, arcname="memory.db")
+        if os.path.exists(CHROMA_PATH):
+            tar.add(CHROMA_PATH, arcname="chroma_db")
+    data = buf.getvalue()
+
+    salt = os.urandom(16)
+    key = _derive_key(passphrase, salt)
+    nonce = os.urandom(12)
+    aes = AESGCM(key)
+    ct = aes.encrypt(nonce, data, None)
+
+    with open(path, "wb") as f:
+        f.write(salt + nonce + ct)
+
+
+def _safe_extract(tar: tarfile.TarFile, path: str) -> None:
+    """Safely extract a tarfile to the given path."""
+    for member in tar.getmembers():
+        member_path = os.path.join(path, member.name)
+        abs_target = os.path.abspath(path)
+        abs_member = os.path.abspath(member_path)
+        if not abs_member.startswith(abs_target):
+            raise RuntimeError("Attempted Path Traversal in Tar File")
+    tar.extractall(path)
+
+
+def import_backup(path: str, passphrase: str) -> None:
+    """Restore the memory database and embeddings from an encrypted archive."""
+    with open(path, "rb") as f:
+        raw = f.read()
+    salt, nonce, ct = raw[:16], raw[16:28], raw[28:]
+    key = _derive_key(passphrase, salt)
+    aes = AESGCM(key)
+    data = aes.decrypt(nonce, ct, None)
+
+    buf = io.BytesIO(data)
+    with tarfile.open(fileobj=buf, mode="r:gz") as tar:
+        _safe_extract(tar, os.path.dirname(DB_PATH))
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Backup or restore the memory store")
+    parser.add_argument("command", choices=["export", "import"])
+    parser.add_argument("path", help="Path to output (export) or input (import) file")
+    parser.add_argument("--passphrase", required=True, help="Encryption passphrase")
+    args = parser.parse_args()
+
+    if args.command == "export":
+        export_backup(args.path, args.passphrase)
+    else:
+        import_backup(args.path, args.passphrase)

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -58,6 +58,24 @@ export default function SettingsView() {
     toast({ title: "Profile deleted", description: "Your profile has been removed." });
   };
 
+  const handleBackup = async () => {
+    const passphrase = prompt("Enter backup passphrase") || "";
+    if (!passphrase) return;
+    const picker = await (window as any).showSaveFilePicker({
+      suggestedName: "aurora-backup.bin",
+    });
+    const writable = await picker.createWritable();
+    const res = await fetch("/api/backup/export", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ passphrase }),
+    });
+    const blob = await res.blob();
+    await writable.write(blob);
+    await writable.close();
+    toast({ title: "Backup exported", description: "Encrypted backup saved." });
+  };
+
   return (
     <div className="container mx-auto px-4 py-6 space-y-4">
       <h1 className="text-2xl font-semibold">Settings</h1>
@@ -68,6 +86,9 @@ export default function SettingsView() {
             <div className="flex flex-wrap gap-2">
               <Button variant="outline" onClick={handleExport}>
                 Export Profile
+              </Button>
+              <Button variant="outline" onClick={handleBackup}>
+                Backup Data
               </Button>
               <AlertDialog>
                 <AlertDialogTrigger asChild>


### PR DESCRIPTION
## Summary
- add AES-encrypted backup and restore utilities for memory database
- expose "Backup Data" button in settings to download an encrypted archive
- document how to create and restore backups

## Testing
- `python -m py_compile memory/backup.py`
- `python - <<'PY'
from memory.backup import export_backup, import_backup
import os

tmp = '/tmp/test-backup.bin'
export_backup(tmp, 'secret')
print('exported', os.path.getsize(tmp))
import_backup(tmp, 'secret')
print('imported')
os.remove(tmp)
PY`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689aca2bfb208326ae512c647a9a3451