### PR TITLE
Centralize configuration and validate environment variables

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+"""Central configuration management for core, voice, and api modules."""
+
+from dataclasses import dataclass
+import os
+
+
+@dataclass
+class ModelConfig:
+    """Configuration for selecting local or remote models."""
+
+    local: str | None = None
+    cloud: str | None = None
+    voice_model_path: str | None = None
+    voice_api_endpoint: str | None = None
+
+
+@dataclass
+class APIKeys:
+    """Stores API keys for external services."""
+
+    openai: str | None = None
+    elevenlabs: str | None = None
+
+    def validate(self) -> None:
+        """Ensure required API keys are present."""
+        missing = [
+            name
+            for name, value in {
+                "OPENAI_API_KEY": self.openai,
+                "ELEVENLABS_API_KEY": self.elevenlabs,
+            }.items()
+            if not value
+        ]
+        if missing:
+            raise EnvironmentError(
+                "Missing environment variables: " + ", ".join(missing)
+            )
+
+
+@dataclass
+class RuntimeOptions:
+    """Miscellaneous runtime toggles."""
+
+    debug: bool = False
+
+
+@dataclass
+class AppConfig:
+    """Aggregate application configuration."""
+
+    models: ModelConfig
+    api_keys: APIKeys
+    runtime: RuntimeOptions
+
+    def validate(self) -> None:
+        """Validate configuration and raise if any required values are missing."""
+        self.api_keys.validate()
+
+
+def load_config(*, validate: bool = False) -> AppConfig:
+    """Load application configuration from environment variables.
+
+    Parameters
+    ----------
+    validate:
+        When ``True``, ``AppConfig.validate`` is invoked before returning and
+        missing required environment variables will raise ``EnvironmentError``.
+    """
+    cfg = AppConfig(
+        models=ModelConfig(
+            local=os.getenv("LOCAL_MODEL"),
+            cloud=os.getenv("CLOUD_MODEL"),
+            voice_model_path=os.getenv("VOICE_MODEL_PATH"),
+            voice_api_endpoint=os.getenv("VOICE_API_ENDPOINT"),
+        ),
+        api_keys=APIKeys(
+            openai=os.getenv("OPENAI_API_KEY"),
+            elevenlabs=os.getenv("ELEVENLABS_API_KEY"),
+        ),
+        runtime=RuntimeOptions(
+            debug=os.getenv("DEBUG", "").lower() in {"1", "true", "yes"}
+        ),
+    )
+    if validate:
+        cfg.validate()
+    return cfg
+
+
+CONFIG: AppConfig = load_config()

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,26 @@
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+
+
+def _load_core_config():
+    """Load ``core.config`` without importing the entire ``core`` package."""
+    spec = importlib.util.spec_from_file_location("core.config", Path("core/config.py"))
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_missing_api_keys_raise_error(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+
+    core_config = _load_core_config()
+    with pytest.raises(EnvironmentError) as excinfo:
+        core_config.load_config(validate=True)
+    msg = str(excinfo.value)
+    assert "OPENAI_API_KEY" in msg and "ELEVENLABS_API_KEY" in msg

--- a/voice/config.py
+++ b/voice/config.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 """Configuration for voice synthesis backends."""
 
 from dataclasses import dataclass
-import os
+
+from core.config import CONFIG as CORE_CONFIG
 
 
 @dataclass
@@ -22,10 +23,11 @@ class VoiceConfig:
 
 
 def load_config() -> VoiceConfig:
-    """Load configuration from environment variables."""
+    """Load configuration from the central app config."""
+    models = CORE_CONFIG.models
     return VoiceConfig(
-        model_path=os.getenv("VOICE_MODEL_PATH"),
-        api_endpoint=os.getenv("VOICE_API_ENDPOINT"),
+        model_path=models.voice_model_path,
+        api_endpoint=models.voice_api_endpoint,
     )
 
 


### PR DESCRIPTION
## Summary
- add `core/config.py` with dataclasses for model selection, API keys and runtime options
- switch voice config to pull values from the central config
- allow optional validation when loading config to raise on missing API keys and add a test

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi', 'numpy')*
- `PYTHONPATH=$PWD pytest tests/test_config_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_689c9dcd10948326b485e1cfb6110686