### PR TITLE
feat: add voice toolbar and indicators

### DIFF
--- a/src/components/game/GameHUD.tsx
+++ b/src/components/game/GameHUD.tsx
@@ -3,7 +3,8 @@ import { cn } from "@/lib/utils";
 import { useGameStore } from "@/game/store";
 import { quickSlots } from "@/game/hud/hud.data";
 import { AvatarSphere } from "@/components/avatar/AvatarSphere";
-import { Mic, ChevronDown, ChevronUp } from "lucide-react";
+import { Mic, ChevronDown, ChevronUp, Loader2 } from "lucide-react";
+import { useTextToSpeech } from "@/voice/useTextToSpeech";
 import { useHUDActions } from "@/game/hud/useHUDActions";
 import { useAvatarStore } from "@/state/avatar";
 import SettingsPanel from "../../../frontend/components/SettingsPanel.jsx";
@@ -17,6 +18,9 @@ export function GameHUD() {
   const { run } = useHUDActions();
   const avatarEnabled = useAvatarStore((s) => s.enabled);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const { enabled, enable } = useTextToSpeech();
+  const [listening, setListening] = useState(false);
+  const [processing, setProcessing] = useState(false);
 
   // Mobile collapse state
   const isMobile = window.innerWidth <= 768;
@@ -26,6 +30,17 @@ export function GameHUD() {
     const h = expanded ? (isMobile ? 148 : 132) : (isMobile ? 92 : 88);
     document.documentElement.style.setProperty('--hud-h', `${h}px`);
   }, [expanded, isMobile]);
+
+  useEffect(() => {
+    const onListen = (e: any) => setListening(Boolean(e.detail));
+    const onProcess = (e: any) => setProcessing(Boolean(e.detail));
+    window.addEventListener('voice-listening', onListen);
+    window.addEventListener('voice-processing', onProcess);
+    return () => {
+      window.removeEventListener('voice-listening', onListen);
+      window.removeEventListener('voice-processing', onProcess);
+    };
+  }, []);
 
   const showMetrics = !isMobile || expanded;
 
@@ -93,6 +108,36 @@ export function GameHUD() {
                 </button>
               </li>
             ))}
+            {!enabled && (
+              <li className="snap-start">
+                <button
+                  type="button"
+                  className="action-chip"
+                  aria-label="Enable voice"
+                  title="Enable voice"
+                  onClick={enable}
+                >
+                  <Mic className="w-4 h-4" />
+                  <span className="hidden sm:inline text-sm">Enable Voice</span>
+                </button>
+              </li>
+            )}
+            {listening && (
+              <li className="snap-start">
+                <div className="action-chip pointer-events-none">
+                  <Mic className="w-4 h-4 animate-pulse" />
+                  <span className="hidden sm:inline text-sm">Listening</span>
+                </div>
+              </li>
+            )}
+            {processing && (
+              <li className="snap-start">
+                <div className="action-chip pointer-events-none">
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  <span className="hidden sm:inline text-sm">Processing</span>
+                </div>
+              </li>
+            )}
             <li className="snap-start">
               <button
                 type="button"

