### PR TITLE
feat: add avatar moods and visual effects

### DIFF
--- a/src/components/avatar/AvatarSphere.stories.tsx
+++ b/src/components/avatar/AvatarSphere.stories.tsx
@@ -1,0 +1,20 @@
+import React, { useEffect } from 'react';
+import { AvatarSphere } from './AvatarSphere';
+import { useAvatarStore, type AvatarMood } from '@/state/avatar';
+
+export default {
+  title: 'Avatar/AvatarSphere',
+  component: AvatarSphere,
+};
+
+function MoodStory({ mood }: { mood: AvatarMood }) {
+  const setMood = useAvatarStore((s) => s.setMood);
+  useEffect(() => {
+    setMood(mood);
+  }, [mood, setMood]);
+  return <AvatarSphere />;
+}
+
+export const Neutral = () => <MoodStory mood="neutral" />;
+export const Focused = () => <MoodStory mood="focused" />;
+export const Relaxed = () => <MoodStory mood="relaxed" />;

--- a/src/components/avatar/AvatarSphere.tsx
+++ b/src/components/avatar/AvatarSphere.tsx
@@ -1,19 +1,20 @@
 import React, { useEffect, useRef } from 'react';
 import * as THREE from 'three';
-import { useAvatarStore } from '@/state/avatar';
+import { useAvatarStore, type AvatarMood } from '@/state/avatar';
 
 interface Props {
   size?: number;
 }
 
 export function AvatarSphere({ size = 96 }: Props) {
-  const { enabled, sentiment, audio } = useAvatarStore();
+  const { enabled, sentiment, audio, mood } = useAvatarStore();
   const mountRef = useRef<HTMLDivElement | null>(null);
   const analyserRef = useRef<AnalyserNode | null>(null);
   const meshRef = useRef<THREE.Mesh | null>(null);
   const matRef = useRef<THREE.MeshStandardMaterial | null>(null);
   const geomRef = useRef<THREE.IcosahedronGeometry | null>(null);
   const basePositions = useRef<Float32Array | null>(null);
+  const moodRef = useRef<AvatarMood>('neutral');
 
   // Setup scene
   useEffect(() => {
@@ -49,7 +50,16 @@ export function AvatarSphere({ size = 96 }: Props) {
         let sum = 0;
         for (let i = 0; i < data.length; i++) sum += Math.abs(data[i] - 128);
         const level = sum / data.length / 128;
-        meshRef.current.scale.setScalar(1 + level * 0.3);
+        const time = performance.now() * 0.001;
+        const mood = moodRef.current;
+        let scale = 1 + level * 0.3;
+        if (mood === 'focused') {
+          meshRef.current.rotation.y += 0.02;
+        } else if (mood === 'relaxed') {
+          meshRef.current.rotation.y += 0.005;
+          scale *= 1 + Math.sin(time) * 0.05;
+        }
+        meshRef.current.scale.setScalar(scale);
       }
       renderer.render(scene, camera);
     };
@@ -112,6 +122,22 @@ export function AvatarSphere({ size = 96 }: Props) {
     geom.computeVertexNormals();
     geom.attributes.position.needsUpdate = true;
   }, [sentiment]);
+
+  // React to avatar mood
+  useEffect(() => {
+    moodRef.current = mood;
+    if (!matRef.current) return;
+    switch (mood) {
+      case 'focused':
+        matRef.current.emissive.set('#3366ff');
+        break;
+      case 'relaxed':
+        matRef.current.emissive.set('#00ffff');
+        break;
+      default:
+        matRef.current.emissive.set('#000000');
+    }
+  }, [mood]);
 
   if (!enabled) return null;
   return <div ref={mountRef} style={{ width: size, height: size }} />;

--- a/src/state/avatar.test.ts
+++ b/src/state/avatar.test.ts
@@ -1,0 +1,10 @@
+import { useAvatarStore } from './avatar';
+
+describe('useAvatarStore', () => {
+  it('handles mood changes', () => {
+    const store = useAvatarStore.getState();
+    expect(store.mood).toBe('neutral');
+    store.setMood('focused');
+    expect(useAvatarStore.getState().mood).toBe('focused');
+  });
+});

--- a/src/state/avatar.ts
+++ b/src/state/avatar.ts
@@ -8,11 +8,15 @@ type AvatarState = {
   color: string;
   audio: HTMLAudioElement | null;
   sentiment: number;
+  mood: AvatarMood;
   setEnabled: (v: boolean) => void;
   setColor: (c: string) => void;
   setAudio: (a: HTMLAudioElement | null) => void;
   setSentiment: (s: number) => void;
+  setMood: (m: AvatarMood) => void;
 };
+
+export type AvatarMood = "neutral" | "focused" | "relaxed";
 
 export const useAvatarStore = create<AvatarState>((set) => ({
   enabled:
@@ -25,6 +29,7 @@ export const useAvatarStore = create<AvatarState>((set) => ({
       : "#ffcc99",
   audio: null,
   sentiment: 0,
+  mood: "neutral",
   setEnabled: (v) => {
     try {
       localStorage.setItem(AVATAR_ENABLE_KEY, String(v));
@@ -43,5 +48,6 @@ export const useAvatarStore = create<AvatarState>((set) => ({
   },
   setAudio: (audio) => set({ audio }),
   setSentiment: (sentiment) => set({ sentiment }),
+  setMood: (mood) => set({ mood }),
 }));
 


### PR DESCRIPTION
## Summary
- track avatar mood in store with setMood
- apply mood-specific geometry and shader changes in AvatarSphere
- add story and test demonstrating mood updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ae0ac00d083269e05c9d0578604a9