### PR TITLE
feat: log consent decisions for flagged content

### DIFF
--- a/safety/filter.py
+++ b/safety/filter.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 import sys
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Tuple
 
 # Configure logger
 _LOG_PATH = Path(__file__).with_name("filter.log")
@@ -47,64 +47,70 @@ except Exception:  # pragma: no cover - runtime failure is acceptable
     _moderator = None
 
 WARNING_MESSAGE = "\u26a0\ufe0f Content removed for safety."
+WARNING_TEMPLATE = WARNING_MESSAGE + " (rule: {rule})."
 
 
-def request_user_confirmation(text: str) -> bool:
+def request_user_confirmation(text: str, rule: str) -> bool:
     """Ask the user to confirm display of flagged ``text``.
 
     Returns ``True`` if the user grants consent. Non-interactive environments
-    automatically return ``False``.
+    automatically return ``False``. The triggering moderation ``rule`` is
+    included in the prompt and log for transparency.
     """
 
     if not sys.stdin.isatty():
         logger.info(
-            "consent skipped (non-interactive): %s",
+            "consent skipped (%s, non-interactive): %s",
+            rule,
             text.replace("\n", " ")[:200],
         )
         return False
 
     try:
         decision = input(
-            "\u26a0\ufe0f Potentially harmful content detected. View anyway? [y/N]: "
+            f"\u26a0\ufe0f Potentially harmful content detected ({rule}). View anyway? [y/N]: "
         )
     except Exception:  # pragma: no cover - interactive failure
-        logger.exception("consent prompt failed")
+        logger.exception("consent prompt failed (%s)", rule)
         return False
 
     accepted = decision.strip().lower() in {"y", "yes"}
     logger.info(
-        "consent %s: %s",
+        "consent %s (%s): %s",
         "granted" if accepted else "denied",
+        rule,
         text.replace("\n", " ")[:200],
     )
     return accepted
 
 
-def _is_harmful(text: str, intent: str | None = None) -> bool:
-    """Return ``True`` if ``text`` appears harmful.
+def _is_harmful(text: str, intent: str | None = None) -> Tuple[bool, str | None]:
+    """Return ``(is_harmful, rule)`` for ``text``.
 
     An optional ``intent`` hint may provide additional context such as
-    "seeking_help" which can reduce false positives.
+    "seeking_help" which can reduce false positives. ``rule`` provides an
+    explanation for why the text was flagged.
     """
 
     lower = text.lower()
-    if any(kw in lower for kw in KEYWORDS):
-        helpful_context = {"help", "support", "prevention"}
-        if intent and intent.lower() in helpful_context:
-            return False
-        if any(term in lower for term in helpful_context):
-            return False
-        return True
+    for kw in KEYWORDS:
+        if kw in lower:
+            helpful_context = {"help", "support", "prevention"}
+            if intent and intent.lower() in helpful_context:
+                return False, None
+            if any(term in lower for term in helpful_context):
+                return False, None
+            return True, f"keyword '{kw}'"
     if _moderator is not None:
         try:
             result = _moderator(text, truncation=True)[0]
             label = result.get("label", "").lower()
             score = float(result.get("score", 0))
             if label in {"toxic", "harmful"} and score >= 0.5:
-                return True
+                return True, f"moderation model ({label}:{score:.2f})"
         except Exception:
             pass
-    return False
+    return False, None
 
 def filter_output(text: str, *, intent: str | None = None) -> str:
     """Filter ``text`` returning a safe alternative if necessary.
@@ -113,9 +119,10 @@ def filter_output(text: str, *, intent: str | None = None) -> str:
     content to be returned. Decisions are logged to ``filter.log``.
     """
 
-    if _is_harmful(text, intent=intent):
-        if request_user_confirmation(text):
+    harmful, rule = _is_harmful(text, intent=intent)
+    if harmful:
+        if request_user_confirmation(text, rule or "unknown"):
             return text
-        logger.warning("blocked: %s", text.replace("\n", " ")[:200])
-        return WARNING_MESSAGE
+        logger.warning("blocked (%s): %s", rule, text.replace("\n", " ")[:200])
+        return WARNING_TEMPLATE.format(rule=rule)
     return text

--- a/tests/test_safety_filter.py
+++ b/tests/test_safety_filter.py
@@ -1,0 +1,46 @@
+import sys
+
+import safety.filter as safety_filter
+
+
+def _clear_log():
+    log_path = safety_filter._LOG_PATH
+    log_path.write_text("")
+    return log_path
+
+
+def _flush_logs():
+    for handler in safety_filter.logger.handlers:
+        handler.flush()
+
+
+def test_logs_consent_denied(monkeypatch):
+    log_path = _clear_log()
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda prompt="": "n")
+
+    text = "I am thinking about suicide"
+    result = safety_filter.filter_output(text)
+    expected = safety_filter.WARNING_TEMPLATE.format(rule="keyword 'suicide'")
+    assert result == expected
+
+    _flush_logs()
+    content = log_path.read_text()
+    assert "consent denied" in content
+    assert "keyword 'suicide'" in content
+    assert "blocked (keyword 'suicide')" in content
+
+
+def test_logs_consent_granted(monkeypatch):
+    log_path = _clear_log()
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda prompt="": "y")
+
+    text = "I am thinking about suicide"
+    result = safety_filter.filter_output(text)
+    assert result == text
+
+    _flush_logs()
+    content = log_path.read_text()
+    assert "consent granted" in content
+    assert "keyword 'suicide'" in content


### PR DESCRIPTION
## Summary
- prompt users for confirmation when risky content is detected and log consent decisions
- explain which safety rule triggered a block and return rule in warning message
- add unit tests to ensure consent decisions and reasons are logged to `safety/filter.log`

## Testing
- `PYTHONPATH=$PWD pytest tests/test_safety_filter.py`
- `PYTHONPATH=$PWD pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_689c71294e288326b0bca0e568a77539