### PR TITLE
feat: stream voice transcription with configurable model size

### DIFF
--- a/voice/README.md
+++ b/voice/README.md
@@ -1,0 +1,32 @@
+# Voice Module
+
+This package provides speech-to-text (STT) and text-to-speech (TTS) utilities
+for the Aurora project.  By default it uses [Whisper](https://github.com/openai/whisper)
+for transcription and streams results to the client over WebRTC.
+
+## Configuring Whisper Model Size
+
+The STT pipeline loads a Whisper model at import time.  You can adjust the
+model size by setting the `WHISPER_MODEL_SIZE` environment variable before
+starting the voice server:
+
+```bash
+export WHISPER_MODEL_SIZE=small   # tiny, base, small, medium, large
+```
+
+Larger models are generally more accurate but require more memory and take
+longer to transcribe audio.  Smaller models provide lower latency at the cost
+of accuracy.
+
+## Streaming Transcription
+
+`voice/server.py` begins transcribing audio as soon as recording starts and
+periodically streams intermediate transcripts back to the browser.  This reduces
+perceived delay for the user, but it comes with trade-offs:
+
+- The same audio may be transcribed multiple times, increasing CPU usage.
+- Intermediate transcripts can occasionally include partial or misheard phrases
+  that are corrected in later updates.
+
+When the recording ends, the final transcript and synthesized reply audio are
+sent together over the data channel.

--- a/voice/server.py
+++ b/voice/server.py
@@ -70,20 +70,39 @@ async def voice_endpoint(request: Request):
             recorder.addTrack(track)
             await recorder.start()
             await track.recv()  # wait for at least one frame
-            await asyncio.sleep(0.1)
-            await recorder.stop()
-            with open(recorder_file.name, "rb") as f:
-                audio_bytes = f.read()
-            text = transcribe_audio(audio_bytes)
-            reply_text = brain.process(text)
-            reply_audio = synthesize_reply(reply_text)
-            message = {
-                "transcript": text,
-                "audio": base64.b64encode(reply_audio).decode(),
-            }
-            channel.send(json.dumps(message))
-            recorder_file.close()
-            os.remove(recorder_file.name)
+
+            stop_event = asyncio.Event()
+            loop = asyncio.get_running_loop()
+            final_text: asyncio.Future[str] = loop.create_future()
+
+            async def transcription_worker() -> None:
+                last_text = ""
+                while not stop_event.is_set():
+                    with open(recorder_file.name, "rb") as f:
+                        audio_bytes = f.read()
+                    text = transcribe_audio(audio_bytes)
+                    if text and text != last_text:
+                        channel.send(json.dumps({"transcript": text}))
+                        last_text = text
+                    await asyncio.sleep(0.3)
+                final_text.set_result(last_text)
+
+            asyncio.create_task(transcription_worker())
+
+            @track.on("ended")
+            async def on_ended() -> None:
+                await recorder.stop()
+                stop_event.set()
+                text = await final_text
+                reply_text = brain.process(text)
+                reply_audio = synthesize_reply(reply_text)
+                message = {
+                    "transcript": text,
+                    "audio": base64.b64encode(reply_audio).decode(),
+                }
+                channel.send(json.dumps(message))
+                recorder_file.close()
+                os.remove(recorder_file.name)
 
     await pc.setRemoteDescription(offer)
     answer = await pc.createAnswer()

--- a/voice/stt.py
+++ b/voice/stt.py
@@ -1,19 +1,28 @@
 """Speech-to-text utilities using Whisper models."""
 from __future__ import annotations
 
-import io
+import os
 import tempfile
 from typing import Optional
 
+# Determine which Whisper model to load.  Smaller models are faster but less
+# accurate.  The ``WHISPER_MODEL_SIZE`` environment variable allows overriding
+# the default ``"base"`` size when starting the server.
+_MODEL_SIZE = os.environ.get("WHISPER_MODEL_SIZE", "base")
+
 try:
     from faster_whisper import WhisperModel
-    _MODEL: Optional[WhisperModel] = WhisperModel("base")
+
+    _MODEL: Optional[WhisperModel] = WhisperModel(_MODEL_SIZE)
+
     def _run_model(path: str, language: str | None) -> str:
         segments, _ = _MODEL.transcribe(path, language=language)
         return "".join(seg.text for seg in segments).strip()
 except Exception:  # pragma: no cover - fallback to openai whisper
     import whisper
-    _MODEL = whisper.load_model("base")
+
+    _MODEL = whisper.load_model(_MODEL_SIZE)
+
     def _run_model(path: str, language: str | None) -> str:
         result = _MODEL.transcribe(path, language=language)
         return result["text"].strip()


### PR DESCRIPTION
## Summary
- allow configuring Whisper model via `WHISPER_MODEL_SIZE`
- stream incremental transcripts while audio recording is active
- document model size options and streaming trade-offs

## Testing
- `PYTHONPATH=. pytest tests/test_voice_metrics.py tests/test_voice_memory_recall.py`


------
https://chatgpt.com/codex/tasks/task_e_689c9dcefd048326a50a4411b666ac23