### PR TITLE
feat: add shared prompt builder

### DIFF
--- a/core/brain.py
+++ b/core/brain.py
@@ -18,6 +18,7 @@ from safety.filter import filter_output
 from orchestration.router import ModelRouter, UsageLogger
 from .logger import get_logger
 from .metrics import metrics
+from .prompt import build_prompt
 
 
 class SupportsAgent(Protocol):
@@ -49,20 +50,22 @@ class BrainAgent:
         Optional :class:`CoachingAgent` that always generates a short
         motivational snippet which is appended to the chosen agent's
         response.
-    prompt_template:
-        Format string used to build the master prompt.  ``{persona}`` and
-        ``{memories}`` placeholders will be replaced prior to dispatch.
+    behavior_style:
+        Optional description of the assistant's behavior style to include in
+        the prompt.
+    skills:
+        Optional sequence describing available skills.
+    filters:
+        Optional sequence naming active output filters.
     """
 
     persona_store: Callable[[], str]
     memory_store: Callable[[str], Iterable[str | Mapping[str, Any]]]
     agents: Sequence[SupportsAgent] = field(default_factory=list)
     coach: CoachingAgent | None = None
-    prompt_template: str = (
-        "You are the idealized version of the user.\n"
-        "Persona: {persona}\n"
-        "Relevant memories:\n{memories}\n"
-    )
+    behavior_style: str = ""
+    skills: Sequence[str] = field(default_factory=list)
+    filters: Sequence[str] = field(default_factory=list)
     router: ModelRouter = field(init=False)
     _current_agent: SupportsAgent | None = field(init=False, default=None)
     _current_message: str = field(init=False, default="")
@@ -123,8 +126,13 @@ class BrainAgent:
                 if text:
                     memories.append(str(text))
 
-        memory_text = "\n".join(memories)
-        context = self.prompt_template.format(persona=persona, memories=memory_text)
+        context = build_prompt(
+            persona,
+            memories,
+            behavior_style=self.behavior_style,
+            skills=self.skills,
+            filters=self.filters,
+        )
 
         response = None
         for agent in self.agents:

--- a/core/prompt.js
+++ b/core/prompt.js
@@ -1,0 +1,20 @@
+export function buildPrompt(
+  persona,
+  memories,
+  behaviorStyle = "",
+  skills = [],
+  filters = [],
+) {
+  const parts = [
+    "You are the idealized version of the user.",
+    `Persona: ${persona}`,
+    "Relevant memories:",
+    memories.join("\n"),
+  ];
+  if (behaviorStyle) parts.push(`Behavior style: ${behaviorStyle}`);
+  if (skills.length) parts.push(`Available skills: ${skills.join("; ")}`);
+  if (filters.length) parts.push(`Applied filters: ${filters.join(", ")}`);
+  return parts.join("\n").trim();
+}
+
+export default buildPrompt;

--- a/core/prompt.py
+++ b/core/prompt.py
@@ -1,0 +1,44 @@
+"""Shared prompt builder for persona and memory context."""
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+
+def build_prompt(
+    persona: str,
+    memories: Iterable[str],
+    behavior_style: str = "",
+    skills: Sequence[str] | None = None,
+    filters: Sequence[str] | None = None,
+) -> str:
+    """Construct the master prompt.
+
+    Parameters
+    ----------
+    persona:
+        Description of the user's ideal persona.
+    memories:
+        Iterable of memory snippets relevant to the current conversation.
+    behavior_style:
+        Optional description of the assistant's behavior style.
+    skills:
+        Optional sequence describing available skills.
+    filters:
+        Optional sequence naming active output filters.
+    """
+
+    skills = skills or []
+    filters = filters or []
+    parts = [
+        "You are the idealized version of the user.",
+        f"Persona: {persona}",
+        "Relevant memories:",
+        "\n".join(memories),
+    ]
+    if behavior_style:
+        parts.append(f"Behavior style: {behavior_style}")
+    if skills:
+        parts.append("Available skills: " + "; ".join(skills))
+    if filters:
+        parts.append("Applied filters: " + ", ".join(filters))
+    return "\n".join(parts).strip()

--- a/core/prompt.ts
+++ b/core/prompt.ts
@@ -1,0 +1,20 @@
+export function buildPrompt(
+  persona: string,
+  memories: string[],
+  behaviorStyle: string = "",
+  skills: string[] = [],
+  filters: string[] = [],
+): string {
+  const parts = [
+    "You are the idealized version of the user.",
+    `Persona: ${persona}`,
+    "Relevant memories:",
+    memories.join("\n"),
+  ];
+  if (behaviorStyle) parts.push(`Behavior style: ${behaviorStyle}`);
+  if (skills.length) parts.push(`Available skills: ${skills.join("; ")}`);
+  if (filters.length) parts.push(`Applied filters: ${filters.join(", ")}`);
+  return parts.join("\n").trim();
+}
+
+export default buildPrompt;

--- a/supabase/functions/aurora-chat/index.ts
+++ b/supabase/functions/aurora-chat/index.ts
@@ -6,6 +6,7 @@ import brain from "../../../src/brain/Brain.ts";
 import { getFilterName } from "../../../src/brain/filters.ts";
 import { summarizeProfile, UserProfile } from "../../../src/data/profile.ts";
 import { analyzeSentiment } from "../../../src/utils/sentiment.ts";
+import { buildPrompt } from "../../../core/prompt.ts";
 
 
 const corsHeaders = {
@@ -53,6 +54,20 @@ serve(async (req) => {
 
     const usedModel = model || "o4-mini-2025-04-16"; // cost-effective default
 
+    const profileSummary = summarizeProfile(profile);
+    const filterNames = brain.filters
+      .map((f) => getFilterName(f))
+      .filter((n): n is string => Boolean(n));
+    const skills = brain.skills.map((s) => `${s.name}: ${s.description}`);
+
+    const builtPrompt = buildPrompt(
+      profileSummary || "",
+      [],
+      brain.behavior.style,
+      skills,
+      filterNames,
+    );
+
     const systemMessages = [
       { role: "system", content: brain.cognition.systemPrompt },
     ];
@@ -61,26 +76,7 @@ serve(async (req) => {
       systemMessages.push({ role: "system", content: brain.cognition.contextPrompt });
     }
 
-    systemMessages.push({ role: "system", content: `Behavior style: ${brain.behavior.style}` });
-
-    const skillPrompt = brain.skills
-      .map((s) => `${s.name}: ${s.description}`)
-      .join("; ");
-    if (skillPrompt) {
-      systemMessages.push({ role: "system", content: `Available skills: ${skillPrompt}` });
-    }
-
-    const profileSummary = summarizeProfile(profile);
-    if (profileSummary) {
-      systemMessages.unshift({ role: "system", content: `User profile: ${profileSummary}` });
-    }
-
-    const filterNames = brain.filters
-      .map((f) => getFilterName(f))
-      .filter((n): n is string => Boolean(n));
-    if (filterNames.length > 0) {
-      systemMessages.push({ role: "system", content: `Applied filters: ${filterNames.join(", ")}` });
-    }
+    systemMessages.push({ role: "system", content: builtPrompt });
 
     const payload = messages && Array.isArray(messages)
       ? { model: usedModel, messages: [...systemMessages, ...messages] }

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -1,0 +1,39 @@
+import subprocess
+import json
+import importlib.util
+from pathlib import Path
+
+
+spec = importlib.util.spec_from_file_location(
+    "prompt", Path(__file__).resolve().parents[1] / "core" / "prompt.py"
+)
+prompt = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(prompt)
+build_prompt = prompt.build_prompt
+
+
+def run_js_builder(persona, memories, behavior_style, skills, filters):
+    script = (
+        "import { buildPrompt } from './core/prompt.js';\n"
+        f"console.log(buildPrompt({json.dumps(persona)}, {json.dumps(memories)}, {json.dumps(behavior_style)}, {json.dumps(skills)}, {json.dumps(filters)}));"
+    )
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def test_prompt_builder_matches_js():
+    persona = "Confident coder"
+    memories = ["Finished project", "Won hackathon"]
+    behavior_style = "supportive"
+    skills = ["coding", "debugging"]
+    filters = ["sarcasm"]
+
+    py_prompt = build_prompt(persona, memories, behavior_style, skills, filters)
+    js_prompt = run_js_builder(persona, memories, behavior_style, skills, filters)
+
+    assert py_prompt == js_prompt


### PR DESCRIPTION
## Summary
- add cross-runtime prompt builder capturing persona, memories, behavior style, skills, and filters
- refactor BrainAgent to use shared builder
- reuse builder in Supabase aurora-chat function and add unit test verifying parity between Python and JS implementations

## Testing
- `PYTHONPATH=. pytest tests/test_prompt_builder.py`
- `npm test`
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*


------
https://chatgpt.com/codex/tasks/task_e_689c9ab3b4e0832680ae7a1dc4570353