### PR TITLE
Include user message in fallback routing

### DIFF
--- a/core/__tests__/test_fallback_routing.py
+++ b/core/__tests__/test_fallback_routing.py
@@ -1,0 +1,34 @@
+"""Tests for fallback routing when no specialized agent handles the message."""
+
+from core.brain import BrainAgent
+
+
+def test_user_message_appended_when_routed(monkeypatch):
+    """Router should receive persona, memories, and the latest user message."""
+    captured: dict[str, str] = {}
+
+    brain = BrainAgent(
+        persona_store=lambda: "persona",
+        memory_store=lambda _msg: ["memory"],
+        agents=[],
+    )
+
+    def fake_route(prompt: str) -> str:
+        captured["prompt"] = prompt
+        return "router-response"
+
+    monkeypatch.setattr(brain.router, "route", fake_route)
+
+    result = brain.process("hello")
+
+    expected = (
+        "You are the idealized version of the user.\n"
+        "Persona: persona\n"
+        "Relevant memories:\n"
+        "memory\n"
+        "\n"
+        "User message:\n"
+        "hello"
+    )
+    assert captured["prompt"] == expected
+    assert result == "router-response"

--- a/core/brain.py
+++ b/core/brain.py
@@ -153,7 +153,8 @@ class BrainAgent:
         if response is None:
             self._current_agent = None
             self._current_message = message
-            response = self.router.route(context)
+            combined = f"{context}\nUser message:\n{message}"
+            response = self.router.route(combined)
 
         if self.coach is not None:
             coaching = self.coach.generate(context)


### PR DESCRIPTION
## Summary
- Append the user's latest message to the context when no specialized agent handles it, ensuring persona, memories, and message are distinct sections before routing.
- Add regression test to verify the router receives the full context with the user message.

## Testing
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c7c082ef883268a2bc1f0934f35d7