### PR TITLE
feat: persist voice mode and locale

### DIFF
--- a/src/components/VoiceSetup.tsx
+++ b/src/components/VoiceSetup.tsx
@@ -16,6 +16,8 @@ export default function VoiceSetup() {
     setPitch,
     expression,
     setExpression,
+    setMode,
+    setLocale,
   } = useVoiceStore();
   const [uploading, setUploading] = useState(false);
   const [recording, setRecording] = useState(false);
@@ -40,6 +42,8 @@ export default function VoiceSetup() {
       const json = await resp.json();
       if (json?.voice_id) {
         setVoiceId(json.voice_id);
+        setMode("cloned");
+        setLocale(navigator.language || "en-US");
         try {
           const { data: auth } = await supabase.auth.getUser();
           const uid = auth.user?.id;

--- a/src/hypno/tts.ts
+++ b/src/hypno/tts.ts
@@ -15,13 +15,17 @@ export async function playHypno(
   onEnd: () => void,
   onError?: (err: unknown) => void
 ): Promise<PlaybackHandle | null> {
+  const { voiceId, mode, locale } = useVoiceStore.getState();
+  if (mode === "off") {
+    onEnd();
+    return null;
+  }
   // Try ElevenLabs via Supabase function
   try {
-    const voiceId = useVoiceStore.getState().voiceId;
     const { data, error } = await supabase.functions.invoke("tts-generate", {
-      body: { text, voiceId },
+      body: { text, voiceId: mode === "cloned" ? voiceId : undefined },
     });
-    if (!error && data?.audioBase64) {
+    if (mode !== "browser-tts" && !error && data?.audioBase64) {
       const src = `data:${data.contentType};base64,${data.audioBase64}`;
       const audio = new Audio(src);
       audio.onended = onEnd;
@@ -51,6 +55,7 @@ export async function playHypno(
     const utter = new SpeechSynthesisUtterance(text);
     utter.rate = 0.95;
     utter.pitch = 1.0;
+    utter.lang = locale;
     utter.onend = onEnd;
     window.speechSynthesis.speak(utter);
     return {

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -11,14 +11,19 @@ import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
 export default function Onboarding() {
   const navigate = useNavigate();
   const { user } = useSupabaseAuth();
-  const { voiceId, setMode } = useVoiceStore((s) => ({
+  const { voiceId, setMode, setLocale } = useVoiceStore((s) => ({
     voiceId: s.voiceId,
     setMode: s.setMode,
+    setLocale: s.setLocale,
   }));
   const [step, setStep] = useState(0);
   const [name, setName] = useState("");
   const [goals, setGoals] = useState("");
   const [showVoiceSetup, setShowVoiceSetup] = useState(false);
+
+  useEffect(() => {
+    setLocale(navigator.language || "en-US");
+  }, [setLocale]);
 
   const saveProfile = async () => {
     const data = { name, goals, voiceId };

--- a/src/state/voice.ts
+++ b/src/state/voice.ts
@@ -6,13 +6,20 @@ const VOICE_PITCH_KEY = "aurora.voicePitch";
 const VOICE_EXPR_KEY = "aurora.voiceExpression";
 const VOICE_EMOTION_KEY = "aurora.voiceEmotion";
 const VOICE_MODE_KEY = "aurora.voiceMode";
+const VOICE_LOCALE_KEY = "aurora.voiceLocale";
 
-type VoiceMode = "cloned" | "eleven-default" | "browser-tts";
+type VoiceMode =
+  | "cloned"
+  | "eleven-default"
+  | "browser-tts"
+  | "local-tts"
+  | "off";
 
 type VoiceState = {
   isSpeaking: boolean;
   voiceId: string | null;
   mode: VoiceMode;
+  locale: string;
   speed: number;
   pitch: number;
   expression: number;
@@ -20,6 +27,7 @@ type VoiceState = {
   setSpeaking: (v: boolean) => void;
   setVoiceId: (id: string | null) => void;
   setMode: (m: VoiceMode) => void;
+  setLocale: (l: string) => void;
   setSpeed: (v: number) => void;
   setPitch: (v: number) => void;
   setExpression: (v: number) => void;
@@ -37,6 +45,12 @@ export const useVoiceStore = create<VoiceState>((set) => ({
       ? ((window.localStorage.getItem(VOICE_MODE_KEY) as VoiceMode) ||
           (import.meta.env.VITE_ELEVEN_API_KEY ? "eleven-default" : "browser-tts"))
       : "browser-tts",
+  locale:
+    typeof window !== "undefined"
+      ? window.localStorage.getItem(VOICE_LOCALE_KEY) ||
+        navigator.language ||
+        "en-US"
+      : "en-US",
   speed:
     typeof window !== "undefined"
       ? Number(window.localStorage.getItem(VOICE_SPEED_KEY) || 1)
@@ -70,6 +84,14 @@ export const useVoiceStore = create<VoiceState>((set) => ({
       /* ignore */
     }
     set({ mode });
+  },
+  setLocale: (locale) => {
+    try {
+      window.localStorage.setItem(VOICE_LOCALE_KEY, locale);
+    } catch {
+      /* ignore */
+    }
+    set({ locale });
   },
   setSpeed: (speed) => {
     try {

--- a/src/voice/useTextToSpeech.ts
+++ b/src/voice/useTextToSpeech.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useVoiceStore } from "@/state/voice";
 import { playClonedVoice } from "./voiceClone";
+import { supabase } from "@/integrations/supabase/client";
 
 export function useTextToSpeech() {
   const [isSpeaking, setIsSpeaking] = useState(false);
@@ -9,13 +10,16 @@ export function useTextToSpeech() {
   });
   const utterRef = useRef<SpeechSynthesisUtterance | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
-  const { voiceId, speed, pitch, expression, emotion } = useVoiceStore((s) => ({
-    voiceId: s.voiceId,
-    speed: s.speed,
-    pitch: s.pitch,
-    expression: s.expression,
-    emotion: s.emotion,
-  }));
+  const { voiceId, speed, pitch, expression, emotion, mode, locale } =
+    useVoiceStore((s) => ({
+      voiceId: s.voiceId,
+      speed: s.speed,
+      pitch: s.pitch,
+      expression: s.expression,
+      emotion: s.emotion,
+      mode: s.mode,
+      locale: s.locale,
+    }));
 
   // Allow enabling via first user gesture (click/keydown) OR explicit call
   useEffect(() => {
@@ -39,9 +43,9 @@ export function useTextToSpeech() {
 
   const speak = useCallback(
     async (text: string) => {
-      if (!enabled || !text?.trim()) return; // <- gate prevents NotAllowedError
-      // Try cloned voice via Supabase when a voiceId is configured
-      if (voiceId) {
+      if (!enabled || !text?.trim() || mode === "off") return; // <- gate prevents NotAllowedError
+      // Try cloned voice via Supabase when selected
+      if (mode === "cloned" && voiceId) {
         const audio = await playClonedVoice(text, voiceId, {
           emotion,
           speed,
@@ -56,6 +60,27 @@ export function useTextToSpeech() {
         }
       }
 
+      if (mode !== "browser-tts") {
+        try {
+          const { data, error } = await supabase.functions.invoke("tts-generate", {
+            body: { text, voiceId: mode === "cloned" ? voiceId : undefined, emotion, speed, pitch, expression },
+          });
+          if (!error && data?.audioBase64) {
+            const src = `data:${data.contentType};base64,${data.audioBase64}`;
+            const audio = new Audio(src);
+            audioRef.current = audio;
+            audio.onplay = () => setIsSpeaking(true);
+            const end = () => setIsSpeaking(false);
+            audio.onended = end;
+            audio.onerror = end;
+            await audio.play();
+            return;
+          }
+        } catch (e) {
+          console.error("[tts] tts-generate failed", e);
+        }
+      }
+
       // Fallback to Web Speech API
       try {
         window.speechSynthesis.cancel();
@@ -63,6 +88,7 @@ export function useTextToSpeech() {
         utterRef.current = u;
         u.rate = speed;
         u.pitch = pitch;
+        u.lang = locale;
         u.onstart = () => setIsSpeaking(true);
         u.onend = () => setIsSpeaking(false);
         u.onerror = () => setIsSpeaking(false);
@@ -71,7 +97,7 @@ export function useTextToSpeech() {
         setIsSpeaking(false);
       }
     },
-    [enabled, voiceId, speed, pitch, expression, emotion],
+    [enabled, voiceId, speed, pitch, expression, emotion, mode, locale],
   );
 
   const cancel = useCallback(() => {

--- a/src/voice/voiceio.ts
+++ b/src/voice/voiceio.ts
@@ -26,7 +26,7 @@ export class VoiceIO {
       return;
     }
     this.recognition = new SR();
-    this.recognition.lang = document.documentElement.lang || navigator.language || 'en-US';
+    this.recognition.lang = useVoiceStore.getState().locale;
     this.recognition.interimResults = true;
     this.recognition.maxAlternatives = 1;
 
@@ -61,43 +61,47 @@ export class VoiceIO {
   }
 
   async speak(text: string) {
-    const { voiceId, speed, pitch, expression, emotion } =
+    const { voiceId, speed, pitch, expression, emotion, mode, locale } =
       useVoiceStore.getState();
+    if (mode === "off") return;
     try {
-      const { data, error } = await supabase.functions.invoke("tts-generate", {
-        body: { text, voiceId, emotion, speed, pitch, expression },
-      });
-      if (!error && data?.audioBase64) {
-        const src = `data:${data.contentType};base64,${data.audioBase64}`;
-        const audio = new Audio(src);
-        this.audio = audio;
-        useAvatarStore.getState().setAudio(audio);
-        audio.onplay = () => {
-          useVoiceStore.getState().setSpeaking(true);
-          this.callbacks.onSpeakingChange?.(true);
-        };
-        const end = () => {
-          useVoiceStore.getState().setSpeaking(false);
-          this.callbacks.onSpeakingChange?.(false);
-          useAvatarStore.getState().setAudio(null);
-          useAvatarStore.getState().setSentiment(0);
-        };
-        audio.onended = end;
-        audio.onerror = (e) => {
-          end();
-          this.callbacks.onError?.(e);
-        };
-        await audio.play();
-        return;
+      if (mode !== "browser-tts") {
+        const { data, error } = await supabase.functions.invoke("tts-generate", {
+          body: { text, voiceId: mode === "cloned" ? voiceId : undefined, emotion, speed, pitch, expression },
+        });
+        if (!error && data?.audioBase64) {
+          const src = `data:${data.contentType};base64,${data.audioBase64}`;
+          const audio = new Audio(src);
+          this.audio = audio;
+          useAvatarStore.getState().setAudio(audio);
+          audio.onplay = () => {
+            useVoiceStore.getState().setSpeaking(true);
+            this.callbacks.onSpeakingChange?.(true);
+          };
+          const end = () => {
+            useVoiceStore.getState().setSpeaking(false);
+            this.callbacks.onSpeakingChange?.(false);
+            useAvatarStore.getState().setAudio(null);
+            useAvatarStore.getState().setSentiment(0);
+          };
+          audio.onended = end;
+          audio.onerror = (e) => {
+            end();
+            this.callbacks.onError?.(e);
+          };
+          await audio.play();
+          return;
+        }
       }
     } catch (e) {
       this.callbacks.onError?.(e);
     }
 
-    if (!('speechSynthesis' in window)) return;
+    if (!("speechSynthesis" in window)) return;
     const u = new SpeechSynthesisUtterance(text);
     u.rate = speed;
     u.pitch = pitch;
+    u.lang = locale;
     u.onstart = () => {
       useVoiceStore.getState().setSpeaking(true);
       this.callbacks.onSpeakingChange?.(true);


### PR DESCRIPTION
## Summary
- extend voice store with persisted `mode` and `locale`
- sync onboarding and voice setup flows with new setters
- respect voice mode and locale across text-to-speech helpers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cb07543f08326ab46fb89aa6a722a