### PR TITLE
feat: add JSON logging and metrics endpoint

### DIFF
--- a/core/brain.py
+++ b/core/brain.py
@@ -11,6 +11,8 @@ from typing import Callable, Iterable, Protocol, Sequence
 
 from agents.coaching import CoachingAgent
 from safety.filter import filter_output
+from .logger import get_logger
+from .metrics import metrics
 
 
 class SupportsAgent(Protocol):
@@ -56,7 +58,7 @@ class BrainAgent:
         "Relevant memories:\n{memories}\n"
     )
 
-    def process(self, message: str) -> str:
+    def process(self, message: str, request_id: str | None = None) -> str:
         """Process a user ``message`` by delegating to a sub-agent.
 
         The method retrieves persona and memory snippets, constructs the
@@ -65,8 +67,21 @@ class BrainAgent:
         returned so callers can decide how to handle it.
         """
 
+        logger = get_logger(__name__)
+        metrics.conversations += 1
+        logger.info("processing message", extra={"request_id": request_id, "agent": "BrainAgent"})
+
         persona = self.persona_store() or ""
-        memories = list(self.memory_store(message))
+
+        try:
+            memories = list(self.memory_store(message))
+        except Exception:
+            metrics.errors += 1
+            logger.exception("memory store error", extra={"request_id": request_id, "agent": "memory_store"})
+            memories = []
+        else:
+            metrics.memory_queries += 1
+
         memory_text = "\n".join(memories)
         context = self.prompt_template.format(persona=persona, memories=memory_text)
 
@@ -74,10 +89,21 @@ class BrainAgent:
         for agent in self.agents:
             try:
                 if agent.can_handle(message):
+                    logger.info(
+                        "invoking agent",
+                        extra={
+                            "request_id": request_id,
+                            "agent": type(agent).__name__,
+                        },
+                    )
                     response = agent.handle(message, context)
                     break
             except Exception:
-                # A misbehaving agent should not crash the BrainAgent
+                metrics.errors += 1
+                logger.exception(
+                    "agent error",
+                    extra={"request_id": request_id, "agent": type(agent).__name__},
+                )
                 continue
 
         if response is None:

--- a/core/logger.py
+++ b/core/logger.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+import logging
+from logging.handlers import TimedRotatingFileHandler
+from pathlib import Path
+
+
+LOG_DIR = Path(__file__).resolve().parent.parent / "logs"
+LOG_DIR.mkdir(exist_ok=True)
+LOG_FILE = LOG_DIR / "app.log"
+
+
+class JsonFormatter(logging.Formatter):
+    """Format log records as JSON with request and agent metadata."""
+
+    def format(self, record: logging.LogRecord) -> str:  # type: ignore[override]
+        log_record = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "message": record.getMessage(),
+            "request_id": getattr(record, "request_id", None),
+            "agent": getattr(record, "agent", None),
+        }
+        return json.dumps(log_record)
+
+
+_handler = TimedRotatingFileHandler(LOG_FILE, when="midnight")
+_handler.setFormatter(JsonFormatter())
+
+logging.basicConfig(level=logging.INFO, handlers=[_handler])
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a logger configured for JSON output and daily rotation."""
+
+    return logging.getLogger(name)

--- a/core/metrics.py
+++ b/core/metrics.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+
+@dataclass
+class Metrics:
+    conversations: int = 0
+    memory_queries: int = 0
+    errors: int = 0
+
+    def as_dict(self) -> dict[str, int]:
+        return asdict(self)
+
+
+metrics = Metrics()

--- a/voice/server.py
+++ b/voice/server.py
@@ -10,10 +10,18 @@ from fastapi import FastAPI, Request
 from aiortc import RTCPeerConnection, RTCSessionDescription
 from aiortc.contrib.media import MediaRecorder
 
+from core.metrics import metrics
 from .stt import transcribe_audio
 from .tts import synthesize_reply
 
 app = FastAPI()
+
+
+@app.get("/metrics")
+async def metrics_endpoint():
+    """Expose application metrics."""
+
+    return metrics.as_dict()
 
 
 @app.post("/voice")


### PR DESCRIPTION
## Summary
- add JSON logging with daily rotation
- expose metrics endpoint for conversations, memory queries, and errors

## Testing
- `python -m py_compile core/*.py voice/server.py`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689acb7d6d7c83268226129a58c0923e