### PR TITLE
feat: add planner integration hooks

### DIFF
--- a/agents/planner.py
+++ b/agents/planner.py
@@ -7,14 +7,22 @@ store using the ``plan`` tag so they can be retrieved later.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List
+from typing import Any, Dict, List
 
 from memory import store
+from settings import settings
 
 
 @dataclass
 class PlannerAgent:
-    """Generate basic plans for user goals."""
+    """Generate basic plans for user goals.
+
+    Optional calendar or todo API clients can be supplied to push the
+    generated steps to external services.
+    """
+
+    calendar_api: Any | None = None
+    todo_api: Any | None = None
 
     def can_handle(self, message: str) -> bool:
         """Return ``True`` if ``message`` appears to be a planning request."""
@@ -33,12 +41,24 @@ class PlannerAgent:
         ]
 
     def handle(self, message: str, context: str) -> str:
-        """Generate a plan and persist it to memory."""
+        """Generate a plan, optionally push to integrations and persist."""
 
         goal = message.split(" ", 1)[1] if " " in message else ""
         goal = goal.strip() or "your goal"
         steps = self.plan(goal)
-        store.save_plan(goal, steps)
+
+        external_ids: Dict[str, List[str]] = {}
+        if settings.get("integrations", {}).get("calendar") and self.calendar_api:
+            calendar_ids = [self.calendar_api.create_event(step) for step in steps]
+            if calendar_ids:
+                external_ids["calendar"] = calendar_ids
+
+        if settings.get("integrations", {}).get("todo") and self.todo_api:
+            todo_ids = [self.todo_api.create_task(step) for step in steps]
+            if todo_ids:
+                external_ids["todo"] = todo_ids
+
+        store.save_plan(goal, steps, external_ids or None)
         numbered = "\n".join(
             f"{i + 1}. {step}" for i, step in enumerate(steps)
         )

--- a/core/brain.py
+++ b/core/brain.py
@@ -129,9 +129,8 @@ class BrainAgent:
             coaching = self.coach.generate(context)
             response = f"{response}\n\n{coaching}".strip()
 
+        response = apply_style(response)
         final = filter_output(response)
         self._save_memory_async(message, "user")
         self._save_memory_async(final, "assistant")
         return final
-        response = apply_style(response)
-        return filter_output(response)

--- a/memory/store.py
+++ b/memory/store.py
@@ -52,7 +52,11 @@ def save_memory(text: str, metadata: Dict[str, Any] | None = None) -> int:
     return mem_id
 
 
