### PR TITLE
feat(memory): add exclusion filters to avoid duplicate recall

### DIFF
--- a/core/__tests__/test_agent_metrics.py
+++ b/core/__tests__/test_agent_metrics.py
@@ -25,7 +25,7 @@ def test_planner_calls_are_counted() -> None:
         def handle(self, message: str, context: str) -> str:
             return "plan"
 
-    brain = BrainAgent(persona_store=lambda: "", memory_store=lambda _msg: [], agents=[PlannerAgent()])
+    brain = BrainAgent(persona_store=lambda: "", memory_store=lambda _msg, exclude_ids=None: [], agents=[PlannerAgent()])
     brain.process("anything")
 
     assert metrics.planner_calls == 1
@@ -40,7 +40,7 @@ def test_hypnosis_calls_are_counted() -> None:
         def handle(self, message: str, context: str) -> str:
             return "hypnosis"
 
-    brain = BrainAgent(persona_store=lambda: "", memory_store=lambda _msg: [], agents=[HypnosisAgent()])
+    brain = BrainAgent(persona_store=lambda: "", memory_store=lambda _msg, exclude_ids=None: [], agents=[HypnosisAgent()])
     brain.process("anything")
 
     assert metrics.hypnosis_calls == 1
@@ -61,7 +61,7 @@ def test_coaching_calls_are_counted() -> None:
 
     brain = BrainAgent(
         persona_store=lambda: "",
-        memory_store=lambda _msg: [],
+        memory_store=lambda _msg, exclude_ids=None: [],
         agents=[DummyAgent()],
         coach=CoachingAgent(),
     )

--- a/core/__tests__/test_fallback_routing.py
+++ b/core/__tests__/test_fallback_routing.py
@@ -9,7 +9,7 @@ def test_user_message_appended_when_routed(monkeypatch):
 
     brain = BrainAgent(
         persona_store=lambda: "persona",
-        memory_store=lambda _msg: ["memory"],
+        memory_store=lambda _msg, exclude_ids=None: ["memory"],
         agents=[],
     )
 

--- a/core/__tests__/test_style_application.py
+++ b/core/__tests__/test_style_application.py
@@ -15,7 +15,7 @@ class DummyAgent:
 
 
 def _make_brain() -> BrainAgent:
-    return BrainAgent(persona_store=lambda: "", memory_store=lambda _msg: [], agents=[DummyAgent()])
+    return BrainAgent(persona_store=lambda: "", memory_store=lambda _msg, exclude_ids=None: [], agents=[DummyAgent()])
 
 
 def test_tone_is_applied(monkeypatch):

--- a/core/brain.py
+++ b/core/brain.py
@@ -6,8 +6,6 @@ dispatching a user message to a suitable sub-agent.
 """
 from __future__ import annotations
 
-import asyncio
-import threading
 from dataclasses import dataclass, field
 from typing import Any, Callable, Iterable, Mapping, Protocol, Sequence
 
@@ -55,7 +53,7 @@ class BrainAgent:
     """
 
     persona_store: Callable[[], str]
