### PR TITLE
Add conversation flow test and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install --upgrade pip && pip install fastapi httpx pytest
+      - name: Run tests
+        run: python -m pytest

--- a/tests/test_conversation_flow.py
+++ b/tests/test_conversation_flow.py
@@ -1,0 +1,61 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from core.brain import BrainAgent
+
+app = FastAPI()
+
+state = {
+    "persona": "",
+    "memories": [],
+}
+
+
+@app.post("/onboard")
+def onboard(payload: dict):
+    """Store the user's persona information."""
+    state["persona"] = payload["persona"]
+    return {"status": "ok"}
+
+
+@app.post("/chat")
+def chat(payload: dict):
+    """Process a chat message and persist it to memory."""
+    message = payload["message"]
+    brain = BrainAgent(
+        persona_store=lambda: state["persona"],
+        memory_store=lambda _msg: state["memories"],
+    )
+    reply = brain.process(message)
+    state["memories"].append(message)
+    return {"reply": reply}
+
+
+@app.get("/memory")
+def get_memory():
+    """Return stored memory snippets."""
+    return {"memories": state["memories"]}
+
+
+def test_conversation_flow():
+    client = TestClient(app)
+
+    # Onboarding step
+    res = client.post("/onboard", json={"persona": "curious coder"})
+    assert res.status_code == 200
+    assert res.json() == {"status": "ok"}
+
+    # First chat message is saved to memory
+    res = client.post("/chat", json={"message": "I love unit tests"})
+    assert res.status_code == 200
+    assert "Persona: curious coder" in res.json()["reply"]
+
+    # Second chat should retrieve previous memory
+    res = client.post("/chat", json={"message": "What do I love?"})
+    assert res.status_code == 200
+    assert "I love unit tests" in res.json()["reply"]
+
+    # Direct memory retrieval
+    res = client.get("/memory")
+    assert res.status_code == 200
+    assert "I love unit tests" in res.json()["memories"]


### PR DESCRIPTION
## Summary
- add FastAPI TestClient test covering onboarding → chat → memory retrieval
- run Python unit tests in GitHub Actions

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689acdda294c8326a3f00944785aae8f