### PR TITLE
feat: relax onboarding keyword validation

### DIFF
--- a/src/pages/OnboardingFlow.tsx
+++ b/src/pages/OnboardingFlow.tsx
@@ -37,12 +37,48 @@ const MODULES: Module[] = [
 
 const MIN_LENGTH = 10;
 
-function validateAnswer(answer: string, moduleIndex: number, questionIndex: number): string | null {
-  if (answer.length < MIN_LENGTH) return `Please provide at least ${MIN_LENGTH} characters.`;
-  const keyword = MODULES[moduleIndex].questions[questionIndex].keyword;
-  if (keyword && !answer.toLowerCase().includes(keyword)) {
-    return `Please mention the word "${keyword}" in your response.`;
+function validateAnswer(
+  answer: string,
+  moduleIndex: number,
+  questionIndex: number,
+): string | null {
+  if (answer.length < MIN_LENGTH) {
+    return `Could you add a bit more detail (at least ${MIN_LENGTH} characters)?`;
   }
+
+  const keyword = MODULES[moduleIndex].questions[questionIndex].keyword;
+  const lower = answer.toLowerCase();
+
+  switch (keyword) {
+    case "deadline": {
+      const dateRegex = /\b(\d{1,2}[\/\-]\d{1,2}(?:[\/\-]\d{2,4})?|\d{1,2}(?:st|nd|rd|th)?\s+(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\w*|next\s+(?:week|month|year|monday|tuesday|wednesday|thursday|friday|saturday|sunday)|tomorrow|today|tonight)\b/;
+      if (!dateRegex.test(lower)) {
+        return "A timeframe helps with planning. When would you like it done?";
+      }
+      break;
+    }
+    case "scopes": {
+      if (!/(personal|team|organization|company|group|individual)/.test(lower)) {
+        return "Is this personal, for your team, or for your organization?";
+      }
+      break;
+    }
+    case "priors": {
+      if (answer.trim().split(/\s+/).length < 2) {
+        return "Any prior context I should know about?";
+      }
+      break;
+    }
+    case "headline": {
+      if (answer.trim().split(/\s+/).length < 2) {
+        return "Could you share a short headline?";
+      }
+      break;
+    }
+    default:
+      break;
+  }
+
   return null;
 }
 

--- a/tests/test_conversation_flow.py
+++ b/tests/test_conversation_flow.py
@@ -1,3 +1,8 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -59,3 +64,23 @@ def test_conversation_flow():
     res = client.get("/memory")
     assert res.status_code == 200
     assert "I love unit tests" in res.json()["memories"]
+
+
+def test_conversation_flow_understands_implied_deadline():
+    client = TestClient(app)
+
+    res = client.post("/onboard", json={"persona": "curious coder"})
+    assert res.status_code == 200
+
+    res = client.post(
+        "/chat",
+        json={"message": "Let's finish this by next Friday"},
+    )
+    assert res.status_code == 200
+
+    res = client.post(
+        "/chat",
+        json={"message": "When do we plan to finish?"},
+    )
+    assert res.status_code == 200
+    assert "next Friday" in res.json()["reply"]


### PR DESCRIPTION
## Summary
- parse onboarding answers with regex to infer headlines, deadlines, priors and scopes
- gently prompt for missing details instead of enforcing exact keywords
- test conversation flow when user omits keywords like "deadline"

## Testing
- `npm test`
- `pytest tests/test_conversation_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_689cbec8f96c83269d65e39c497b6cd7