### PR TITLE
Add memory management UI and API with deletion cleanup tests

### DIFF
--- a/api/memory.py
+++ b/api/memory.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from memory.store import (
+    delete_memory,
+    list_memories,
+    save_memory,
+    update_memory,
+)
+
+app = FastAPI()
+
+
+class Memory(BaseModel):
+    text: str
+    metadata: dict | None = None
+
+
+class MemoryResponse(Memory):
+    id: int
+
+
+@app.get("/memories", response_model=list[MemoryResponse])
+def get_memories():
+    """Return all stored memories."""
+    return [MemoryResponse(**m) for m in list_memories()]
+
+
+@app.post("/memories", response_model=MemoryResponse)
+def create_memory(payload: Memory):
+    mem_id = save_memory(payload.text, payload.metadata)
+    return MemoryResponse(id=mem_id, text=payload.text, metadata=payload.metadata or {})
+
+
+@app.put("/memories/{mem_id}", response_model=MemoryResponse)
+def update_memory_endpoint(mem_id: int, payload: Memory):
+    updated = update_memory(mem_id, payload.text, payload.metadata)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Memory not found")
+    return MemoryResponse(id=mem_id, text=payload.text, metadata=payload.metadata or {})
+
+
+@app.delete("/memories/{mem_id}")
+def delete_memory_endpoint(mem_id: int):
+    if not delete_memory(mem_id):
+        raise HTTPException(status_code=404, detail="Memory not found")
+    return {"status": "ok"}

--- a/memory/store.py
+++ b/memory/store.py
@@ -77,6 +77,50 @@ def query_memory(query: str, k: int = 5) -> List[Dict[str, Any]]:
     return output
 
 
+def list_memories() -> List[Dict[str, Any]]:
+    """Return all stored memories."""
+    with db_lock:
+        cur.execute("SELECT id, text, metadata FROM memories")
+        rows = cur.fetchall()
+    output: List[Dict[str, Any]] = []
+    for mid, text, meta_json in rows:
+        try:
+            meta = json.loads(meta_json) if meta_json else {}
+        except Exception:
+            meta = {}
+        output.append({"id": mid, "text": text, "metadata": meta})
+    return output
+
+
+def update_memory(mem_id: int, text: str, metadata: Dict[str, Any] | None = None) -> bool:
+    """Update an existing memory and re-index its embedding."""
+    metadata = metadata or {}
+    with db_lock:
+        cur.execute("SELECT 1 FROM memories WHERE id=?", (mem_id,))
+        if not cur.fetchone():
+            return False
+        cur.execute(
+            "UPDATE memories SET text=?, metadata=? WHERE id=?",
+            (text, json.dumps(metadata), mem_id),
+        )
+        conn.commit()
+    vector_store.delete(str(mem_id))
+    vector_store.add(str(mem_id), text, metadata)
+    return True
+
+
+def delete_memory(mem_id: int) -> bool:
+    """Remove a memory and its embedding."""
+    with db_lock:
+        cur.execute("DELETE FROM memories WHERE id=?", (mem_id,))
+        removed = cur.rowcount > 0
+        if removed:
+            conn.commit()
+    if removed:
+        vector_store.delete(str(mem_id))
+    return removed
+
+
 if __name__ == "__main__":  # pragma: no cover - convenience CLI
     import sys
 

--- a/memory/vector_store.py
+++ b/memory/vector_store.py
@@ -88,6 +88,18 @@ class VectorStore:
         return [self._ids[i] for i in order[:k] if sims[i] > 0]
 
     # ------------------------------------------------------------------
+    def delete(self, doc_id: str) -> None:
+        """Remove a document and its embedding from the store."""
+        if self._use_chroma and self._collection is not None:  # pragma: no cover
+            self._collection.delete(ids=[doc_id])
+            return
+        if doc_id in self._ids:
+            idx = self._ids.index(doc_id)
+            del self._ids[idx]
+            del self._docs[idx]
+            del self._embeddings[idx]
+
+    # ------------------------------------------------------------------
     def clear(self) -> None:
         """Remove all stored documents."""
         if self._use_chroma and self._collection is not None:  # pragma: no cover

