### PR TITLE
Add Gemini/ChatGPT call metrics and tests

### DIFF
--- a/core/__tests__/test_agent_metrics.py
+++ b/core/__tests__/test_agent_metrics.py
@@ -10,6 +10,10 @@ def _reset_metrics() -> None:
     metrics.planner_calls = 0
     metrics.hypnosis_calls = 0
     metrics.coaching_calls = 0
+    metrics.router_local = 0
+    metrics.router_cloud = 0
+    metrics.gemini_calls = 0
+    metrics.chatgpt_calls = 0
 
 def test_planner_calls_are_counted() -> None:
     _reset_metrics()

--- a/core/metrics.py
+++ b/core/metrics.py
@@ -13,6 +13,8 @@ class Metrics:
     coaching_calls: int = 0
     router_local: int = 0
     router_cloud: int = 0
+    gemini_calls: int = 0
+    chatgpt_calls: int = 0
 
     def as_dict(self) -> dict[str, int]:
         return asdict(self)
@@ -20,8 +22,8 @@ class Metrics:
     def increment_agent(self, name: str) -> None:
         """Increment the call counter for a given agent name.
 
-        ``name`` should be the lower-case agent identifier without the
-        ``Agent`` suffix, e.g. ``"planner"`` or ``"hypnosis"``.
+        ``name`` should be the lower-case agent or model identifier without
+        the ``Agent`` suffix, e.g. ``"planner"`` or ``"hypnosis"``.
         """
         attr = f"{name}_calls"
         if hasattr(self, attr):

--- a/orchestration/router.py
+++ b/orchestration/router.py
@@ -147,6 +147,7 @@ class ModelRouter:
             response = self.gemini_model(prompt)
             self.logger.log("gemini_offline", tokens, 0.0)
             _metrics().router_local += 1
+            _metrics().increment_agent("gemini")
             return response
 
         use_chatgpt = (
@@ -160,9 +161,11 @@ class ModelRouter:
             response = self.chatgpt_model(sanitized)
             self.logger.log("chatgpt", tokens, chatgpt_cost)
             _metrics().router_cloud += 1
+            _metrics().increment_agent("chatgpt")
             return response
 
         response = self.gemini_model(sanitized)
         self.logger.log("gemini", tokens, gemini_cost)
         _metrics().router_local += 1
+        _metrics().increment_agent("gemini")
         return response

--- a/tests/test_router_metrics.py
+++ b/tests/test_router_metrics.py
@@ -1,0 +1,41 @@
+from orchestration.router import ModelRouter, RouterConfig
+from core.metrics import metrics
+
+
+def test_router_increments_gemini_calls(monkeypatch):
+    monkeypatch.setattr("orchestration.router.is_online", lambda: True)
+    metrics.gemini_calls = 0
+    metrics.chatgpt_calls = 0
+
+    def gemini_model(prompt: str) -> str:
+        return "gemini"
+
+    def chatgpt_model(prompt: str) -> str:
+        return "chatgpt"
+
+    router = ModelRouter(gemini_model, chatgpt_model, config=RouterConfig(max_gemini_tokens=5))
+    router.route("short prompt")
+
+    data = metrics.as_dict()
+    assert data["gemini_calls"] == 1
+    assert data["chatgpt_calls"] == 0
+
+
+def test_router_increments_chatgpt_calls(monkeypatch):
+    monkeypatch.setattr("orchestration.router.is_online", lambda: True)
+    metrics.gemini_calls = 0
+    metrics.chatgpt_calls = 0
+
+    def gemini_model(prompt: str) -> str:
+        return "gemini"
+
+    def chatgpt_model(prompt: str) -> str:
+        return "chatgpt"
+
+    config = RouterConfig(max_gemini_tokens=5, depth_threshold=0, max_chatgpt_cost=1.0)
+    router = ModelRouter(gemini_model, chatgpt_model, config=config)
+    router.route("long prompt " * 50, depth=1)
+
+    data = metrics.as_dict()
+    assert data["chatgpt_calls"] == 1
+    assert data["gemini_calls"] == 0


### PR DESCRIPTION
## Summary
- Track gemini and chatgpt model invocations in `core.metrics`
- Increment model call metrics in `ModelRouter.route`
- Test that router updates gemini/chatgpt counters

## Testing
- `PYTHONPATH=. pytest tests/test_router_metrics.py -q`
- `PYTHONPATH=. pytest -q` *(fails: segmentation fault after initial tests)*

------
https://chatgpt.com/codex/tasks/task_e_689c7129320483268ef2269907df500b