-    memory_store: Callable[[str], Iterable[str | Mapping[str, Any]]]
+    memory_store: Callable[[str, Iterable[int] | None], Iterable[str | Mapping[str, Any]]]
     agents: Sequence[SupportsAgent] = field(default_factory=list)
     coach: CoachingAgent | None = None
     prompt_template: str = (
@@ -66,6 +64,7 @@ class BrainAgent:
     router: ModelRouter = field(init=False)
     _current_agent: SupportsAgent | None = field(init=False, default=None)
     _current_message: str = field(init=False, default="")
+    _recent_memory_ids: list[int] = field(init=False, default_factory=list)
 
     def __post_init__(self) -> None:
         self.router = ModelRouter(self._local_model, self._cloud_model, logger=UsageLogger())
@@ -79,16 +78,10 @@ class BrainAgent:
         return self._local_model(prompt)
 
     def _save_memory_async(self, text: str, role: str) -> None:
-        """Persist ``text`` with ``role`` metadata without blocking."""
-        metadata = {"role": role}
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            threading.Thread(
-                target=save_memory, args=(text, metadata), daemon=True
-            ).start()
-        else:
-            loop.run_in_executor(None, save_memory, text, metadata)
+        """Persist ``text`` with ``role`` metadata and record its ID."""
+
+        mem_id = save_memory(text, {"role": role})
+        self._recent_memory_ids.append(mem_id)
 
     def process(self, message: str, request_id: str | None = None) -> str:
         """Process a user ``message`` by delegating to a sub-agent.
@@ -106,7 +99,7 @@ class BrainAgent:
         persona = self.persona_store() or ""
 
         try:
-            raw_memories = list(self.memory_store(message))
+            raw_memories = list(self.memory_store(message, exclude_ids=self._recent_memory_ids))
         except Exception:
             metrics.errors += 1
             logger.exception("memory store error", extra={"request_id": request_id, "agent": "memory_store"})

--- a/memory/store.py
+++ b/memory/store.py
@@ -5,7 +5,8 @@ import json
 import os
 import sqlite3
 import threading
-from typing import Any, Dict, List
+import time
+from typing import Any, Dict, Iterable, List
 
 from .vector_store import VectorStore
 
@@ -15,16 +16,25 @@ CHROMA_PATH = os.path.join(os.path.dirname(__file__), "chroma_db")
 conn = sqlite3.connect(DB_PATH, check_same_thread=False)
 cur = conn.cursor()
 db_lock = threading.Lock()
+# Ensure the backing table exists and has a ``created_at`` column for age filtering
 cur.execute(
     """
     CREATE TABLE IF NOT EXISTS memories (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         text TEXT NOT NULL,
-        metadata TEXT
+        metadata TEXT,
+        created_at REAL DEFAULT (strftime('%s','now'))
     )
     """,
 )
 conn.commit()
+
+# Backwards compatibility: older databases might lack ``created_at``
+cur.execute("PRAGMA table_info(memories)")
+columns = {row[1] for row in cur.fetchall()}
+if "created_at" not in columns:
+    cur.execute("ALTER TABLE memories ADD COLUMN created_at REAL DEFAULT (strftime('%s','now'))")
+    conn.commit()
 
 vector_store = VectorStore(CHROMA_PATH)
 
@@ -61,24 +71,52 @@ def save_plan(
     return save_memory(text, metadata)
 
 
-def query_memory(query: str, k: int = 5) -> List[Dict[str, Any]]:
-    """Return top ``k`` memories relevant to ``query`` using similarity search."""
-    ids = [int(i) for i in vector_store.query(query, k)]
+def query_memory(
+    query: str,
+    k: int = 5,
+    exclude_ids: Iterable[int] | None = None,
+    min_age_days: int | None = None,
+) -> List[Dict[str, Any]]:
+    """Return top ``k`` memories relevant to ``query`` using similarity search.
+
+    Parameters
+    ----------
+    query:
+        Search query.
+    k:
+        Maximum number of memories to return.
+    exclude_ids:
+        Iterable of memory IDs that should be skipped.
+    min_age_days:
+        Minimum age in days for returned memories.  Memories newer than this
+        threshold are excluded.
+    """
+
+    exclude_ids_set = set(exclude_ids or [])
+
+    ids = [int(i) for i in vector_store.query(query, k + len(exclude_ids_set))]
+    ids = [i for i in ids if i not in exclude_ids_set]
     if not ids:
         return []
+
     placeholders = ",".join(["?"] * len(ids))
     cur.execute(
-        f"SELECT id, text, metadata FROM memories WHERE id IN ({placeholders})",
+        f"SELECT id, text, metadata, created_at FROM memories WHERE id IN ({placeholders})",
         ids,
     )
     rows = cur.fetchall()
     output: List[Dict[str, Any]] = []
-    for mid, text, meta_json in rows:
+    now = time.time()
+    for mid, text, meta_json, created_at in rows:
+        if min_age_days is not None and created_at is not None:
+            age_days = (now - float(created_at)) / 86400
+            if age_days < min_age_days:
+                continue
         try:
             meta = json.loads(meta_json) if meta_json else {}
         except Exception:
             meta = {}
-        output.append({"id": mid, "text": text, "metadata": meta})
+        output.append({"id": mid, "text": text, "metadata": meta, "created_at": created_at})
     return output
 
 

--- a/tests/test_conversation_flow.py
+++ b/tests/test_conversation_flow.py
@@ -24,7 +24,7 @@ def chat(payload: dict):
     message = payload["message"]
     brain = BrainAgent(
         persona_store=lambda: state["persona"],
-        memory_store=lambda _msg: state["memories"],
+        memory_store=lambda _msg, exclude_ids=None: state["memories"],
     )
     reply = brain.process(message)
     state["memories"].append(message)

--- a/tests/test_memory_recall.py
+++ b/tests/test_memory_recall.py
@@ -17,7 +17,9 @@ class EchoAgent:
 def _brain() -> BrainAgent:
     return BrainAgent(
         persona_store=lambda: "",
-        memory_store=lambda msg: [m["text"] for m in mem.query_memory(msg)],
+        memory_store=lambda msg, exclude_ids=None: [
+            m["text"] for m in mem.query_memory(msg, exclude_ids=exclude_ids)
+        ],
         agents=[EchoAgent()],
     )
 
@@ -34,3 +36,32 @@ def test_similarity_recall(monkeypatch):
     monkeypatch.setattr(brain, "_save_memory_async", lambda text, role: None)
     reply = brain.process("What is my secret hobby?")
     assert "alpine-unicycling" in reply
+
+
+def test_query_memory_exclude_ids():
+    """Memories listed in ``exclude_ids`` should not be returned."""
+    mem.cur.execute("DELETE FROM memories")
+    mem.conn.commit()
+    mem.vector_store.clear()
+
+    mid = mem.save_memory("banana split dessert")
+    assert mem.query_memory("banana")[0]["id"] == mid
+    assert mem.query_memory("banana", exclude_ids=[mid]) == []
+
+
+def test_brain_avoids_recent_message_echos(monkeypatch):
+    """BrainAgent should exclude IDs from the current conversation."""
+    brain = _brain()
+
+    # Make memory saving synchronous for deterministic testing
+    monkeypatch.setattr(
+        brain,
+        "_save_memory_async",
+        lambda text, role: brain._recent_memory_ids.append(
+            mem.save_memory(text, {"role": role})
+        ),
+    )
+
+    brain.process("I love unit tests")
+    reply = brain.process("What did I just say?")
+    assert "I love unit tests" not in reply

--- a/tests/test_persona_style.py
+++ b/tests/test_persona_style.py
@@ -29,7 +29,7 @@ def test_persona_profile_applied(tmp_path):
     try:
         brain = BrainAgent(
             persona_store=lambda: "",
-            memory_store=lambda _msg: [],
+            memory_store=lambda _msg, exclude_ids=None: [],
             agents=[EchoAgent()],
         )
         result = brain.process("Hi")

--- a/tests/test_voice_memory_recall.py
+++ b/tests/test_voice_memory_recall.py
@@ -110,7 +110,7 @@ def test_voice_recall(monkeypatch):
 
     monkeypatch.setattr(vs, "_load_profile", lambda: {})
 
-    def fake_query_memory(message: str, k: int = 5):  # noqa: ARG001
+    def fake_query_memory(message: str, k: int = 5, exclude_ids=None, min_age_days=None):  # noqa: ARG001
         return [{"text": m} for m in stored]
 
     monkeypatch.setattr(vs, "query_memory", fake_query_memory)

--- a/tests/test_voice_metrics.py
+++ b/tests/test_voice_metrics.py
@@ -8,7 +8,7 @@ def test_voice_message_counts_single_conversation() -> None:
     """Processing a single voice message increments conversation count once."""
     metrics.conversations = 0
 
-    brain = BrainAgent(persona_store=lambda: "", memory_store=lambda _msg: [])
+    brain = BrainAgent(persona_store=lambda: "", memory_store=lambda _msg, exclude_ids=None: [])
     brain.process("hello there")
 
     assert metrics.conversations == 1

--- a/voice/server.py
+++ b/voice/server.py
@@ -31,8 +31,8 @@ def load_persona() -> str:
     return " ".join(part for part in parts if part)
 
 
-def fetch_memories(message: str) -> List[str]:
-    return [m["text"] for m in query_memory(message)]
+def fetch_memories(message: str, exclude_ids: List[int] | None = None) -> List[str]:
+    return [m["text"] for m in query_memory(message, exclude_ids=exclude_ids)]
 
 
 brain = BrainAgent(persona_store=load_persona, memory_store=fetch_memories)


### PR DESCRIPTION
## Summary
- support `exclude_ids` and `min_age_days` filters when querying memory
- avoid echoing recent messages by tracking memory IDs in `BrainAgent`
- ensure voice and tests use updated memory API

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c9abe3d548326963b3ee448384824