### PR TITLE
Warm TTS on import with audio normalization

### DIFF
--- a/tests/test_voice_metrics.py
+++ b/tests/test_voice_metrics.py
@@ -1,5 +1,15 @@
 """Tests for voice conversation metrics."""
 
+import importlib
+import importlib.util
+import sys
+import types
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
 from core.brain import BrainAgent
 from core.metrics import metrics
 
@@ -12,3 +22,54 @@ def test_voice_message_counts_single_conversation() -> None:
     brain.process("hello there")
 
     assert metrics.conversations == 1
+
+
+def test_first_synthesis_warm_start(monkeypatch: Any) -> None:
+    """Warm TTS model avoids delay on the first synthesis."""
+
+    fake_time = {"value": 0.0}
+
+    def fake_monotonic() -> float:
+        return fake_time["value"]
+
+    def fake_sleep(secs: float) -> None:
+        fake_time["value"] += secs
+
+    monkeypatch.setattr(time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(time, "sleep", fake_sleep)
+
+    class DummyTTS:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - boilerplate
+            fake_sleep(5)
+            self.synthesizer = types.SimpleNamespace(output_sample_rate=16000)
+
+        def tts(self, _text: str, speaker_wav: str | None = None) -> np.ndarray:
+            return np.zeros(10, dtype=np.float32)
+
+    def dummy_write(buf: Any, _data: Any, samplerate: int, format: str = "WAV") -> None:  # pragma: no cover - simple stub
+        buf.write(b"FAKE")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "TTS.api",
+        types.SimpleNamespace(TTS=DummyTTS),
+    )
+    monkeypatch.setitem(sys.modules, "soundfile", types.SimpleNamespace(write=dummy_write))
+
+    pkg = types.ModuleType("voice")
+    pkg.__path__ = [str(Path("voice"))]
+    sys.modules["voice"] = pkg
+
+    spec = importlib.util.spec_from_file_location("voice.tts", Path("voice/tts.py"))
+    tts_module = importlib.util.module_from_spec(spec)
+    sys.modules["voice.tts"] = tts_module
+    assert spec.loader is not None  # for mypy
+    spec.loader.exec_module(tts_module)
+    warm_time = fake_time["value"]
+
+    start = time.monotonic()
+    tts_module.synthesize_reply("hello")
+    duration = time.monotonic() - start
+
+    assert warm_time == 5
+    assert duration == 0

--- a/voice/tts.py
+++ b/voice/tts.py
@@ -6,6 +6,7 @@ import json
 import urllib.request
 from typing import Optional
 
+import numpy as np
 import soundfile as sf
 from TTS.api import TTS
 
@@ -34,6 +35,12 @@ def _get_tts(model_path: str | None) -> TTS:
         else:
             _TTS = TTS(model_name="tts_models/en/vctk/vits")
     return _TTS
+
+
+try:
+    _get_tts(CONFIG.model_path)
+except Exception:
+    pass
 
 
 def _api_synthesize(endpoint: str, text: str, voice_clone: Optional[str]) -> bytes:
@@ -78,6 +85,12 @@ def synthesize_reply(text: str, *, voice_clone: Optional[str] = None) -> bytes:
         audio = tts.tts(text, speaker_wav=voice_clone)
     else:
         audio = tts.tts(text)
+
+    audio = np.asarray(audio)
+    rms = np.sqrt(np.mean(np.square(audio)))
+    if rms > 0:
+        audio = audio / rms
+
     buf = io.BytesIO()
     sf.write(buf, audio, samplerate=tts.synthesizer.output_sample_rate, format="WAV")
     return buf.getvalue()


### PR DESCRIPTION
## Summary
- Preload TTS model at import time to avoid first-call delays and added RMS normalization for generated audio
- Introduce regression test confirming first synthesis avoids initialization lag

## Testing
- `PYTHONPATH=. pytest tests/test_voice_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_689c9dd02ec883269e4d4a5fb579bed0