### PR TITLE
Persist chat messages asynchronously

### DIFF
--- a/core/brain.py
+++ b/core/brain.py
@@ -6,10 +6,13 @@ dispatching a user message to a suitable sub-agent.
 """
 from __future__ import annotations
 
+import asyncio
+import threading
 from dataclasses import dataclass, field
 from typing import Callable, Iterable, Protocol, Sequence
 
 from agents.coaching import CoachingAgent
+from memory.store import save_memory
 from safety.filter import filter_output
 from .logger import get_logger
 from .metrics import metrics
@@ -57,6 +60,18 @@ class BrainAgent:
         "Persona: {persona}\n"
         "Relevant memories:\n{memories}\n"
     )
+
+    def _save_memory_async(self, text: str, role: str) -> None:
+        """Persist ``text`` with ``role`` metadata without blocking."""
+        metadata = {"role": role}
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            threading.Thread(
+                target=save_memory, args=(text, metadata), daemon=True
+            ).start()
+        else:
+            loop.run_in_executor(None, save_memory, text, metadata)
 
     def process(self, message: str, request_id: str | None = None) -> str:
         """Process a user ``message`` by delegating to a sub-agent.
@@ -113,4 +128,7 @@ class BrainAgent:
             coaching = self.coach.generate(context)
             response = f"{response}\n\n{coaching}".strip()
 
-        return filter_output(response)
+        final = filter_output(response)
+        self._save_memory_async(message, "user")
+        self._save_memory_async(final, "assistant")
+        return final

--- a/memory/store.py
+++ b/memory/store.py
@@ -1,6 +1,7 @@
 import os
 import json
 import sqlite3
+import threading
 from typing import Any, Dict, List
 
 try:
@@ -12,8 +13,9 @@ except Exception:  # pragma: no cover - chromadb optional
 DB_PATH = os.path.join(os.path.dirname(__file__), "memory.db")
 CHROMA_PATH = os.path.join(os.path.dirname(__file__), "chroma_db")
 
-conn = sqlite3.connect(DB_PATH)
+conn = sqlite3.connect(DB_PATH, check_same_thread=False)
 cur = conn.cursor()
+db_lock = threading.Lock()
 cur.execute(
     """
     CREATE TABLE IF NOT EXISTS memories (
@@ -38,12 +40,13 @@ if chromadb is not None:
 
 def save_memory(text: str, metadata: Dict[str, Any] | None = None) -> int:
     metadata = metadata or {}
-    cur.execute(
-        "INSERT INTO memories (text, metadata) VALUES (?, ?)",
-        (text, json.dumps(metadata)),
-    )
-    mem_id = cur.lastrowid
-    conn.commit()
+    with db_lock:
+        cur.execute(
+            "INSERT INTO memories (text, metadata) VALUES (?, ?)",
+            (text, json.dumps(metadata)),
+        )
+        mem_id = cur.lastrowid
+        conn.commit()
     if collection is not None:
         collection.add(documents=[text], metadatas=[metadata], ids=[str(mem_id)])
     return mem_id


### PR DESCRIPTION
## Summary
- Save user prompts and assistant replies in the long-term memory store.
- Use background tasks to persist memories without blocking the BrainAgent.
- Make memory storage thread-safe by allowing cross-thread SQLite access.

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689acf6f6e9c83269c89d7c5c546ecb5