### PR TITLE
Add interactive consent checks to safety filter

### DIFF
--- a/safety/filter.py
+++ b/safety/filter.py
@@ -9,6 +9,7 @@ incident is logged to ``filter.log``.
 from __future__ import annotations
 
 import logging
+import sys
 from pathlib import Path
 from typing import Iterable
 
@@ -24,11 +25,17 @@ logger.setLevel(logging.INFO)
 # Simple keyword list as a fallback moderation mechanism
 KEYWORDS: Iterable[str] = {
     "self-harm",
+    "self harm",
     "suicide",
     "kill myself",
+    "kill yourself",
     "murder",
     "hate",
     "violence",
+    "terrorism",
+    "bomb",
+    "shoot",
+    "abuse",
 }
 
 # Attempt to load an open-source moderation model if available
@@ -42,10 +49,51 @@ except Exception:  # pragma: no cover - runtime failure is acceptable
 WARNING_MESSAGE = "\u26a0\ufe0f Content removed for safety."
 
 
-def _is_harmful(text: str) -> bool:
-    """Return ``True`` if ``text`` appears harmful."""
+def request_user_confirmation(text: str) -> bool:
+    """Ask the user to confirm display of flagged ``text``.
+
+    Returns ``True`` if the user grants consent. Non-interactive environments
+    automatically return ``False``.
+    """
+
+    if not sys.stdin.isatty():
+        logger.info(
+            "consent skipped (non-interactive): %s",
+            text.replace("\n", " ")[:200],
+        )
+        return False
+
+    try:
+        decision = input(
+            "\u26a0\ufe0f Potentially harmful content detected. View anyway? [y/N]: "
+        )
+    except Exception:  # pragma: no cover - interactive failure
+        logger.exception("consent prompt failed")
+        return False
+
+    accepted = decision.strip().lower() in {"y", "yes"}
+    logger.info(
+        "consent %s: %s",
+        "granted" if accepted else "denied",
+        text.replace("\n", " ")[:200],
+    )
+    return accepted
+
+
+def _is_harmful(text: str, intent: str | None = None) -> bool:
+    """Return ``True`` if ``text`` appears harmful.
+
+    An optional ``intent`` hint may provide additional context such as
+    "seeking_help" which can reduce false positives.
+    """
+
     lower = text.lower()
     if any(kw in lower for kw in KEYWORDS):
+        helpful_context = {"help", "support", "prevention"}
+        if intent and intent.lower() in helpful_context:
+            return False
+        if any(term in lower for term in helpful_context):
+            return False
         return True
     if _moderator is not None:
         try:
@@ -58,10 +106,16 @@ def _is_harmful(text: str) -> bool:
             pass
     return False
 
+def filter_output(text: str, *, intent: str | None = None) -> str:
+    """Filter ``text`` returning a safe alternative if necessary.
 
-def filter_output(text: str) -> str:
-    """Filter ``text`` returning a safe alternative if necessary."""
-    if _is_harmful(text):
+    When harmful content is detected, the user must explicitly consent for the
+    content to be returned. Decisions are logged to ``filter.log``.
+    """
+
+    if _is_harmful(text, intent=intent):
+        if request_user_confirmation(text):
+            return text
         logger.warning("blocked: %s", text.replace("\n", " ")[:200])
         return WARNING_MESSAGE
     return text


### PR DESCRIPTION
## Summary
- expand safety keywords and add context-aware heuristics
- prompt users for consent before displaying flagged content and log their decision

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi'; ModuleNotFoundError: No module named 'agents')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ae31e1b0c8326aa5b2e390623e0ff