### PR TITLE
feat: add voice mode options during onboarding

### DIFF
--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -11,10 +11,14 @@ import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
 export default function Onboarding() {
   const navigate = useNavigate();
   const { user } = useSupabaseAuth();
-  const voiceId = useVoiceStore((s) => s.voiceId);
+  const { voiceId, setMode } = useVoiceStore((s) => ({
+    voiceId: s.voiceId,
+    setMode: s.setMode,
+  }));
   const [step, setStep] = useState(0);
   const [name, setName] = useState("");
   const [goals, setGoals] = useState("");
+  const [showVoiceSetup, setShowVoiceSetup] = useState(false);
 
   const saveProfile = async () => {
     const data = { name, goals, voiceId };
@@ -43,10 +47,16 @@ export default function Onboarding() {
     }
   };
 
+  useEffect(() => {
+    if (step === 2 && showVoiceSetup && voiceId) {
+      setMode("cloned");
+      next();
+    }
+  }, [voiceId, showVoiceSetup, step]);
+
   const disabled =
     (step === 0 && !name.trim()) ||
-    (step === 1 && !goals.trim()) ||
-    (step === 2 && !voiceId);
+    (step === 1 && !goals.trim());
 
   return (
     <div className="min-h-svh flex flex-col items-center justify-center gap-4 p-4">
@@ -68,13 +78,57 @@ export default function Onboarding() {
       )}
       {step === 2 && (
         <div className="w-full max-w-sm space-y-2">
-          <p className="text-sm">Record a short voice sample.</p>
-          <VoiceSetup />
+          {!showVoiceSetup ? (
+            <>
+              <p className="text-sm">Choose a voice option:</p>
+              <div className="space-y-2">
+                <Button className="w-full" onClick={() => setShowVoiceSetup(true)}>
+                  Use my sample
+                </Button>
+                <Button
+                  className="w-full"
+                  onClick={() => {
+                    setMode("eleven-default");
+                    next();
+                  }}
+                >
+                  Use default voice
+                </Button>
+                <Button
+                  className="w-full"
+                  variant="ghost"
+                  onClick={() => {
+                    const mode = import.meta.env.VITE_ELEVEN_API_KEY
+                      ? "eleven-default"
+                      : "browser-tts";
+                    setMode(mode);
+                    next();
+                  }}
+                >
+                  Skip for now
+                </Button>
+              </div>
+            </>
+          ) : (
+            <>
+              <p className="text-sm">Record a short voice sample.</p>
+              <VoiceSetup />
+              <Button
+                variant="ghost"
+                className="w-full"
+                onClick={() => setShowVoiceSetup(false)}
+              >
+                Back
+              </Button>
+            </>
+          )}
         </div>
       )}
-      <Button onClick={next} disabled={disabled}>
-        {step < 2 ? "Next" : "Finish"}
-      </Button>
+      {step < 2 && (
+        <Button onClick={next} disabled={disabled}>
+          Next
+        </Button>
+      )}
     </div>
   );
 }

--- a/src/state/voice.ts
+++ b/src/state/voice.ts
@@ -5,16 +5,21 @@ const VOICE_SPEED_KEY = "aurora.voiceSpeed";
 const VOICE_PITCH_KEY = "aurora.voicePitch";
 const VOICE_EXPR_KEY = "aurora.voiceExpression";
 const VOICE_EMOTION_KEY = "aurora.voiceEmotion";
+const VOICE_MODE_KEY = "aurora.voiceMode";
+
+type VoiceMode = "cloned" | "eleven-default" | "browser-tts";
 
 type VoiceState = {
   isSpeaking: boolean;
   voiceId: string | null;
+  mode: VoiceMode;
   speed: number;
   pitch: number;
   expression: number;
   emotion: string;
   setSpeaking: (v: boolean) => void;
   setVoiceId: (id: string | null) => void;
+  setMode: (m: VoiceMode) => void;
   setSpeed: (v: number) => void;
   setPitch: (v: number) => void;
   setExpression: (v: number) => void;
@@ -27,6 +32,11 @@ export const useVoiceStore = create<VoiceState>((set) => ({
     typeof window !== "undefined"
       ? window.localStorage.getItem(VOICE_ID_KEY)
       : null,
+  mode:
+    typeof window !== "undefined"
+      ? ((window.localStorage.getItem(VOICE_MODE_KEY) as VoiceMode) ||
+          (import.meta.env.VITE_ELEVEN_API_KEY ? "eleven-default" : "browser-tts"))
+      : "browser-tts",
   speed:
     typeof window !== "undefined"
       ? Number(window.localStorage.getItem(VOICE_SPEED_KEY) || 1)
@@ -52,6 +62,14 @@ export const useVoiceStore = create<VoiceState>((set) => ({
       /* ignore storage errors */
     }
     set({ voiceId: id });
+  },
+  setMode: (mode) => {
+    try {
+      window.localStorage.setItem(VOICE_MODE_KEY, mode);
+    } catch {
+      /* ignore */
+    }
+    set({ mode });
   },
   setSpeed: (speed) => {
     try {


### PR DESCRIPTION
## Summary
- allow onboarding without a cloned voice by removing voiceId requirement
- offer voice choices (sample, default, skip) and persist selected voice mode
- extend voice store with mode field stored in localStorage

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, Empty block statement, A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689ca4a7c30c8326a64b552369f85eb2