### PR TITLE
refactor: remove fs usage from client

### DIFF
--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -19,13 +19,9 @@ export default function Onboarding() {
   const saveProfile = async () => {
     const data = { name, goals, voiceId };
     try {
-      const fs = await import("fs");
-      const path = await import("path");
-      const filePath = path.resolve("persona", "profile.json");
-      await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
-      await fs.promises.writeFile(filePath, JSON.stringify(data, null, 2));
+      localStorage.setItem("persona-profile", JSON.stringify(data));
     } catch (err) {
-      console.error("Failed to save profile.json", err);
+      console.error("Failed to save profile", err);
     }
     if (user) {
       await supabase

--- a/src/state/settings.ts
+++ b/src/state/settings.ts
@@ -1,10 +1,4 @@
 import { create } from 'zustand';
-import { readFileSync, writeFileSync } from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const configPath = path.resolve(__dirname, '../../settings/config.json');
 
 export interface IntegrationsConfig {
   calendar: boolean;
@@ -18,29 +12,41 @@ export interface AppSettings {
   integrations: IntegrationsConfig;
 }
 
+const STORAGE_KEY = 'app-settings';
+
+const defaultSettings: AppSettings = {
+  voiceOutput: true,
+  hypnosisMode: false,
+  memoryRetention: 30,
+  integrations: { calendar: false, todo: false },
+};
+
 function loadSettings(): AppSettings {
+  if (typeof localStorage === 'undefined') return defaultSettings;
   try {
-    const raw = readFileSync(configPath, 'utf-8');
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return defaultSettings;
     const parsed = JSON.parse(raw) as Partial<AppSettings>;
     return {
-      voiceOutput: true,
-      hypnosisMode: false,
-      memoryRetention: 30,
-      integrations: { calendar: false, todo: false, ...(parsed.integrations || {}) },
+      ...defaultSettings,
       ...parsed,
+      integrations: {
+        ...defaultSettings.integrations,
+        ...(parsed.integrations ?? {}),
+      },
     };
   } catch {
-    return {
-      voiceOutput: true,
-      hypnosisMode: false,
-      memoryRetention: 30,
-      integrations: { calendar: false, todo: false },
-    };
+    return defaultSettings;
   }
 }
 
 function saveSettings(s: AppSettings) {
-  writeFileSync(configPath, JSON.stringify(s, null, 2));
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(s));
+  } catch {
+    // ignore write errors
+  }
 }
 
 const initial = loadSettings();


### PR DESCRIPTION
## Summary
- replace filesystem-based settings storage with localStorage for browser compatibility
- remove Node fs usage from onboarding page and store profile in localStorage

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any; no-empty; no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_689b6aa4fedc83269a500a32ff7b5a32