### PR TITLE
Apply persona style to BrainAgent responses

### DIFF
--- a/core/__tests__/test_style_application.py
+++ b/core/__tests__/test_style_application.py
@@ -1,0 +1,49 @@
+"""Tests for ensuring persona style is applied to BrainAgent responses."""
+
+from core.brain import BrainAgent
+from persona import style as persona_style
+
+
+class DummyAgent:
+    """Simple agent that always returns a static response."""
+
+    def can_handle(self, message: str) -> bool:  # pragma: no cover - simple stub
+        return True
+
+    def handle(self, message: str, context: str) -> str:  # pragma: no cover - simple stub
+        return "base response"
+
+
+def _make_brain() -> BrainAgent:
+    return BrainAgent(persona_store=lambda: "", memory_store=lambda _msg: [], agents=[DummyAgent()])
+
+
+def test_tone_is_applied(monkeypatch):
+    """The tone from the persona profile should prefix the response."""
+
+    monkeypatch.setattr(
+        persona_style,
+        "_load_profile",
+        lambda: {"tone": "cheerful", "catchphrases": []},
+    )
+    brain = _make_brain()
+
+    result = brain.process("hello")
+
+    assert result == "[cheerful] base response"
+
+
+def test_catchphrases_are_applied(monkeypatch):
+    """Catchphrases from the persona profile should wrap the response."""
+
+    monkeypatch.setattr(
+        persona_style,
+        "_load_profile",
+        lambda: {"tone": "", "catchphrases": ["yo", "buddy"]},
+    )
+    brain = _make_brain()
+
+    result = brain.process("hello")
+
+    assert result == "yo base response buddy"
+

--- a/core/brain.py
+++ b/core/brain.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from typing import Callable, Iterable, Protocol, Sequence
 
 from agents.coaching import CoachingAgent
+from persona.style import apply_style
 from safety.filter import filter_output
 from .logger import get_logger
 from .metrics import metrics
@@ -113,4 +114,5 @@ class BrainAgent:
             coaching = self.coach.generate(context)
             response = f"{response}\n\n{coaching}".strip()
 
+        response = apply_style(response)
         return filter_output(response)


### PR DESCRIPTION
## Summary
- style BrainAgent outputs using persona's tone and catchphrases
- add unit tests verifying tone and catchphrase application

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689acf6c2f2c8326abbce86204417875