### PR TITLE
Track agent metrics and expose via API

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,4 +1,5 @@
 """Core package for brain agents."""
 from .brain import BrainAgent
+from .metrics import metrics
 
-__all__ = ["BrainAgent"]
+__all__ = ["BrainAgent", "metrics"]

--- a/core/__tests__/test_agent_metrics.py
+++ b/core/__tests__/test_agent_metrics.py
@@ -1,0 +1,66 @@
+"""Tests for tracking agent call metrics."""
+
+from core.brain import BrainAgent
+from core.metrics import metrics
+
+def _reset_metrics() -> None:
+    metrics.conversations = 0
+    metrics.memory_queries = 0
+    metrics.errors = 0
+    metrics.planner_calls = 0
+    metrics.hypnosis_calls = 0
+    metrics.coaching_calls = 0
+
+def test_planner_calls_are_counted() -> None:
+    _reset_metrics()
+
+    class PlannerAgent:
+        def can_handle(self, message: str) -> bool:
+            return True
+
+        def handle(self, message: str, context: str) -> str:
+            return "plan"
+
+    brain = BrainAgent(persona_store=lambda: "", memory_store=lambda _msg: [], agents=[PlannerAgent()])
+    brain.process("anything")
+
+    assert metrics.planner_calls == 1
+
+def test_hypnosis_calls_are_counted() -> None:
+    _reset_metrics()
+
+    class HypnosisAgent:
+        def can_handle(self, message: str) -> bool:
+            return True
+
+        def handle(self, message: str, context: str) -> str:
+            return "hypnosis"
+
+    brain = BrainAgent(persona_store=lambda: "", memory_store=lambda _msg: [], agents=[HypnosisAgent()])
+    brain.process("anything")
+
+    assert metrics.hypnosis_calls == 1
+
+def test_coaching_calls_are_counted() -> None:
+    _reset_metrics()
+
+    class DummyAgent:
+        def can_handle(self, message: str) -> bool:
+            return True
+
+        def handle(self, message: str, context: str) -> str:
+            return "base"
+
+    class CoachingAgent:
+        def generate(self, context: str) -> str:
+            return "coach"
+
+    brain = BrainAgent(
+        persona_store=lambda: "",
+        memory_store=lambda _msg: [],
+        agents=[DummyAgent()],
+        coach=CoachingAgent(),
+    )
+    brain.process("anything")
+
+    assert metrics.coaching_calls == 1

--- a/core/brain.py
+++ b/core/brain.py
@@ -113,6 +113,8 @@ class BrainAgent:
                         },
                     )
                     response = agent.handle(message, context)
+                    agent_name = type(agent).__name__.replace("Agent", "").lower()
+                    metrics.increment_agent(agent_name)
                     break
             except Exception:
                 metrics.errors += 1
@@ -127,6 +129,8 @@ class BrainAgent:
 
         if self.coach is not None:
             coaching = self.coach.generate(context)
+            coach_name = type(self.coach).__name__.replace("Agent", "").lower()
+            metrics.increment_agent(coach_name)
             response = f"{response}\n\n{coaching}".strip()
 
         response = apply_style(response)

--- a/core/metrics.py
+++ b/core/metrics.py
@@ -8,9 +8,22 @@ class Metrics:
     conversations: int = 0
     memory_queries: int = 0
     errors: int = 0
+    planner_calls: int = 0
+    hypnosis_calls: int = 0
+    coaching_calls: int = 0
 
     def as_dict(self) -> dict[str, int]:
         return asdict(self)
+
+    def increment_agent(self, name: str) -> None:
+        """Increment the call counter for a given agent name.
+
+        ``name`` should be the lower-case agent identifier without the
+        ``Agent`` suffix, e.g. ``"planner"`` or ``"hypnosis"``.
+        """
+        attr = f"{name}_calls"
+        if hasattr(self, attr):
+            setattr(self, attr, getattr(self, attr) + 1)
 
 
 metrics = Metrics()

--- a/voice/server.py
+++ b/voice/server.py
@@ -23,7 +23,7 @@ brain = BrainAgent(persona_store=lambda: "", memory_store=lambda _msg: [])
 
 @app.get("/metrics")
 async def metrics_endpoint():
-    """Expose application metrics."""
+    """Expose application metrics including agent call counts."""
 
     return metrics.as_dict()
 


### PR DESCRIPTION
## Summary
- add planner, hypnosis and coaching call counters to core metrics with helper
- update BrainAgent to increment agent call metrics when agents or coach handle messages
- document agent metrics in voice server endpoint and expose metrics via core package
- test metrics counting for planner, hypnosis and coaching agents

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ae31fe77483268892bce2dfa7dca0