### PR TITLE
Expand hypnosis agent script phases

### DIFF
--- a/agents/hypnosis.py
+++ b/agents/hypnosis.py
@@ -1,6 +1,7 @@
 """Hypnosis agent generating brief guided imagery scripts."""
 
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass
@@ -8,21 +9,48 @@ class HypnosisAgent:
     """Generate guided imagery scripts with a positive anchor."""
 
     @staticmethod
-    def generate(context: str, goal: str) -> str:
-        """Return a short hypnotic script.
+    def generate(
+        context: str,
+        goal: str,
+        duration: Optional[int] = None,
+        mode: Optional[str] = None,
+    ) -> str:
+        """Return a structured hypnotic script.
 
         Args:
             context: Current user state or surroundings.
             goal: Desired outcome for the session.
+            duration: Optional length of the session in seconds.
+            mode: Focus of the session, e.g. "confidence", "calm", "focus", "reset".
 
         Returns:
-            A brief guided imagery script ending with a positive anchor.
+            A multi‑section guided imagery script ending with a positive anchor.
         """
         context = context.strip()
         goal = goal.strip()
-        return (
-            "Close your eyes and take a slow, deep breath. "
-            f"{context} As you relax, picture {goal} unfolding with ease. "
-            "With each breath, calm confidence spreads through you. "
-            "Whenever you press your thumb and forefinger together, this steady calm returns." 
+
+        mode = (mode or "calm").lower()
+        mode_lines = {
+            "confidence": "a steady confidence fills you with each breath",
+            "focus": "your mind sharpens on what matters most",
+            "calm": "a gentle calm spreads through every part of you",
+            "reset": "you release what no longer serves you and reset",
+        }
+        suggestion = mode_lines.get(mode, mode_lines["calm"])
+        pace = (
+            f"This session lasts about {duration} seconds. " if duration else ""
         )
+
+        sections = [
+            f"Preparation:\n{pace}{context} Allow yourself to get comfortable.",
+            "Induction:\nClose your eyes and take slow, deep breaths, letting tension melt away.",
+            "Deepening:\nWith each count from ten down to one, you feel twice as relaxed, drifting deeper.",
+            (
+                "Suggestion:\nAs you rest, "
+                f"{suggestion}. Visualize {goal} as already unfolding perfectly. "
+                "Whenever you press your thumb and forefinger together, this feeling returns."
+            ),
+            "Awakening:\nTake a final deep breath, gently wiggle your fingers, and open your eyes, bringing this feeling back with you.",
+        ]
+
+        return "\n\n".join(sections)

--- a/docs/hypnosis.md
+++ b/docs/hypnosis.md
@@ -1,0 +1,47 @@
+# Hypnosis Scripts
+
+The `HypnosisAgent` assembles hypnotic guidance in **five phases**:
+
+1. **Preparation** – sets context and pacing so the user can settle in.
+2. **Induction** – guides slow breathing to begin relaxation.
+3. **Deepening** – counts down or uses imagery to drift further inward.
+4. **Suggestion** – mode‑specific affirmations and goal visualization with a positive anchor.
+5. **Awakening** – returns the listener to alertness while preserving the anchor.
+
+Optional parameters let the caller shape pacing or focus:
+
+- `duration`: approximate length of the session in seconds.
+- `mode`: focus of the script such as `"calm"`, `"confidence"`, `"focus"`, or `"reset"`.
+
+## Example
+
+```python
+from agents.hypnosis import HypnosisAgent
+
+text = HypnosisAgent.generate(
+    "It's a quiet evening.",
+    "crush tomorrow's presentation",
+    duration=90,
+    mode="confidence",
+)
+print(text)
+```
+
+Sample output:
+
+```
+Preparation:
+This session lasts about 90 seconds. It's a quiet evening. Allow yourself to get comfortable.
+
+Induction:
+Close your eyes and take slow, deep breaths, letting tension melt away.
+
+Deepening:
+With each count from ten down to one, you feel twice as relaxed, drifting deeper.
+
+Suggestion:
+As you rest, a steady confidence fills you with each breath. Visualize crush tomorrow's presentation as already unfolding perfectly. Whenever you press your thumb and forefinger together, this feeling returns.
+
+Awakening:
+Take a final deep breath, gently wiggle your fingers, and open your eyes, bringing this feeling back with you.
+```


### PR DESCRIPTION
## Summary
- expand HypnosisAgent.generate to create five-phase hypnosis scripts
- allow optional duration and mode parameters to tailor pacing or focus
- document hypnosis script structure with sample output

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core'; ModuleNotFoundError: No module named 'fastapi')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689adcaf2fa48326a6f161bde39c25c2