### PR TITLE
Use model router with metrics for backend selection

### DIFF
--- a/core/brain.py
+++ b/core/brain.py
@@ -15,6 +15,7 @@ from agents.coaching import CoachingAgent
 from memory.store import save_memory
 from persona.style import apply_style
 from safety.filter import filter_output
+from orchestration.router import ModelRouter, UsageLogger
 from .logger import get_logger
 from .metrics import metrics
 
@@ -61,6 +62,20 @@ class BrainAgent:
         "Persona: {persona}\n"
         "Relevant memories:\n{memories}\n"
     )
+    router: ModelRouter = field(init=False)
+    _current_agent: SupportsAgent | None = field(init=False, default=None)
+    _current_message: str = field(init=False, default="")
+
+    def __post_init__(self) -> None:
+        self.router = ModelRouter(self._local_model, self._cloud_model, logger=UsageLogger())
+
+    def _local_model(self, prompt: str) -> str:
+        if self._current_agent is not None:
+            return self._current_agent.handle(self._current_message, prompt)
+        return prompt
+
+    def _cloud_model(self, prompt: str) -> str:
+        return self._local_model(prompt)
 
     def _save_memory_async(self, text: str, role: str) -> None:
         """Persist ``text`` with ``role`` metadata without blocking."""
@@ -112,7 +127,10 @@ class BrainAgent:
                             "agent": type(agent).__name__,
                         },
                     )
-                    response = agent.handle(message, context)
+                    self._current_agent = agent
+                    self._current_message = message
+                    response = self.router.route(context)
+                    self._current_agent = None
                     break
             except Exception:
                 metrics.errors += 1
@@ -123,7 +141,9 @@ class BrainAgent:
                 continue
 
         if response is None:
-            response = context
+            self._current_agent = None
+            self._current_message = message
+            response = self.router.route(context)
 
         if self.coach is not None:
             coaching = self.coach.generate(context)

--- a/core/metrics.py
+++ b/core/metrics.py
@@ -8,6 +8,8 @@ class Metrics:
     conversations: int = 0
     memory_queries: int = 0
     errors: int = 0
+    router_local: int = 0
+    router_cloud: int = 0
 
     def as_dict(self) -> dict[str, int]:
         return asdict(self)

--- a/orchestration/router.py
+++ b/orchestration/router.py
@@ -16,6 +16,7 @@ from typing import Protocol
 import socket
 
 from models import preload as preload_models
+from core.metrics import metrics
 
 
 class Model(Protocol):
@@ -115,14 +116,17 @@ class ModelRouter:
         if not is_online():
             response = self.local_model(prompt)
             self.logger.log("local_offline", tokens, 0.0)
+            metrics.router_local += 1
             return response
 
         if tokens > self.config.max_local_tokens and cloud_cost <= self.config.max_cloud_cost:
             sanitized = abstract_sensitive_data(prompt)
             response = self.cloud_model(sanitized)
             self.logger.log("cloud", tokens, cloud_cost)
+            metrics.router_cloud += 1
             return response
 
         response = self.local_model(prompt)
         self.logger.log("local", tokens, 0.0)
+        metrics.router_local += 1
         return response


### PR DESCRIPTION
## Summary
- route BrainAgent prompts through ModelRouter wired with local/cloud callables
- record routing decisions to usage metrics
- expose router stats via `/metrics`

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ae31bb5c0832680634dad943a9a2c