--- a/src/memory/MemoryManager.tsx
+++ b/src/memory/MemoryManager.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useState } from "react";
+import {
+  memoryStore,
+  type MemoryBucket,
+  type MemoryEntry,
+} from "@/memory/indexedDbMemory";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+
+interface Props {
+  bucket?: MemoryBucket;
+}
+
+export default function MemoryManager({ bucket = "semantic" }: Props) {
+  const [memories, setMemories] = useState<MemoryEntry[]>([]);
+  const [editing, setEditing] = useState<MemoryEntry | null>(null);
+  const [content, setContent] = useState("");
+  const [mood, setMood] = useState("");
+  const [context, setContext] = useState("");
+  const [confidence, setConfidence] = useState("");
+
+  useEffect(() => {
+    setMemories(memoryStore.list(bucket));
+  }, [bucket]);
+
+  const startEdit = (entry: MemoryEntry) => {
+    setEditing(entry);
+    setContent(entry.content);
+    setMood(entry.mood ?? "");
+    setContext(entry.context ?? "");
+    setConfidence(entry.confidence !== undefined ? String(entry.confidence) : "");
+  };
+
+  const submitEdit = async () => {
+    if (!editing) return;
+    await memoryStore.update(bucket, editing.id, {
+      content,
+      mood: mood || undefined,
+      context: context || undefined,
+      confidence: confidence ? Number(confidence) : undefined,
+    });
+    setEditing(null);
+    setMemories(memoryStore.list(bucket));
+  };
+
+  const handleDelete = (id: string) => {
+    memoryStore.delete(bucket, id);
+    setMemories(memoryStore.list(bucket));
+  };
+
+  return (
+    <div className="space-y-4">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Content</TableHead>
+            <TableHead>Mood</TableHead>
+            <TableHead>Context</TableHead>
+            <TableHead>Confidence</TableHead>
+            <TableHead className="w-[120px]">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {memories.map((m) => (
+            <TableRow key={m.id}>
+              <TableCell className="max-w-xs truncate">{m.content}</TableCell>
+              <TableCell>{m.mood}</TableCell>
+              <TableCell>{m.context}</TableCell>
+              <TableCell>{m.confidence ?? ""}</TableCell>
+              <TableCell>
+                <div className="flex gap-2">
+                  <Button size="sm" variant="outline" onClick={() => startEdit(m)}>
+                    Edit
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    onClick={() => handleDelete(m.id)}
+                  >
+                    Delete
+                  </Button>
+                </div>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      <Dialog open={!!editing} onOpenChange={() => setEditing(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit Memory</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-2 py-2">
+            <div className="space-y-1">
+              <Label htmlFor="content">Content</Label>
+              <Textarea
+                id="content"
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+              />
+            </div>
+            <div className="grid grid-cols-3 gap-2">
+              <div className="space-y-1">
+                <Label htmlFor="mood">Mood</Label>
+                <Input
+                  id="mood"
+                  value={mood}
+                  onChange={(e) => setMood(e.target.value)}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="context">Context</Label>
+                <Input
+                  id="context"
+                  value={context}
+                  onChange={(e) => setContext(e.target.value)}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="confidence">Confidence</Label>
+                <Input
+                  id="confidence"
+                  type="number"
+                  value={confidence}
+                  onChange={(e) => setConfidence(e.target.value)}
+                />
+              </div>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditing(null)}>
+              Cancel
+            </Button>
+            <Button onClick={submitEdit}>Save</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/tests/test_memory_api.py
+++ b/tests/test_memory_api.py
@@ -1,0 +1,34 @@
+from fastapi.testclient import TestClient
+
+from api.memory import app
+from memory import store as mem
+
+
+def setup_function(_):
+    # ensure a clean slate for each test
+    mem.cur.execute("DELETE FROM memories")
+    mem.conn.commit()
+    mem.vector_store.clear()
+
+
+def test_delete_removes_embedding_and_metadata():
+    client = TestClient(app)
+    resp = client.post(
+        "/memories",
+        json={"text": "delete me", "metadata": {"tag": "temp"}},
+    )
+    assert resp.status_code == 200
+    mem_id = resp.json()["id"]
+
+    # ensure the memory can be retrieved before deletion
+    assert mem.query_memory("delete me")
+
+    del_resp = client.delete(f"/memories/{mem_id}")
+    assert del_resp.status_code == 200
+
+    # embedding should be gone
+    assert mem.query_memory("delete me") == []
+
+    # database row should be removed
+    mem.cur.execute("SELECT id FROM memories WHERE id=?", (mem_id,))
+    assert mem.cur.fetchone() is None


### PR DESCRIPTION
## Summary
- build MemoryManager component to list, edit and delete local memories
- add FastAPI memory endpoints to create, update and remove memories
- ensure vector store and DB stay in sync and test deletion cleanup

## Testing
- `npm test`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bad3186988326917a2fb932ef5ac4