-def save_plan(goal: str, steps: List[str]) -> int:
+def save_plan(
+    goal: str,
+    steps: List[str],
+    external_ids: Dict[str, List[str]] | None = None,
+) -> int:
     """Persist a plan in the memory database.
 
     Parameters
@@ -61,6 +65,9 @@ def save_plan(goal: str, steps: List[str]) -> int:
         Goal the plan addresses.
     steps:
         Ordered list of steps for achieving the goal.
+    external_ids:
+        Optional mapping of integration names to lists of external
+        identifiers for the created steps.
 
     Returns
     -------
@@ -70,6 +77,8 @@ def save_plan(goal: str, steps: List[str]) -> int:
 
     text = f"Plan for {goal}: " + " | ".join(steps)
     metadata = {"tag": "plan", "goal": goal, "steps": steps}
+    if external_ids:
+        metadata["external_ids"] = external_ids
     return save_memory(text, metadata)
 
 

--- a/settings/__init__.py
+++ b/settings/__init__.py
@@ -1,0 +1,28 @@
+import json
+import os
+from typing import Any, Dict
+
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), "config.json")
+
+_DEFAULTS: Dict[str, Any] = {
+    "integrations": {"calendar": False, "todo": False}
+}
+
+
+def load_settings() -> Dict[str, Any]:
+    """Load configuration from disk with sensible defaults."""
+    try:
+        with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        data = {}
+    settings: Dict[str, Any] = {**_DEFAULTS, **data}
+    if "integrations" in data:
+        settings["integrations"] = {
+            **_DEFAULTS["integrations"],
+            **data.get("integrations", {}),
+        }
+    return settings
+
+
+settings = load_settings()

--- a/settings/config.json
+++ b/settings/config.json
@@ -1,5 +1,9 @@
 {
   "voiceOutput": true,
   "hypnosisMode": false,
-  "memoryRetention": 30
+  "memoryRetention": 30,
+  "integrations": {
+    "calendar": false,
+    "todo": false
+  }
 }

--- a/src/state/settings.ts
+++ b/src/state/settings.ts
@@ -6,18 +6,36 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const configPath = path.resolve(__dirname, '../../settings/config.json');
 
+export interface IntegrationsConfig {
+  calendar: boolean;
+  todo: boolean;
+}
+
 export interface AppSettings {
   voiceOutput: boolean;
   hypnosisMode: boolean;
   memoryRetention: number;
+  integrations: IntegrationsConfig;
 }
 
 function loadSettings(): AppSettings {
   try {
     const raw = readFileSync(configPath, 'utf-8');
-    return JSON.parse(raw) as AppSettings;
+    const parsed = JSON.parse(raw) as Partial<AppSettings>;
+    return {
+      voiceOutput: true,
+      hypnosisMode: false,
+      memoryRetention: 30,
+      integrations: { calendar: false, todo: false, ...(parsed.integrations || {}) },
+      ...parsed,
+    };
   } catch {
-    return { voiceOutput: true, hypnosisMode: false, memoryRetention: 30 };
+    return {
+      voiceOutput: true,
+      hypnosisMode: false,
+      memoryRetention: 30,
+      integrations: { calendar: false, todo: false },
+    };
   }
 }
 
@@ -31,6 +49,8 @@ export const useAppSettings = create<AppSettings & {
   toggleVoiceOutput: () => void;
   toggleHypnosisMode: () => void;
   setMemoryRetention: (v: number) => void;
+  toggleCalendarIntegration: () => void;
+  toggleTodoIntegration: () => void;
 }>((set, get) => ({
   ...initial,
   toggleVoiceOutput() {
@@ -45,6 +65,28 @@ export const useAppSettings = create<AppSettings & {
   },
   setMemoryRetention(v: number) {
     const next = { ...get(), memoryRetention: v };
+    saveSettings(next);
+    set(next);
+  },
+  toggleCalendarIntegration() {
+    const next = {
+      ...get(),
+      integrations: {
+        ...get().integrations,
+        calendar: !get().integrations.calendar,
+      },
+    };
+    saveSettings(next);
+    set(next);
+  },
+  toggleTodoIntegration() {
+    const next = {
+      ...get(),
+      integrations: {
+        ...get().integrations,
+        todo: !get().integrations.todo,
+      },
+    };
     saveSettings(next);
     set(next);
   },

--- a/tests/test_planner_agent.py
+++ b/tests/test_planner_agent.py
@@ -1,0 +1,50 @@
+import json
+
+import json
+
+from agents.planner import PlannerAgent
+from memory import store
+import settings
+
+
+class DummyCalendarAPI:
+    def __init__(self):
+        self.counter = 0
+
+    def create_event(self, step: str) -> str:  # pragma: no cover - trivial
+        self.counter += 1
+        return f"cal-{self.counter}"
+
+
+class DummyTodoAPI:
+    def __init__(self):
+        self.counter = 0
+
+    def create_task(self, step: str) -> str:  # pragma: no cover - trivial
+        self.counter += 1
+        return f"todo-{self.counter}"
+
+
+def test_plan_persists_external_ids():
+    settings.settings["integrations"] = {"calendar": True, "todo": True}
+
+    # clean memory table
+    with store.db_lock:
+        store.cur.execute("DELETE FROM memories")
+        store.conn.commit()
+
+    agent = PlannerAgent(
+        calendar_api=DummyCalendarAPI(), todo_api=DummyTodoAPI()
+    )
+    agent.handle("plan launch", "")
+
+    with store.db_lock:
+        store.cur.execute(
+            "SELECT metadata FROM memories ORDER BY id DESC LIMIT 1"
+        )
+        meta_json = store.cur.fetchone()[0]
+    meta = json.loads(meta_json)
+
+    assert "external_ids" in meta
+    assert len(meta["external_ids"]["calendar"]) == 4
+    assert len(meta["external_ids"]["todo"]) == 4


### PR DESCRIPTION
## Summary
- add optional calendar/todo integration hooks to planning agent and persist external IDs
- record external IDs in memory metadata and expose settings for enabling integrations
- include integration toggles in frontend settings store and config

## Testing
- `PYTHONPATH=. pytest`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ae0ad6cf08326bc2b0240021827c6