### PR TITLE
feat: add calendar and todo integration

### DIFF
--- a/agents/planner.py
+++ b/agents/planner.py
@@ -47,14 +47,18 @@ class PlannerAgent:
         goal = goal.strip() or "your goal"
         steps = self.plan(goal)
 
-        external_ids: Dict[str, List[str]] = {}
+        # Map each step to any external task/event IDs for later follow-up.
+        external_ids: Dict[str, Dict[str, str]] = {}
+
         if settings.get("integrations", {}).get("calendar") and self.calendar_api:
-            calendar_ids = [self.calendar_api.create_event(step) for step in steps]
+            calendar_ids = {
+                step: self.calendar_api.create_event(step) for step in steps
+            }
             if calendar_ids:
                 external_ids["calendar"] = calendar_ids
 
         if settings.get("integrations", {}).get("todo") and self.todo_api:
-            todo_ids = [self.todo_api.create_task(step) for step in steps]
+            todo_ids = {step: self.todo_api.create_task(step) for step in steps}
             if todo_ids:
                 external_ids["todo"] = todo_ids
 

--- a/memory/store.py
+++ b/memory/store.py
@@ -46,9 +46,14 @@ def save_memory(text: str, metadata: Dict[str, Any] | None = None) -> int:
 def save_plan(
     goal: str,
     steps: List[str],
-    external_ids: Dict[str, List[str]] | None = None,
+    external_ids: Dict[str, Dict[str, str]] | None = None,
 ) -> int:
-    """Persist a plan in the memory database."""
+    """Persist a plan in the memory database.
+
+    ``external_ids`` maps integration names (e.g. ``"calendar"``) to a
+    mapping of step text -> external task or event identifiers.  This allows
+    later follow-up with the respective services.
+    """
     text = f"Plan for {goal}: " + " | ".join(steps)
     metadata: Dict[str, Any] = {"tag": "plan", "goal": goal, "steps": steps}
     if external_ids:

--- a/tests/test_planner_agent.py
+++ b/tests/test_planner_agent.py
@@ -1,7 +1,5 @@
 import json
 
-import json
-
 from agents.planner import PlannerAgent
 from memory import store
 import settings
@@ -26,25 +24,58 @@ class DummyTodoAPI:
 
 
 def test_plan_persists_external_ids():
+    original = settings.settings["integrations"].copy()
     settings.settings["integrations"] = {"calendar": True, "todo": True}
 
-    # clean memory table
-    with store.db_lock:
-        store.cur.execute("DELETE FROM memories")
-        store.conn.commit()
+    try:
+        # clean memory table
+        with store.db_lock:
+            store.cur.execute("DELETE FROM memories")
+            store.conn.commit()
 
-    agent = PlannerAgent(
-        calendar_api=DummyCalendarAPI(), todo_api=DummyTodoAPI()
-    )
-    agent.handle("plan launch", "")
-
-    with store.db_lock:
-        store.cur.execute(
-            "SELECT metadata FROM memories ORDER BY id DESC LIMIT 1"
+        agent = PlannerAgent(
+            calendar_api=DummyCalendarAPI(), todo_api=DummyTodoAPI()
         )
-        meta_json = store.cur.fetchone()[0]
-    meta = json.loads(meta_json)
+        agent.handle("plan launch", "")
 
-    assert "external_ids" in meta
-    assert len(meta["external_ids"]["calendar"]) == 4
-    assert len(meta["external_ids"]["todo"]) == 4
+        with store.db_lock:
+            store.cur.execute(
+                "SELECT metadata FROM memories ORDER BY id DESC LIMIT 1"
+            )
+            meta_json = store.cur.fetchone()[0]
+        meta = json.loads(meta_json)
+
+        assert "external_ids" in meta
+        steps = meta["steps"]
+        cal_ids = meta["external_ids"]["calendar"]
+        todo_ids = meta["external_ids"]["todo"]
+        assert set(cal_ids.keys()) == set(steps)
+        assert set(todo_ids.keys()) == set(steps)
+    finally:
+        settings.settings["integrations"] = original
+
+
+def test_plan_skips_integrations_when_disabled():
+    original = settings.settings["integrations"].copy()
+    settings.settings["integrations"] = {"calendar": False, "todo": False}
+
+    try:
+        with store.db_lock:
+            store.cur.execute("DELETE FROM memories")
+            store.conn.commit()
+
+        agent = PlannerAgent(
+            calendar_api=DummyCalendarAPI(), todo_api=DummyTodoAPI()
+        )
+        agent.handle("plan launch", "")
+
+        with store.db_lock:
+            store.cur.execute(
+                "SELECT metadata FROM memories ORDER BY id DESC LIMIT 1"
+            )
+            meta_json = store.cur.fetchone()[0]
+        meta = json.loads(meta_json)
+
+        assert "external_ids" not in meta
+    finally:
+        settings.settings["integrations"] = original


### PR DESCRIPTION
## Summary
- map generated plan steps to external calendar and todo IDs when integrations are enabled
- persist external IDs in memory metadata for later follow-up
- add tests covering enabled/disabled integration scenarios

## Testing
- `PYTHONPATH=. pytest tests/test_planner_agent.py -q`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bad2e98cc8326aedaad816d630736