### PR TITLE
fix: avoid child_process in browser

### DIFF
--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -1,11 +1,17 @@
-import { execFile } from 'child_process';
-import { promisify } from 'util';
-import path from 'path';
-import { fileURLToPath } from 'url';
-
-const execFileAsync = promisify(execFile);
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const STORE_PY = path.resolve(__dirname, '../../memory/store.py');
+// Node-specific memory store that delegates to a Python script.
+// These utilities are loaded dynamically so the module can be imported in
+// browser environments without bundling Node built-ins.
+async function runStorePy(args: string[]) {
+  if (typeof window !== 'undefined') return null;
+  const { execFile } = await import('child_process');
+  const { promisify } = await import('util');
+  const path = await import('path');
+  const { fileURLToPath } = await import('url');
+  const execFileAsync = promisify(execFile);
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const STORE_PY = path.resolve(__dirname, '../../memory/store.py');
+  return execFileAsync('python', [STORE_PY, ...args]);
+}
 
 export interface MemoryRecord {
   id: number;
@@ -15,7 +21,7 @@ export interface MemoryRecord {
 
 export async function saveMemory(text: string, metadata: Record<string, any> = {}): Promise<void> {
   try {
-    await execFileAsync('python', [STORE_PY, 'save', text, JSON.stringify(metadata)]);
+    await runStorePy(['save', text, JSON.stringify(metadata)]);
   } catch (e) {
     console.error('saveMemory failed', e);
   }
@@ -23,7 +29,9 @@ export async function saveMemory(text: string, metadata: Record<string, any> = {
 
 export async function queryMemory(query: string, k = 5): Promise<MemoryRecord[]> {
   try {
-    const { stdout } = await execFileAsync('python', [STORE_PY, 'query', query, String(k)]);
+    const result = await runStorePy(['query', query, String(k)]);
+    if (!result) return [];
+    const stdout = (result as any).stdout ?? '';
     return JSON.parse(stdout || '[]');
   } catch (e) {
     console.error('queryMemory failed', e);


### PR DESCRIPTION
## Summary
- load Node-only modules dynamically in memory store to avoid bundling `child_process`

## Testing
- `npm test`
- `npm run build` *(fails: JSX expressions must have one parent element in src/views/MasterPlanView.tsx)*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689ae13fe0fc8326aee9e21b2933ae73