### PR TITLE
feat: add voice fallback toast

### DIFF
--- a/src/voice/ttsFallbackToast.ts
+++ b/src/voice/ttsFallbackToast.ts
@@ -1,0 +1,11 @@
+import { toast } from "@/hooks/use-toast";
+
+let shown = false;
+
+export function ttsFallbackToast() {
+  if (shown) return;
+  shown = true;
+  toast({
+    description: "Using a default voice for now. You can retry cloning in Settings → Voice.",
+  });
+}

--- a/src/voice/useTextToSpeech.ts
+++ b/src/voice/useTextToSpeech.ts
@@ -1,8 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { toast } from "@/hooks/use-toast";
 import { useVoiceStore } from "@/state/voice";
 import { playClonedVoice } from "./voiceClone";
-import { supabase } from "@/integrations/supabase/client";
+import { ttsFallbackToast } from "@/voice/ttsFallbackToast";
 
 const ELEVENLABS_DEFAULT_VOICE_ID =
   import.meta.env.VITE_ELEVEN_DEFAULT_VOICE_ID || "9BWtsMINqrJLrRacOk9x";
@@ -14,7 +13,6 @@ export function useTextToSpeech() {
   });
   const utterRef = useRef<SpeechSynthesisUtterance | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
-  const downgradeToast = useRef(false);
   const { voiceId, speed, pitch, expression, emotion, mode, setMode } =
 
     useVoiceStore((s) => ({
@@ -76,13 +74,7 @@ export function useTextToSpeech() {
             return;
           }
           const status = (error as { status?: number } | undefined)?.status;
-          if ((status === 401 || status === 429) && !downgradeToast.current) {
-            toast({
-              title: "Cloned voice unavailable",
-              description: "Using default voice",
-            });
-            downgradeToast.current = true;
-          }
+          if (status === 401 || status === 429) ttsFallbackToast();
           current = "eleven-default";
           setMode("eleven-default", false);
           continue;
@@ -106,6 +98,7 @@ export function useTextToSpeech() {
           }
           current = "browser-tts";
           setMode("browser-tts", false);
+          ttsFallbackToast();
           continue;
         }
         if (current === "browser-tts") {

--- a/src/voice/voiceio.ts
+++ b/src/voice/voiceio.ts
@@ -2,7 +2,7 @@ import { useVoiceStore } from "@/state/voice";
 import { supabase } from "@/integrations/supabase/client";
 import { useAvatarStore } from "@/state/avatar";
 import { playClonedVoice } from "./voiceClone";
-import { toast } from "@/hooks/use-toast";
+import { ttsFallbackToast } from "@/voice/ttsFallbackToast";
 
 export type VoiceCallbacks = {
   onPartial?: (text: string) => void;
@@ -153,12 +153,7 @@ export class VoiceIO {
       if (!success) {
         useVoiceStore.getState().setMode("eleven-default");
         currentMode = "eleven-default";
-        if (voiceId) {
-          toast({
-            title: "Voice clone unavailable",
-            description: "Falling back to ElevenLabs voice.",
-          });
-        }
+        if (voiceId) ttsFallbackToast();
       }
     }
 
@@ -167,10 +162,7 @@ export class VoiceIO {
       if (!success) {
         useVoiceStore.getState().setMode("browser-tts");
         currentMode = "browser-tts";
-        toast({
-          title: "ElevenLabs error",
-          description: "Using browser speech synthesis.",
-        });
+        ttsFallbackToast();
       }
     }
 


### PR DESCRIPTION
## Summary
- show one-time toast when falling back to a default voice
- invoke toast utility on TTS mode downgrades

## Testing
- `npm test`
- `npm run lint` *(fails: Empty block statement, prefer-const, no-explicit-any, no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_689cb89fa68083268de02bdc90f8f5b0