### PR TITLE
feat(settings): add settings panel with persistence

### DIFF
--- a/frontend/components/SettingsPanel.jsx
+++ b/frontend/components/SettingsPanel.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { useAppSettings } from '../../src/state/settings.ts';
+
+export default function SettingsPanel({ open, onClose }) {
+  const {
+    voiceOutput,
+    hypnosisMode,
+    memoryRetention,
+    toggleVoiceOutput,
+    toggleHypnosisMode,
+    setMemoryRetention,
+  } = useAppSettings();
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        right: 0,
+        height: '100%',
+        width: '260px',
+        background: 'white',
+        boxShadow: '-2px 0 8px rgba(0,0,0,0.2)',
+        transform: open ? 'translateX(0)' : 'translateX(100%)',
+        transition: 'transform 0.3s ease-in-out',
+        zIndex: 1000,
+      }}
+    >
+      <div style={{ padding: '16px' }}>
+        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '12px' }}>Settings</h2>
+        <label style={{ display: 'flex', alignItems: 'center', marginBottom: '12px' }}>
+          <input type="checkbox" checked={voiceOutput} onChange={toggleVoiceOutput} style={{ marginRight: '8px' }} />
+          Voice Output
+        </label>
+        <label style={{ display: 'flex', alignItems: 'center', marginBottom: '12px' }}>
+          <input type="checkbox" checked={hypnosisMode} onChange={toggleHypnosisMode} style={{ marginRight: '8px' }} />
+          Hypnosis Mode
+        </label>
+        <label style={{ display: 'flex', flexDirection: 'column', marginBottom: '12px' }}>
+          <span style={{ marginBottom: '4px' }}>Memory Retention (days): {memoryRetention}</span>
+          <input
+            type="range"
+            min="1"
+            max="365"
+            value={memoryRetention}
+            onChange={(e) => setMemoryRetention(Number(e.target.value))}
+          />
+        </label>
+        <button onClick={onClose} style={{ marginTop: '8px', padding: '4px 8px', border: '1px solid #ccc', borderRadius: '4px' }}>
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/settings/config.json
+++ b/settings/config.json
@@ -1,0 +1,5 @@
+{
+  "voiceOutput": true,
+  "hypnosisMode": false,
+  "memoryRetention": 30
+}

--- a/src/components/game/GameHUD.tsx
+++ b/src/components/game/GameHUD.tsx
@@ -6,6 +6,7 @@ import { AvatarSphere } from "@/components/avatar/AvatarSphere";
 import { Mic, ChevronDown, ChevronUp } from "lucide-react";
 import { useHUDActions } from "@/game/hud/useHUDActions";
 import { useAvatarStore } from "@/state/avatar";
+import SettingsPanel from "../../../frontend/components/SettingsPanel.jsx";
 
 function fire(type: string, payload?: any) {
   window.dispatchEvent(new CustomEvent('mos', { detail: { type, payload } }));
@@ -15,6 +16,7 @@ export function GameHUD() {
   const stats = useGameStore((s) => s.stats);
   const { run } = useHUDActions();
   const avatarEnabled = useAvatarStore((s) => s.enabled);
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   // Mobile collapse state
   const isMobile = window.innerWidth <= 768;
@@ -43,14 +45,16 @@ export function GameHUD() {
   }, []);
 
   return (
-    <div
-      className="fixed left-3 right-3"
-      style={{
-        bottom: 'max(12px, env(safe-area-inset-bottom))',
-        zIndex: 'var(--z-hud)',
-        pointerEvents: 'auto',
-      }}
-    >
+    <>
+      <SettingsPanel open={settingsOpen} onClose={() => setSettingsOpen(false)} />
+      <div
+        className="fixed left-3 right-3"
+        style={{
+          bottom: 'max(12px, env(safe-area-inset-bottom))',
+          zIndex: 'var(--z-hud)',
+          pointerEvents: 'auto',
+        }}
+      >
       <div className="hud-panel hud-maple rounded-2xl px-4 py-3 select-none" aria-label="Game HUD">
         <span className="hud-spot" />
         <div className="flex flex-col gap-3">
@@ -101,6 +105,17 @@ export function GameHUD() {
                 <span className="hidden sm:inline text-sm">Agent</span>
               </button>
             </li>
+            <li className="snap-start">
+              <button
+                type="button"
+                className="action-chip"
+                aria-label="Open Settings"
+                title="Settings"
+                onClick={() => setSettingsOpen(true)}
+              >
+                <span className="text-sm font-medium">Settings</span>
+              </button>
+            </li>
           </ul>
         </div>
 
@@ -146,5 +161,6 @@ export function GameHUD() {
         )}
       </div>
     </div>
+    </>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,10 +4,13 @@ import ErrorBoundary from './components/ErrorBoundary'
 import './index.css'
 import './styles/hud-fixes.css'
 import { registerSW } from 'virtual:pwa-register';
+import { initSettings } from './state/settings';
 
 if ('serviceWorker' in navigator) {
   registerSW({ immediate: true })
 }
+
+initSettings();
 
 createRoot(document.getElementById('root')!).render(
   <ErrorBoundary>

--- a/src/state/settings.ts
+++ b/src/state/settings.ts
@@ -1,0 +1,55 @@
+import { create } from 'zustand';
+import { readFileSync, writeFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const configPath = path.resolve(__dirname, '../../settings/config.json');
+
+export interface AppSettings {
+  voiceOutput: boolean;
+  hypnosisMode: boolean;
+  memoryRetention: number;
+}
+
+function loadSettings(): AppSettings {
+  try {
+    const raw = readFileSync(configPath, 'utf-8');
+    return JSON.parse(raw) as AppSettings;
+  } catch {
+    return { voiceOutput: true, hypnosisMode: false, memoryRetention: 30 };
+  }
+}
+
+function saveSettings(s: AppSettings) {
+  writeFileSync(configPath, JSON.stringify(s, null, 2));
+}
+
+const initial = loadSettings();
+
+export const useAppSettings = create<AppSettings & {
+  toggleVoiceOutput: () => void;
+  toggleHypnosisMode: () => void;
+  setMemoryRetention: (v: number) => void;
+}>((set, get) => ({
+  ...initial,
+  toggleVoiceOutput() {
+    const next = { ...get(), voiceOutput: !get().voiceOutput };
+    saveSettings(next);
+    set(next);
+  },
+  toggleHypnosisMode() {
+    const next = { ...get(), hypnosisMode: !get().hypnosisMode };
+    saveSettings(next);
+    set(next);
+  },
+  setMemoryRetention(v: number) {
+    const next = { ...get(), memoryRetention: v };
+    saveSettings(next);
+    set(next);
+  },
+}));
+
+export function initSettings() {
+  useAppSettings.getState();
+}


### PR DESCRIPTION
## Summary
- add settings store backed by `settings/config.json`
- build sliding `SettingsPanel` UI with voice, hypnosis, and memory retention controls
- wire Settings button in HUD and load settings at startup

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, Empty block statements, require imports)*

------
https://chatgpt.com/codex/tasks/task_e_689acb7f1f188326ad16043a15ca6e17