--- a/src/pages/OnboardingFlow.tsx
+++ b/src/pages/OnboardingFlow.tsx
@@ -343,18 +343,6 @@ export default function OnboardingFlow() {
       <div className="relative z-10 flex h-full flex-col">
         <div className="flex-shrink-0 flex flex-col items-center gap-4 p-4">
           <EvolvingSphere size={220} speaking={isSpeaking} />
-          <div className="flex items-center gap-2">
-            {!enabled && (
-              <button
-                type="button"
-                onClick={enable}
-                className="rounded-full bg-white/10 px-3 py-1 text-xs text-white hover:bg-white/20"
-                title="Enable voice"
-              >
-                Enable Voice
-              </button>
-            )}
-          </div>
           <div className="relative w-full">
             <Progress value={progressPercent} />
             <div className="pointer-events-none absolute inset-0 grid place-items-center">

--- a/src/voice/useTextToSpeech.ts
+++ b/src/voice/useTextToSpeech.ts
@@ -3,6 +3,10 @@ import { useVoiceStore } from "@/state/voice";
 import { playClonedVoice } from "./voiceClone";
 import { ttsFallbackToast } from "@/voice/ttsFallbackToast";
 
+function fire(type: string, detail: boolean) {
+  window.dispatchEvent(new CustomEvent(type, { detail }));
+}
+
 const ELEVENLABS_DEFAULT_VOICE_ID =
   import.meta.env.VITE_ELEVENLABS_DEFAULT_VOICE_ID ||
   "21m00Tcm4TlvDq8ikWAM"; // Rachel (stock voice)
@@ -51,6 +55,7 @@ export function useTextToSpeech() {
   const speak = useCallback(
     async (text: string) => {
       if (!enabled || !text?.trim()) return; // gate prevents NotAllowedError
+      fire('voice-processing', true);
 
       let current = mode;
       const locale = navigator.language;
@@ -67,7 +72,10 @@ export function useTextToSpeech() {
             speed,
             pitch,
             expression,
-            onStart: () => setIsSpeaking(true),
+            onStart: () => {
+              fire('voice-processing', false);
+              setIsSpeaking(true);
+            },
             onEnd: () => setIsSpeaking(false),
           });
           if (audio) {
@@ -89,7 +97,10 @@ export function useTextToSpeech() {
               speed,
               pitch,
               expression,
-              onStart: () => setIsSpeaking(true),
+              onStart: () => {
+                fire('voice-processing', false);
+                setIsSpeaking(true);
+              },
               onEnd: () => setIsSpeaking(false),
             },
           );
@@ -125,7 +136,10 @@ export function useTextToSpeech() {
             u.voice = v;
             u.rate = speed;
             u.pitch = pitch;
-            u.onstart = () => setIsSpeaking(true);
+            u.onstart = () => {
+              fire('voice-processing', false);
+              setIsSpeaking(true);
+            };
             u.onend = () => setIsSpeaking(false);
             u.onerror = () => setIsSpeaking(false);
             window.speechSynthesis.speak(u);
@@ -142,6 +156,7 @@ export function useTextToSpeech() {
           continue;
         }
       }
+      fire('voice-processing', false);
     },
     [enabled, mode, voiceId, emotion, speed, pitch, expression, setMode],
 

--- a/src/voice/useVoiceInput.ts
+++ b/src/voice/useVoiceInput.ts
@@ -1,5 +1,9 @@
 import { useState, useRef, useCallback } from 'react'
 
+function fire(type: string, detail: boolean) {
+  window.dispatchEvent(new CustomEvent(type, { detail }))
+}
+
 export function useVoiceInput() {
   const [isRecording, setIsRecording] = useState(false)
   const [transcript, setTranscript] = useState('')
@@ -17,7 +21,10 @@ export function useVoiceInput() {
       e.channel.onmessage = ev => {
         try {
           const msg = JSON.parse(ev.data)
-          if (msg.transcript) setTranscript(msg.transcript)
+          if (msg.transcript) {
+            setTranscript(msg.transcript)
+            fire('voice-processing', false)
+          }
           if (msg.audio) {
             const audio = new Audio('data:audio/wav;base64,' + msg.audio)
             audio.play()
@@ -47,6 +54,8 @@ export function useVoiceInput() {
     const answer = await res.json()
     await pc.setRemoteDescription(answer)
     setIsRecording(true)
+    fire('voice-listening', true)
+    fire('voice-processing', false)
   }, [isRecording])
 
   const stop = useCallback(() => {
@@ -55,6 +64,8 @@ export function useVoiceInput() {
     pcRef.current?.close()
     pcRef.current = null
     setIsRecording(false)
+    fire('voice-listening', false)
+    fire('voice-processing', true)
   }, [])
 
   return { startRecording: start, stopRecording: stop, transcript, setTranscript, isRecording, audioRef }

--- a/src/voice/voiceio.ts
+++ b/src/voice/voiceio.ts
@@ -4,6 +4,10 @@ import { useAvatarStore } from "@/state/avatar";
 import { playClonedVoice } from "./voiceClone";
 import { ttsFallbackToast } from "@/voice/ttsFallbackToast";
 
+function fire(type: string, detail: boolean) {
+  window.dispatchEvent(new CustomEvent(type, { detail }));
+}
+
 export type VoiceCallbacks = {
   onPartial?: (text: string) => void;
   onFinal?: (text: string) => void;
@@ -42,17 +46,24 @@ export class VoiceIO {
         else interim += res[0].transcript;
       }
       if (interim) this.callbacks.onPartial?.(interim);
-      if (finalText) this.callbacks.onFinal?.(finalText.trim());
+      if (finalText) {
+        fire('voice-processing', false);
+        this.callbacks.onFinal?.(finalText.trim());
+      }
     };
 
     this.recognition.onerror = (e: any) => this.callbacks.onError?.(e);
     this.recognition.onend = () => {
       this.callbacks.onSpeakingChange?.(false);
+      fire('voice-listening', false);
+      fire('voice-processing', true);
       this.recognition = null;
     };
 
     try {
       this.recognition.start();
+      fire('voice-listening', true);
+      fire('voice-processing', false);
     } catch (e) {
       // starting while already started throws
     }
@@ -60,6 +71,7 @@ export class VoiceIO {
 
   stopListening() {
     try { this.recognition?.stop(); } catch {}
+    fire('voice-listening', false);
     this.recognition = null;
   }
 


### PR DESCRIPTION
## Summary
- relocate voice enablement into the game HUD so it’s always accessible during chat
- show listening and transcription indicators in the HUD
- fire window events from voice hooks to toggle the new indicators

## Testing
- `npm test`
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689cbee5258083268cac37ca824a137c