### PR TITLE
feat: implement voice fallback modes

### DIFF
--- a/src/state/voice.ts
+++ b/src/state/voice.ts
@@ -7,7 +7,12 @@ const VOICE_EXPR_KEY = "aurora.voiceExpression";
 const VOICE_EMOTION_KEY = "aurora.voiceEmotion";
 const VOICE_MODE_KEY = "aurora.voiceMode";
 
-type VoiceMode = "cloned" | "eleven-default" | "browser-tts";
+type VoiceMode =
+  | "cloned"
+  | "eleven-default"
+  | "browser-tts"
+  | "local-tts"
+  | "off";
 
 type VoiceState = {
   isSpeaking: boolean;
@@ -19,7 +24,7 @@ type VoiceState = {
   emotion: string;
   setSpeaking: (v: boolean) => void;
   setVoiceId: (id: string | null) => void;
-  setMode: (m: VoiceMode) => void;
+  setMode: (m: VoiceMode, persist?: boolean) => void;
   setSpeed: (v: number) => void;
   setPitch: (v: number) => void;
   setExpression: (v: number) => void;
@@ -63,11 +68,13 @@ export const useVoiceStore = create<VoiceState>((set) => ({
     }
     set({ voiceId: id });
   },
-  setMode: (mode) => {
-    try {
-      window.localStorage.setItem(VOICE_MODE_KEY, mode);
-    } catch {
-      /* ignore */
+  setMode: (mode, persist = true) => {
+    if (persist) {
+      try {
+        window.localStorage.setItem(VOICE_MODE_KEY, mode);
+      } catch {
+        /* ignore */
+      }
     }
     set({ mode });
   },

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -7,5 +7,6 @@ declare module 'virtual:pwa-register' {
 interface ImportMetaEnv {
   readonly VITE_SUPABASE_URL: string;
   readonly VITE_SUPABASE_ANON_KEY: string;
+  readonly VITE_ELEVEN_DEFAULT_VOICE_ID?: string;
 }
 

--- a/src/voice/useTextToSpeech.ts
+++ b/src/voice/useTextToSpeech.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "@/hooks/use-toast";
 import { useVoiceStore } from "@/state/voice";
 import { playClonedVoice } from "./voiceClone";
+
+const ELEVENLABS_DEFAULT_VOICE_ID =
+  import.meta.env.VITE_ELEVEN_DEFAULT_VOICE_ID || "9BWtsMINqrJLrRacOk9x";
 
 export function useTextToSpeech() {
   const [isSpeaking, setIsSpeaking] = useState(false);
@@ -9,13 +13,17 @@ export function useTextToSpeech() {
   });
   const utterRef = useRef<SpeechSynthesisUtterance | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
-  const { voiceId, speed, pitch, expression, emotion } = useVoiceStore((s) => ({
-    voiceId: s.voiceId,
-    speed: s.speed,
-    pitch: s.pitch,
-    expression: s.expression,
-    emotion: s.emotion,
-  }));
+  const downgradeToast = useRef(false);
+  const { voiceId, speed, pitch, expression, emotion, mode, setMode } =
+    useVoiceStore((s) => ({
+      voiceId: s.voiceId,
+      speed: s.speed,
+      pitch: s.pitch,
+      expression: s.expression,
+      emotion: s.emotion,
+      mode: s.mode,
+      setMode: s.setMode,
+    }));
 
   // Allow enabling via first user gesture (click/keydown) OR explicit call
   useEffect(() => {
@@ -24,6 +32,7 @@ export function useTextToSpeech() {
       setEnabled(true);
       localStorage.setItem("aurora_voice_enabled", "1");
       try {
+        window.speechSynthesis.getVoices();
         window.speechSynthesis.resume();
       } catch {
         /* ignore */
@@ -39,39 +48,105 @@ export function useTextToSpeech() {
 
   const speak = useCallback(
     async (text: string) => {
-      if (!enabled || !text?.trim()) return; // <- gate prevents NotAllowedError
-      // Try cloned voice via Supabase when a voiceId is configured
-      if (voiceId) {
-        const audio = await playClonedVoice(text, voiceId, {
-          emotion,
-          speed,
-          pitch,
-          expression,
-          onStart: () => setIsSpeaking(true),
-          onEnd: () => setIsSpeaking(false),
-        });
-        if (audio) {
-          audioRef.current = audio;
-          return;
+      if (!enabled || !text?.trim()) return; // gate prevents NotAllowedError
+
+      let current = mode;
+      const locale = navigator.language;
+
+      while (current && current !== "off") {
+        if (current === "cloned") {
+          if (!voiceId) {
+            current = "eleven-default";
+            setMode("eleven-default", false);
+            continue;
+          }
+          const { audio, error } = await playClonedVoice(text, voiceId, {
+            emotion,
+            speed,
+            pitch,
+            expression,
+            onStart: () => setIsSpeaking(true),
+            onEnd: () => setIsSpeaking(false),
+          });
+          if (audio) {
+            audioRef.current = audio;
+            return;
+          }
+          const status = (error as { status?: number } | undefined)?.status;
+          if ((status === 401 || status === 429) && !downgradeToast.current) {
+            toast({
+              title: "Cloned voice unavailable",
+              description: "Using default voice",
+            });
+            downgradeToast.current = true;
+          }
+          current = "eleven-default";
+          setMode("eleven-default", false);
+          continue;
+        }
+        if (current === "eleven-default") {
+          const { audio } = await playClonedVoice(
+            text,
+            ELEVENLABS_DEFAULT_VOICE_ID,
+            {
+              emotion,
+              speed,
+              pitch,
+              expression,
+              onStart: () => setIsSpeaking(true),
+              onEnd: () => setIsSpeaking(false),
+            },
+          );
+          if (audio) {
+            audioRef.current = audio;
+            return;
+          }
+          current = "browser-tts";
+          setMode("browser-tts", false);
+          continue;
+        }
+        if (current === "browser-tts") {
+          try {
+            window.speechSynthesis.cancel();
+            let voices = window.speechSynthesis.getVoices();
+            if (!voices.length) {
+              await new Promise((r) => setTimeout(r, 250));
+              voices = window.speechSynthesis.getVoices();
+            }
+            const v = voices.find(
+              (vo) =>
+                vo.lang === locale ||
+                vo.lang.startsWith(locale.split("-")[0]),
+            );
+            if (!v) {
+              current = "off";
+              setMode("off", false);
+              continue;
+            }
+            const u = new SpeechSynthesisUtterance(text);
+            utterRef.current = u;
+            u.voice = v;
+            u.rate = speed;
+            u.pitch = pitch;
+            u.onstart = () => setIsSpeaking(true);
+            u.onend = () => setIsSpeaking(false);
+            u.onerror = () => setIsSpeaking(false);
+            window.speechSynthesis.speak(u);
+            return;
+          } catch {
+            current = "off";
+            setMode("off", false);
+            continue;
+          }
+        }
+        if (current === "local-tts") {
+          current = "off";
+          setMode("off", false);
+          continue;
         }
       }
-
-      // Fallback to Web Speech API
-      try {
-        window.speechSynthesis.cancel();
-        const u = new SpeechSynthesisUtterance(text);
-        utterRef.current = u;
-        u.rate = speed;
-        u.pitch = pitch;
-        u.onstart = () => setIsSpeaking(true);
-        u.onend = () => setIsSpeaking(false);
-        u.onerror = () => setIsSpeaking(false);
-        window.speechSynthesis.speak(u);
-      } catch {
-        setIsSpeaking(false);
-      }
     },
-    [enabled, voiceId, speed, pitch, expression, emotion],
+    [enabled, mode, voiceId, emotion, speed, pitch, expression, setMode],
   );
 
   const cancel = useCallback(() => {
@@ -89,6 +164,7 @@ export function useTextToSpeech() {
     setEnabled(true);
     localStorage.setItem("aurora_voice_enabled", "1");
     try {
+      window.speechSynthesis.getVoices();
       window.speechSynthesis.resume();
     } catch {
       /* ignore */

--- a/src/voice/voiceClone.ts
+++ b/src/voice/voiceClone.ts
@@ -33,7 +33,9 @@ function blobToBase64(blob: Blob): Promise<string> {
  * Try to synthesize speech using the user's cloned voice via Supabase edge function.
  * Supports emotion, speed, pitch and expression parameters. Audio is cached for
  * offline reuse and the voice model is cached locally the first time it is used.
- * Returns the HTMLAudioElement if playback was started, otherwise null.
+ * Returns an object with the HTMLAudioElement if playback was started. If the
+ * request fails, `audio` will be null and `error` will contain any error
+ * returned by the Supabase function.
  */
 export async function playClonedVoice(
   text: string,
@@ -46,7 +48,7 @@ export async function playClonedVoice(
     onStart?: () => void;
     onEnd?: () => void;
   } = {},
-): Promise<HTMLAudioElement | null> {
+  ): Promise<{ audio: HTMLAudioElement | null; error?: unknown }> {
   const { emotion, speed, pitch, expression, onStart, onEnd } = options;
 
   const cacheKey = `aurora_voice_cache:${voiceId}:${emotion || "neutral"}:${
@@ -66,7 +68,7 @@ export async function playClonedVoice(
         audio.onerror = onEnd;
       }
       await audio.play();
-      return audio;
+      return { audio };
     }
 
     const { data, error } = await supabase.functions.invoke("tts-generate", {
@@ -88,10 +90,14 @@ export async function playClonedVoice(
         audio.onerror = onEnd;
       }
       await audio.play();
-      return audio;
+      return { audio };
+    }
+    if (error) {
+      return { audio: null, error };
     }
   } catch (e) {
     console.error("[voiceClone] tts-generate failed", e);
+    return { audio: null, error: e };
   }
-  return null;
+  return { audio: null };
 }


### PR DESCRIPTION
## Summary
- support extended voice modes and session-based mode downgrades
- add error-returning playClonedVoice helper
- implement cascading TTS fallback and engine preload

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type, Empty block statement, A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689cb07777888326adf962d7ca2178e5