### PR TITLE
Avoid double-counting voice conversations

### DIFF
--- a/core/metrics.py
+++ b/core/metrics.py
@@ -11,6 +11,8 @@ class Metrics:
     planner_calls: int = 0
     hypnosis_calls: int = 0
     coaching_calls: int = 0
+    router_local: int = 0
+    router_cloud: int = 0
 
     def as_dict(self) -> dict[str, int]:
         return asdict(self)

--- a/tests/test_voice_metrics.py
+++ b/tests/test_voice_metrics.py
@@ -1,0 +1,14 @@
+"""Tests for voice conversation metrics."""
+
+from core.brain import BrainAgent
+from core.metrics import metrics
+
+
+def test_voice_message_counts_single_conversation() -> None:
+    """Processing a single voice message increments conversation count once."""
+    metrics.conversations = 0
+
+    brain = BrainAgent(persona_store=lambda: "", memory_store=lambda _msg: [])
+    brain.process("hello there")
+
+    assert metrics.conversations == 1

--- a/voice/server.py
+++ b/voice/server.py
@@ -65,7 +65,6 @@ async def voice_endpoint(request: Request):
                 "audio": base64.b64encode(reply_audio).decode(),
             }
             channel.send(json.dumps(message))
-            metrics.conversations += 1
 
     await pc.setRemoteDescription(offer)
     answer = await pc.createAnswer()


### PR DESCRIPTION
## Summary
- Remove the extra conversation metric increment in the voice server's WebRTC track handler
- Extend metrics to include router usage counters
- Add a unit test verifying a single conversation increment per voice message

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b2446b30083269436a3671f38e901