### PR TITLE
Add vector-backed memory recall

### DIFF
--- a/core/brain.py
+++ b/core/brain.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import asyncio
 import threading
 from dataclasses import dataclass, field
-from typing import Callable, Iterable, Protocol, Sequence
+from typing import Any, Callable, Iterable, Mapping, Protocol, Sequence
 
 from agents.coaching import CoachingAgent
 from memory.store import save_memory
@@ -40,7 +40,8 @@ class BrainAgent:
         Callable returning a short string describing the user's ideal persona.
     memory_store:
         Callable accepting a message and returning an iterable of memory
-        snippets relevant to that message.
+        snippets relevant to that message.  Each item may be either a plain
+        string or a mapping containing a ``text`` field.
     agents:
         Sequence of sub-agents responsible for specific tasks.  Each must
         implement :class:`SupportsAgent`.
@@ -54,7 +55,7 @@ class BrainAgent:
     """
 
     persona_store: Callable[[], str]
-    memory_store: Callable[[str], Iterable[str]]
+    memory_store: Callable[[str], Iterable[str | Mapping[str, Any]]]
     agents: Sequence[SupportsAgent] = field(default_factory=list)
     coach: CoachingAgent | None = None
     prompt_template: str = (
@@ -105,13 +106,22 @@ class BrainAgent:
         persona = self.persona_store() or ""
 
         try:
-            memories = list(self.memory_store(message))
+            raw_memories = list(self.memory_store(message))
         except Exception:
             metrics.errors += 1
             logger.exception("memory store error", extra={"request_id": request_id, "agent": "memory_store"})
-            memories = []
+            raw_memories = []
         else:
             metrics.memory_queries += 1
+
+        memories = []
+        for mem in raw_memories:
+            if isinstance(mem, str):
+                memories.append(mem)
+            elif isinstance(mem, Mapping):
+                text = mem.get("text")
+                if text:
+                    memories.append(str(text))
 
         memory_text = "\n".join(memories)
         context = self.prompt_template.format(persona=persona, memories=memory_text)

--- a/memory/store.py
+++ b/memory/store.py
@@ -1,14 +1,13 @@
-import os
+"""Persistent memory store backed by SQLite and a vector index."""
+from __future__ import annotations
+
 import json
+import os
 import sqlite3
 import threading
 from typing import Any, Dict, List
 
-try:
-    import chromadb
-    from chromadb.utils import embedding_functions
-except Exception:  # pragma: no cover - chromadb optional
-    chromadb = None
+from .vector_store import VectorStore
 
 DB_PATH = os.path.join(os.path.dirname(__file__), "memory.db")
 CHROMA_PATH = os.path.join(os.path.dirname(__file__), "chroma_db")
@@ -23,22 +22,15 @@ cur.execute(
         text TEXT NOT NULL,
         metadata TEXT
     )
-    """
+    """,
 )
 conn.commit()
 
-collection = None
-if chromadb is not None:
-    client = chromadb.PersistentClient(path=CHROMA_PATH)
-    embed_fn = embedding_functions.SentenceTransformerEmbeddingFunction(
-        model_name="all-MiniLM-L6-v2"
-    )
-    collection = client.get_or_create_collection(
-        "memories", embedding_function=embed_fn
-    )
+vector_store = VectorStore(CHROMA_PATH)
 
 
 def save_memory(text: str, metadata: Dict[str, Any] | None = None) -> int:
+    """Persist ``text`` and optional ``metadata`` and index its embedding."""
     metadata = metadata or {}
     with db_lock:
         cur.execute(
@@ -47,8 +39,7 @@ def save_memory(text: str, metadata: Dict[str, Any] | None = None) -> int:
         )
         mem_id = cur.lastrowid
         conn.commit()
-    if collection is not None:
-        collection.add(documents=[text], metadatas=[metadata], ids=[str(mem_id)])
+    vector_store.add(str(mem_id), text, metadata)
     return mem_id
 
 
@@ -57,36 +48,17 @@ def save_plan(
     steps: List[str],
     external_ids: Dict[str, List[str]] | None = None,
 ) -> int:
-    """Persist a plan in the memory database.
-
-    Parameters
-    ----------
-    goal:
-        Goal the plan addresses.
-    steps:
-        Ordered list of steps for achieving the goal.
-    external_ids:
-        Optional mapping of integration names to lists of external
-        identifiers for the created steps.
-
-    Returns
-    -------
-    int
-        ID of the stored memory entry.
-    """
-
+    """Persist a plan in the memory database."""
     text = f"Plan for {goal}: " + " | ".join(steps)
-    metadata = {"tag": "plan", "goal": goal, "steps": steps}
+    metadata: Dict[str, Any] = {"tag": "plan", "goal": goal, "steps": steps}
     if external_ids:
         metadata["external_ids"] = external_ids
     return save_memory(text, metadata)
 
 
 def query_memory(query: str, k: int = 5) -> List[Dict[str, Any]]:
-    if collection is None:
-        return []
-    results = collection.query(query_texts=[query], n_results=k)
-    ids = [int(i) for i in results.get("ids", [[""]])[0] if i]
+    """Return top ``k`` memories relevant to ``query`` using similarity search."""
+    ids = [int(i) for i in vector_store.query(query, k)]
     if not ids:
         return []
     placeholders = ",".join(["?"] * len(ids))
@@ -96,8 +68,7 @@ def query_memory(query: str, k: int = 5) -> List[Dict[str, Any]]:
     )
     rows = cur.fetchall()
     output: List[Dict[str, Any]] = []
-    for row in rows:
-        mid, text, meta_json = row
+    for mid, text, meta_json in rows:
         try:
             meta = json.loads(meta_json) if meta_json else {}
         except Exception:
@@ -106,7 +77,7 @@ def query_memory(query: str, k: int = 5) -> List[Dict[str, Any]]:
     return output
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - convenience CLI
     import sys
 
     if len(sys.argv) < 2:

--- a/memory/vector_store.py
+++ b/memory/vector_store.py
@@ -1,0 +1,101 @@
+"""Lightweight vector index for memory embeddings.
+
+This module provides a minimal wrapper around ``chromadb`` when available
+and falls back to a simple in-memory cosine similarity search.  It exposes a
+:class:`VectorStore` with ``add`` and ``query`` methods used by the memory
+store.
+"""
+from __future__ import annotations
+
+import os
+import re
+from collections import Counter
+from typing import Any, Dict, List
+
+try:  # pragma: no cover - optional dependency
+    import chromadb
+    from chromadb.utils import embedding_functions
+except Exception:  # pragma: no cover - chromadb optional
+    chromadb = None  # type: ignore
+
+
+class VectorStore:
+    """Persistent vector index for memory snippets.
+
+    Parameters
+    ----------
+    path:
+        Optional directory used for the underlying ``chromadb`` store.  When
+        ``chromadb`` is unavailable the store operates purely in memory.
+    """
+
+    def __init__(self, path: str | None = None):
+        self._use_chroma = False
+        self._collection = None
+        if chromadb is not None and path is not None:
+            try:  # pragma: no cover - thin wrapper around library
+                client = chromadb.PersistentClient(path=path)
+                embed_fn = embedding_functions.SentenceTransformerEmbeddingFunction(
+                    model_name="all-MiniLM-L6-v2"
+                )
+                self._collection = client.get_or_create_collection(
+                    "memories", embedding_function=embed_fn
+                )
+                self._use_chroma = True
+            except Exception:  # pragma: no cover - chromadb setup failure
+                self._collection = None
+                self._use_chroma = False
+        if not self._use_chroma:
+            self._docs: List[str] = []
+            self._ids: List[str] = []
+            self._embeddings: List[Counter[str]] = []
+
+    # ------------------------------------------------------------------
+    def _embed(self, text: str) -> Counter[str]:
+        tokens = re.findall(r"\w+", text.lower())
+        return Counter(tokens)
+
+    def _cosine(self, a: Counter[str], b: Counter[str]) -> float:
+        dot = sum(a[t] * b.get(t, 0) for t in a)
+        if not dot:
+            return 0.0
+        norm_a = sum(v * v for v in a.values()) ** 0.5
+        norm_b = sum(v * v for v in b.values()) ** 0.5
+        return dot / (norm_a * norm_b)
+
+    # ------------------------------------------------------------------
+    def add(self, doc_id: str, document: str, metadata: Dict[str, Any] | None = None) -> None:
+        metadata = metadata or {}
+        if self._use_chroma and self._collection is not None:  # pragma: no cover - chromadb path
+            self._collection.add(
+                documents=[document], ids=[doc_id], metadatas=[metadata]
+            )
+            return
+        self._ids.append(doc_id)
+        self._docs.append(document)
+        self._embeddings.append(self._embed(document))
+
+    # ------------------------------------------------------------------
+    def query(self, text: str, k: int = 5) -> List[str]:
+        if self._use_chroma and self._collection is not None:  # pragma: no cover
+            result = self._collection.query(query_texts=[text], n_results=k)
+            return [i for i in result.get("ids", [[]])[0] if i]
+        if not self._docs:
+            return []
+        qvec = self._embed(text)
+        sims = [self._cosine(qvec, vec) for vec in self._embeddings]
+        order = sorted(range(len(sims)), key=lambda i: sims[i], reverse=True)
+        return [self._ids[i] for i in order[:k] if sims[i] > 0]
+
+    # ------------------------------------------------------------------
+    def clear(self) -> None:
+        """Remove all stored documents."""
+        if self._use_chroma and self._collection is not None:  # pragma: no cover
+            self._collection.delete(where={})
+            return
+        self._docs.clear()
+        self._ids.clear()
+        self._embeddings.clear()
+
+
+__all__ = ["VectorStore"]

--- a/orchestration/router.py
+++ b/orchestration/router.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import json
 import re
-from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Protocol
@@ -59,20 +58,35 @@ def _metrics():
     return _metrics
 
 
-@dataclass
 class RouterConfig:
-    """Configuration controlling routing behaviour."""
+    """Configuration controlling routing behaviour.
 
