### PR TITLE
Remove temporary audio files after voice processing

### DIFF
--- a/voice/server.py
+++ b/voice/server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import os
 import tempfile
 from typing import List
 
@@ -81,6 +82,8 @@ async def voice_endpoint(request: Request):
                 "audio": base64.b64encode(reply_audio).decode(),
             }
             channel.send(json.dumps(message))
+            recorder_file.close()
+            os.remove(recorder_file.name)
 
     await pc.setRemoteDescription(offer)
     answer = await pc.createAnswer()


### PR DESCRIPTION
## Summary
- Ensure voice WebRTC handler cleans up temporary recording files after responding

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c7c3274448326a5f56d1b09db4f31