### PR TITLE
Add voice settings panel

### DIFF
--- a/frontend/components/SettingsPanel.jsx
+++ b/frontend/components/SettingsPanel.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useAppSettings } from '../../src/state/settings.ts';
+import VoiceSettings from '../../src/components/settings/VoiceSettings.tsx';
 
 export default function SettingsPanel({ open, onClose }) {
   const {
@@ -28,10 +29,13 @@ export default function SettingsPanel({ open, onClose }) {
     >
       <div style={{ padding: '16px' }}>
         <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '12px' }}>Settings</h2>
-        <label style={{ display: 'flex', alignItems: 'center', marginBottom: '12px' }}>
-          <input type="checkbox" checked={voiceOutput} onChange={toggleVoiceOutput} style={{ marginRight: '8px' }} />
-          Voice Output
-        </label>
+          <label style={{ display: 'flex', alignItems: 'center', marginBottom: '12px' }}>
+            <input type="checkbox" checked={voiceOutput} onChange={toggleVoiceOutput} style={{ marginRight: '8px' }} />
+            Voice Output
+          </label>
+          <div style={{ marginBottom: '12px' }}>
+            <VoiceSettings />
+          </div>
         <label style={{ display: 'flex', alignItems: 'center', marginBottom: '12px' }}>
           <input type="checkbox" checked={hypnosisMode} onChange={toggleHypnosisMode} style={{ marginRight: '8px' }} />
           Hypnosis Mode

--- a/src/components/settings/VoiceSettings.tsx
+++ b/src/components/settings/VoiceSettings.tsx
@@ -1,0 +1,37 @@
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import VoiceSetup from "@/components/VoiceSetup";
+import { useVoiceStore } from "@/state/voice";
+
+// Panel for configuring voice output mode and managing custom voice samples.
+export default function VoiceSettings() {
+  const { mode, setMode, voiceId } = useVoiceStore();
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <h2 className="text-lg font-semibold">Voice Output</h2>
+        <div className="flex flex-col gap-2 w-full max-w-sm">
+          <Label htmlFor="voice-mode">Mode</Label>
+          <Select value={mode} onValueChange={(v) => setMode(v as any)}>
+            <SelectTrigger id="voice-mode">
+              <SelectValue placeholder="Choose" />
+            </SelectTrigger>
+            <SelectContent>
+              {voiceId && <SelectItem value="cloned">Your voice</SelectItem>}
+              <SelectItem value="eleven-default">Stock voice</SelectItem>
+              <SelectItem value="browser-tts">Browser voice</SelectItem>
+              <SelectItem value="local-tts">Local TTS</SelectItem>
+              <SelectItem value="off">Off</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <div className="space-y-2">
+        <h3 className="text-md font-semibold">Voice Sample</h3>
+        <VoiceSetup />
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add VoiceSettings panel for selecting voice mode and managing voice samples
- wire VoiceSettings into existing SettingsPanel

## Testing
- `npm test`
- `npm run lint` *(fails: 199 problems (178 errors, 21 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_689cb89de7ec8326a1d29cab8b5f2646