-    # Route short, inexpensive prompts to Gemini by default
-    max_gemini_tokens: int = 128
-    gemini_cost_per_token: float = 0.000002
+    ``max_local_tokens`` mirrors the previous configuration option used in
+    tests and acts as an alias for ``max_gemini_tokens``.  Both may be
+    provided, with ``max_gemini_tokens`` taking precedence when set.
+    """
 
-    # ChatGPT is used for longer or deeper prompts when affordable
-    chatgpt_cost_per_token: float = 0.000015  # approximate USD
-    max_chatgpt_cost: float = 0.01
+    def __init__(
+        self,
+        max_local_tokens: int = 128,
+        *,
+        max_gemini_tokens: int | None = None,
+        gemini_cost_per_token: float = 0.000002,
+        chatgpt_cost_per_token: float = 0.000015,
+        max_chatgpt_cost: float = 0.01,
+        depth_threshold: int = 2,
+    ) -> None:
+        self.max_local_tokens = (
+            max_gemini_tokens if max_gemini_tokens is not None else max_local_tokens
+        )
+        self.gemini_cost_per_token = gemini_cost_per_token
+        self.chatgpt_cost_per_token = chatgpt_cost_per_token
+        self.max_chatgpt_cost = max_chatgpt_cost
+        self.depth_threshold = depth_threshold
 
-    # Depth value above which ChatGPT is preferred
-    depth_threshold: int = 2
+    @property
+    def max_gemini_tokens(self) -> int:  # pragma: no cover - simple alias
+        return self.max_local_tokens
 
 
 class UsageLogger:

--- a/tests/test_memory_recall.py
+++ b/tests/test_memory_recall.py
@@ -1,0 +1,36 @@
+"""Tests for the vector-backed memory store and BrainAgent recall."""
+
+from core.brain import BrainAgent
+from memory import store as mem
+
+
+class EchoAgent:
+    """Agent that simply echoes the provided context."""
+
+    def can_handle(self, message: str) -> bool:  # pragma: no cover - trivial
+        return True
+
+    def handle(self, message: str, context: str) -> str:  # pragma: no cover - trivial
+        return context
+
+
+def _brain() -> BrainAgent:
+    return BrainAgent(
+        persona_store=lambda: "",
+        memory_store=lambda msg: [m["text"] for m in mem.query_memory(msg)],
+        agents=[EchoAgent()],
+    )
+
+
+def test_similarity_recall(monkeypatch):
+    """The store should return memories relevant to the query."""
+    mem.save_memory("My secret hobby is alpine-unicycling")
+    mem.save_memory("Completely unrelated fact")
+
+    results = mem.query_memory("alpine-unicycling", k=1)
+    assert results and "alpine-unicycling" in results[0]["text"]
+
+    brain = _brain()
+    monkeypatch.setattr(brain, "_save_memory_async", lambda text, role: None)
+    reply = brain.process("What is my secret hobby?")
+    assert "alpine-unicycling" in reply


### PR DESCRIPTION
## Summary
- implement lightweight vector index with chromadb fallback
- index memory embeddings and perform similarity search for queries
- plumb recalled context into BrainAgent and add regression test

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b69924efc832688ed4c9a6b8807cf