### PR TITLE
feat: extend avatar store with milestones and moods

### DIFF
--- a/src/components/avatar/AvatarSphere.stories.tsx
+++ b/src/components/avatar/AvatarSphere.stories.tsx
@@ -1,6 +1,10 @@
 import React, { useEffect } from 'react';
 import { AvatarSphere } from './AvatarSphere';
-import { useAvatarStore, type AvatarMood } from '@/state/avatar';
+import {
+  useAvatarStore,
+  type AvatarMood,
+  type AvatarMilestone,
+} from '@/state/avatar';
 
 export default {
   title: 'Avatar/AvatarSphere',
@@ -15,6 +19,26 @@ function MoodStory({ mood }: { mood: AvatarMood }) {
   return <AvatarSphere />;
 }
 
+function MilestoneStory({
+  milestone,
+  streak = 0,
+}: {
+  milestone: AvatarMilestone;
+  streak?: number;
+}) {
+  const setMilestone = useAvatarStore((s) => s.setMilestone);
+  const setStreak = useAvatarStore((s) => s.setStreak);
+  useEffect(() => {
+    setMilestone(milestone);
+    setStreak(streak);
+  }, [milestone, streak, setMilestone, setStreak]);
+  return <AvatarSphere />;
+}
+
 export const Neutral = () => <MoodStory mood="neutral" />;
 export const Focused = () => <MoodStory mood="focused" />;
 export const Relaxed = () => <MoodStory mood="relaxed" />;
+export const GoalCompleted = () => <MilestoneStory milestone="goal" />;
+export const StreakAchieved = () => (
+  <MilestoneStory milestone="streak" streak={5} />
+);

--- a/src/components/avatar/AvatarSphere.tsx
+++ b/src/components/avatar/AvatarSphere.tsx
@@ -1,13 +1,17 @@
 import React, { useEffect, useRef } from 'react';
 import * as THREE from 'three';
-import { useAvatarStore, type AvatarMood } from '@/state/avatar';
+import {
+  useAvatarStore,
+  type AvatarMood,
+  type AvatarMilestone,
+} from '@/state/avatar';
 
 interface Props {
   size?: number;
 }
 
 export function AvatarSphere({ size = 96 }: Props) {
-  const { enabled, sentiment, audio, mood } = useAvatarStore();
+  const { enabled, sentiment, audio, mood, milestone, streak } = useAvatarStore();
   const mountRef = useRef<HTMLDivElement | null>(null);
   const analyserRef = useRef<AnalyserNode | null>(null);
   const meshRef = useRef<THREE.Mesh | null>(null);
@@ -15,6 +19,8 @@ export function AvatarSphere({ size = 96 }: Props) {
   const geomRef = useRef<THREE.IcosahedronGeometry | null>(null);
   const basePositions = useRef<Float32Array | null>(null);
   const moodRef = useRef<AvatarMood>('neutral');
+  const milestoneRef = useRef<AvatarMilestone>('none');
+  const streakRef = useRef<number>(0);
 
   // Setup scene
   useEffect(() => {
@@ -52,7 +58,14 @@ export function AvatarSphere({ size = 96 }: Props) {
         const level = sum / data.length / 128;
         const time = performance.now() * 0.001;
         const mood = moodRef.current;
+        const milestone = milestoneRef.current;
         let scale = 1 + level * 0.3;
+        if (milestone === 'goal') {
+          scale *= 1 + Math.sin(time * 6) * 0.2;
+        } else if (milestone === 'streak') {
+          const streakAmt = Math.min(streakRef.current, 10) / 10;
+          scale *= 1 + Math.sin(time * 2) * 0.1 * streakAmt;
+        }
         if (mood === 'focused') {
           meshRef.current.rotation.y += 0.02;
         } else if (mood === 'relaxed') {
@@ -138,6 +151,29 @@ export function AvatarSphere({ size = 96 }: Props) {
         matRef.current.emissive.set('#000000');
     }
   }, [mood]);
+
+  // React to milestone changes
+  useEffect(() => {
+    milestoneRef.current = milestone;
+    if (!matRef.current) return;
+    switch (milestone) {
+      case 'goal':
+        matRef.current.emissiveIntensity = 0.5;
+        matRef.current.wireframe = false;
+        break;
+      case 'streak':
+        matRef.current.emissiveIntensity = 0.2;
+        matRef.current.wireframe = true;
+        break;
+      default:
+        matRef.current.emissiveIntensity = 0;
+        matRef.current.wireframe = false;
+    }
+  }, [milestone]);
+
+  useEffect(() => {
+    streakRef.current = streak;
+  }, [streak]);
 
   if (!enabled) return null;
   return <div ref={mountRef} style={{ width: size, height: size }} />;

--- a/src/state/avatar.test.ts
+++ b/src/state/avatar.test.ts
@@ -7,4 +7,14 @@ describe('useAvatarStore', () => {
     store.setMood('focused');
     expect(useAvatarStore.getState().mood).toBe('focused');
   });
+
+  it('tracks milestones and streaks', () => {
+    const store = useAvatarStore.getState();
+    expect(store.milestone).toBe('none');
+    store.setMilestone('goal');
+    expect(useAvatarStore.getState().milestone).toBe('goal');
+    expect(store.streak).toBe(0);
+    store.setStreak(3);
+    expect(useAvatarStore.getState().streak).toBe(3);
+  });
 });

--- a/src/state/avatar.ts
+++ b/src/state/avatar.ts
@@ -9,14 +9,19 @@ type AvatarState = {
   audio: HTMLAudioElement | null;
   sentiment: number;
   mood: AvatarMood;
+  milestone: AvatarMilestone;
+  streak: number;
   setEnabled: (v: boolean) => void;
   setColor: (c: string) => void;
   setAudio: (a: HTMLAudioElement | null) => void;
   setSentiment: (s: number) => void;
   setMood: (m: AvatarMood) => void;
+  setMilestone: (m: AvatarMilestone) => void;
+  setStreak: (s: number) => void;
 };
 
 export type AvatarMood = "neutral" | "focused" | "relaxed";
+export type AvatarMilestone = "none" | "goal" | "streak";
 
 export const useAvatarStore = create<AvatarState>((set) => ({
   enabled:
@@ -30,6 +35,8 @@ export const useAvatarStore = create<AvatarState>((set) => ({
   audio: null,
   sentiment: 0,
   mood: "neutral",
+  milestone: "none",
+  streak: 0,
   setEnabled: (v) => {
     try {
       localStorage.setItem(AVATAR_ENABLE_KEY, String(v));
@@ -49,5 +56,7 @@ export const useAvatarStore = create<AvatarState>((set) => ({
   setAudio: (audio) => set({ audio }),
   setSentiment: (sentiment) => set({ sentiment }),
   setMood: (mood) => set({ mood }),
+  setMilestone: (milestone) => set({ milestone }),
+  setStreak: (streak) => set({ streak }),
 }));
 


### PR DESCRIPTION
## Summary
- track avatar milestone and streak state in `useAvatarStore`
- render milestone-driven shader and geometry changes in `AvatarSphere`
- add Storybook stories demonstrating goal completions and streaks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bad2ca4088326b663221b76ea8726