### PR TITLE
Use real persona and memory in voice server

### DIFF
--- a/tests/test_voice_memory_recall.py
+++ b/tests/test_voice_memory_recall.py
@@ -1,0 +1,127 @@
+"""Regression test ensuring voice replies use past utterances."""
+
+import sys
+import types
+
+# Stub heavy optional dependencies before importing voice modules
+
+fake_fw = types.ModuleType("faster_whisper")
+class FakeWhisperModel:  # noqa: D401 - simple stub
+    def __init__(self, *_, **__):
+        pass
+    def transcribe(self, path, language=None):  # noqa: D401 - simple stub
+        class Seg:
+            text = ""
+        return [Seg()], None
+fake_fw.WhisperModel = FakeWhisperModel
+sys.modules.setdefault("faster_whisper", fake_fw)
+
+fake_whisper = types.ModuleType("whisper")
+
+def load_model(name):  # noqa: D401 - simple stub
+    class Model:
+        def transcribe(self, path, language=None):  # noqa: D401 - simple stub
+            return {"text": ""}
+    return Model()
+
+fake_whisper.load_model = load_model
+sys.modules.setdefault("whisper", fake_whisper)
+
+fake_tts_api = types.ModuleType("TTS.api")
+class FakeTTS:  # noqa: D401 - simple stub
+    def __init__(self, *_, **__):
+        pass
+    def tts(self, text, speaker_wav=None):  # noqa: D401 - simple stub
+        return [0.0]
+    @property
+    def synthesizer(self):  # noqa: D401 - simple stub
+        class Synth:
+            output_sample_rate = 22050
+        return Synth()
+fake_tts_api.TTS = FakeTTS
+sys.modules.setdefault("TTS", types.ModuleType("TTS"))
+sys.modules["TTS.api"] = fake_tts_api
+
+fake_sf = types.ModuleType("soundfile")
+
+def write(buf, audio, samplerate, format):  # noqa: D401 - simple stub
+    buf.write(b"")
+
+fake_sf.write = write
+sys.modules.setdefault("soundfile", fake_sf)
+
+fake_fastapi = types.ModuleType("fastapi")
+class FastAPI:  # noqa: D401 - simple stub
+    def __init__(self, *_, **__):
+        pass
+    def get(self, *_, **__):
+        return lambda fn: fn
+    def post(self, *_, **__):
+        return lambda fn: fn
+class Request:  # noqa: D401 - simple stub
+    async def json(self):
+        return {}
+fake_fastapi.FastAPI = FastAPI
+fake_fastapi.Request = Request
+sys.modules.setdefault("fastapi", fake_fastapi)
+
+fake_aiortc = types.ModuleType("aiortc")
+class RTCPeerConnection:  # noqa: D401 - simple stub
+    def createDataChannel(self, *_, **__):
+        return types.SimpleNamespace(send=lambda data: None)
+    async def setRemoteDescription(self, *_, **__):
+        pass
+    async def createAnswer(self):
+        return types.SimpleNamespace(sdp="", type="")
+    async def setLocalDescription(self, *_, **__):
+        pass
+    @property
+    def localDescription(self):
+        return types.SimpleNamespace(sdp="", type="")
+class RTCSessionDescription:  # noqa: D401 - simple stub
+    def __init__(self, sdp: str, type: str):
+        self.sdp = sdp
+        self.type = type
+fake_aiortc.RTCPeerConnection = RTCPeerConnection
+fake_aiortc.RTCSessionDescription = RTCSessionDescription
+sys.modules.setdefault("aiortc", fake_aiortc)
+
+fake_media = types.ModuleType("aiortc.contrib.media")
+class MediaRecorder:  # noqa: D401 - simple stub
+    def __init__(self, *_, **__):
+        pass
+    def addTrack(self, *_, **__):
+        pass
+    async def start(self):
+        pass
+    async def stop(self):
+        pass
+fake_media.MediaRecorder = MediaRecorder
+sys.modules.setdefault("aiortc.contrib", types.ModuleType("aiortc.contrib"))
+sys.modules["aiortc.contrib.media"] = fake_media
+
+import voice.server as vs
+
+
+def test_voice_recall(monkeypatch):
+    """Past utterances should influence subsequent voice replies."""
+
+    stored: list[str] = []
+
+    monkeypatch.setattr(vs, "_load_profile", lambda: {})
+
+    def fake_query_memory(message: str, k: int = 5):  # noqa: ARG001
+        return [{"text": m} for m in stored]
+
+    monkeypatch.setattr(vs, "query_memory", fake_query_memory)
+
+    def save_memory_sync(text: str, role: str):
+        if role == "user":
+            stored.append(text)
+
+    monkeypatch.setattr(vs.brain, "_save_memory_async", save_memory_sync)
+
+    vs.brain.process("I love regression tests")
+    reply = vs.brain.process("What do I love?")
+
+    assert "I love regression tests" in reply

--- a/voice/server.py
+++ b/voice/server.py
@@ -5,6 +5,7 @@ import asyncio
 import base64
 import json
 import tempfile
+from typing import List
 
 from fastapi import FastAPI, Request
 from aiortc import RTCPeerConnection, RTCSessionDescription
@@ -12,13 +13,28 @@ from aiortc.contrib.media import MediaRecorder
 
 from core.brain import BrainAgent
 from core.metrics import metrics
+from memory.store import query_memory
+from persona.style import _load_profile
 from .stt import transcribe_audio
 from .tts import synthesize_reply
 
 app = FastAPI()
 
 
-brain = BrainAgent(persona_store=lambda: "", memory_store=lambda _msg: [])
+def load_persona() -> str:
+    profile = _load_profile()
+    tone = profile.get("tone", "")
+    goals = profile.get("goals", "")
+    catchphrases = " ".join(profile.get("catchphrases", []))
+    parts = [tone, goals, catchphrases]
+    return " ".join(part for part in parts if part)
+
+
+def fetch_memories(message: str) -> List[str]:
+    return [m["text"] for m in query_memory(message)]
+
+
+brain = BrainAgent(persona_store=load_persona, memory_store=fetch_memories)
 
 
 @app.get("/metrics")


### PR DESCRIPTION
## Summary
- wire voice server to query stored memories and persona profile
- add regression test showing voice replies reference past utterances

## Testing
- `PYTHONPATH=. pytest tests/test_voice_memory_recall.py`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b45d01798832699da6f73883ea649