### PR TITLE
feat: add voice mode fallback and locale support

### DIFF
--- a/src/state/voice.ts
+++ b/src/state/voice.ts
@@ -6,6 +6,7 @@ const VOICE_PITCH_KEY = "aurora.voicePitch";
 const VOICE_EXPR_KEY = "aurora.voiceExpression";
 const VOICE_EMOTION_KEY = "aurora.voiceEmotion";
 const VOICE_MODE_KEY = "aurora.voiceMode";
+const VOICE_LOCALE_KEY = "aurora.voiceLocale";
 
 type VoiceMode = "cloned" | "eleven-default" | "browser-tts";
 
@@ -13,6 +14,7 @@ type VoiceState = {
   isSpeaking: boolean;
   voiceId: string | null;
   mode: VoiceMode;
+  locale: string;
   speed: number;
   pitch: number;
   expression: number;
@@ -20,6 +22,7 @@ type VoiceState = {
   setSpeaking: (v: boolean) => void;
   setVoiceId: (id: string | null) => void;
   setMode: (m: VoiceMode) => void;
+  setLocale: (l: string) => void;
   setSpeed: (v: number) => void;
   setPitch: (v: number) => void;
   setExpression: (v: number) => void;
@@ -37,6 +40,10 @@ export const useVoiceStore = create<VoiceState>((set) => ({
       ? ((window.localStorage.getItem(VOICE_MODE_KEY) as VoiceMode) ||
           (import.meta.env.VITE_ELEVEN_API_KEY ? "eleven-default" : "browser-tts"))
       : "browser-tts",
+  locale:
+    typeof window !== "undefined"
+      ? window.localStorage.getItem(VOICE_LOCALE_KEY) || navigator.language || "en-US"
+      : "en-US",
   speed:
     typeof window !== "undefined"
       ? Number(window.localStorage.getItem(VOICE_SPEED_KEY) || 1)
@@ -70,6 +77,14 @@ export const useVoiceStore = create<VoiceState>((set) => ({
       /* ignore */
     }
     set({ mode });
+  },
+  setLocale: (locale) => {
+    try {
+      window.localStorage.setItem(VOICE_LOCALE_KEY, locale);
+    } catch {
+      /* ignore */
+    }
+    set({ locale });
   },
   setSpeed: (speed) => {
     try {

--- a/src/voice/voiceio.ts
+++ b/src/voice/voiceio.ts
@@ -1,6 +1,8 @@
 import { useVoiceStore } from "@/state/voice";
 import { supabase } from "@/integrations/supabase/client";
 import { useAvatarStore } from "@/state/avatar";
+import { playClonedVoice } from "./voiceClone";
+import { toast } from "@/hooks/use-toast";
 
 export type VoiceCallbacks = {
   onPartial?: (text: string) => void;
@@ -26,7 +28,8 @@ export class VoiceIO {
       return;
     }
     this.recognition = new SR();
-    this.recognition.lang = document.documentElement.lang || navigator.language || 'en-US';
+    const { locale } = useVoiceStore.getState();
+    this.recognition.lang = locale;
     this.recognition.interimResults = true;
     this.recognition.maxAlternatives = 1;
 
@@ -61,55 +64,118 @@ export class VoiceIO {
   }
 
   async speak(text: string) {
-    const { voiceId, speed, pitch, expression, emotion } =
-      useVoiceStore.getState();
-    try {
-      const { data, error } = await supabase.functions.invoke("tts-generate", {
-        body: { text, voiceId, emotion, speed, pitch, expression },
-      });
-      if (!error && data?.audioBase64) {
-        const src = `data:${data.contentType};base64,${data.audioBase64}`;
-        const audio = new Audio(src);
-        this.audio = audio;
-        useAvatarStore.getState().setAudio(audio);
-        audio.onplay = () => {
-          useVoiceStore.getState().setSpeaking(true);
-          this.callbacks.onSpeakingChange?.(true);
-        };
-        const end = () => {
-          useVoiceStore.getState().setSpeaking(false);
-          this.callbacks.onSpeakingChange?.(false);
-          useAvatarStore.getState().setAudio(null);
-          useAvatarStore.getState().setSentiment(0);
-        };
-        audio.onended = end;
-        audio.onerror = (e) => {
-          end();
-          this.callbacks.onError?.(e);
-        };
-        await audio.play();
-        return;
-      }
-    } catch (e) {
-      this.callbacks.onError?.(e);
-    }
+    const state = useVoiceStore.getState();
+    let { voiceId, mode, locale, speed, pitch, expression, emotion } = state;
+    let success = false;
 
-    if (!('speechSynthesis' in window)) return;
-    const u = new SpeechSynthesisUtterance(text);
-    u.rate = speed;
-    u.pitch = pitch;
-    u.onstart = () => {
+    const onStart = () => {
       useVoiceStore.getState().setSpeaking(true);
       this.callbacks.onSpeakingChange?.(true);
     };
-    const end = () => {
+    const onEnd = () => {
       useVoiceStore.getState().setSpeaking(false);
       this.callbacks.onSpeakingChange?.(false);
+      useAvatarStore.getState().setAudio(null);
+      useAvatarStore.getState().setSentiment(0);
     };
-    u.onend = end;
-    u.onerror = end;
-    speechSynthesis.speak(u);
-    this.utter = u;
+
+    const tryCloned = async () => {
+      if (!voiceId) return false;
+      const audio = await playClonedVoice(text, voiceId, {
+        emotion,
+        speed,
+        pitch,
+        expression,
+        onStart,
+        onEnd,
+      });
+      if (audio) {
+        this.audio = audio;
+        useAvatarStore.getState().setAudio(audio);
+        return true;
+      }
+      return false;
+    };
+
+    const tryEleven = async () => {
+      try {
+        const { data, error } = await supabase.functions.invoke("tts-generate", {
+          body: { text, emotion, speed, pitch, expression },
+        });
+        if (!error && data?.audioBase64) {
+          const src = `data:${data.contentType};base64,${data.audioBase64}`;
+          const audio = new Audio(src);
+          this.audio = audio;
+          useAvatarStore.getState().setAudio(audio);
+          audio.onplay = onStart;
+          const end = () => {
+            onEnd();
+          };
+          audio.onended = end;
+          audio.onerror = (e) => {
+            end();
+            this.callbacks.onError?.(e);
+          };
+          await audio.play();
+          return true;
+        }
+      } catch (e) {
+        this.callbacks.onError?.(e);
+      }
+      return false;
+    };
+
+    const tryBrowser = () => {
+      if (!("speechSynthesis" in window)) return false;
+      const u = new SpeechSynthesisUtterance(text);
+      u.lang = locale;
+      u.rate = speed;
+      u.pitch = pitch;
+      u.onstart = onStart;
+      const end = () => {
+        onEnd();
+      };
+      u.onend = end;
+      u.onerror = (e) => {
+        end();
+        this.callbacks.onError?.(e);
+      };
+      speechSynthesis.speak(u);
+      this.utter = u;
+      return true;
+    };
+
+    let currentMode = mode;
+
+    if (currentMode === "cloned") {
+      success = await tryCloned();
+      if (!success) {
+        useVoiceStore.getState().setMode("eleven-default");
+        currentMode = "eleven-default";
+        if (voiceId) {
+          toast({
+            title: "Voice clone unavailable",
+            description: "Falling back to ElevenLabs voice.",
+          });
+        }
+      }
+    }
+
+    if (!success && currentMode === "eleven-default") {
+      success = await tryEleven();
+      if (!success) {
+        useVoiceStore.getState().setMode("browser-tts");
+        currentMode = "browser-tts";
+        toast({
+          title: "ElevenLabs error",
+          description: "Using browser speech synthesis.",
+        });
+      }
+    }
+
+    if (!success) {
+      tryBrowser();
+    }
   }
 
   stopSpeaking() {


### PR DESCRIPTION
## Summary
- add locale tracking to voice store
- add multi-engine TTS fallback with mode downgrades and toasts
- route successful audio to avatar store for lip sync

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cb07a00548326bb110701bbb25faa