### PR TITLE
Add SQLite WASM wrapper with OPFS and IndexedDB fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "react-router-dom": "^6.30.1",
         "recharts": "^2.15.4",
         "sonner": "^1.7.4",
+        "sql.js": "^1.13.0",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
         "three": "^0.179.1",
@@ -14263,6 +14264,12 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/sql.js": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.13.0.tgz",
+      "integrity": "sha512-RJbVP1HRDlUUXahJ7VMTcu9Rm1Nzw+EBpoPr94vnbD4LwR715F3CcxE2G2k45PewcaZ57pjetYa+LoSJLAASgA==",
+      "license": "MIT"
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "vaul": "1.1.2",
     "vite-plugin-pwa": "^0.20.5",
     "zod": "^3.25.76",
-    "zustand": "^4.5.7"
+    "zustand": "^4.5.7",
+    "sql.js": "^1.13.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",

--- a/src/memory/brainDb.ts
+++ b/src/memory/brainDb.ts
@@ -1,0 +1,87 @@
+import initSqlJs, { Database } from "sql.js";
+
+const DB_FILE = "brain.db";
+const IDB_NAME = "brain-db";
+const IDB_STORE = "files";
+
+export interface BrainDatabase extends Database {
+  saveToDisk(): Promise<void>;
+}
+
+async function openIndexedDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(IDB_NAME, 1);
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore(IDB_STORE);
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function idbGet(key: string): Promise<Uint8Array | null> {
+  const db = await openIndexedDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(IDB_STORE, "readonly");
+    const req = tx.objectStore(IDB_STORE).get(key);
+    req.onsuccess = () => {
+      const result = req.result as ArrayBuffer | undefined;
+      resolve(result ? new Uint8Array(result) : null);
+    };
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function idbSet(key: string, value: Uint8Array): Promise<void> {
+  const db = await openIndexedDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(IDB_STORE, "readwrite");
+    const req = tx.objectStore(IDB_STORE).put(value, key);
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function openBrainDb(): Promise<BrainDatabase> {
+  const SQL = await initSqlJs({
+    locateFile: (file: string) =>
+      new URL(`../../node_modules/sql.js/dist/${file}`, import.meta.url).toString(),
+  });
+
+  const hasOpfs =
+    typeof navigator !== "undefined" &&
+    !!(navigator as any).storage?.getDirectory;
+
+  if (hasOpfs) {
+    const root = await (navigator as any).storage.getDirectory();
+    const handle = await root.getFileHandle(DB_FILE, { create: true });
+    let db: BrainDatabase;
+    try {
+      const file = await handle.getFile();
+      const buffer = await file.arrayBuffer();
+      db = buffer.byteLength
+        ? (new SQL.Database(new Uint8Array(buffer)) as BrainDatabase)
+        : (new SQL.Database() as BrainDatabase);
+    } catch {
+      db = new SQL.Database() as BrainDatabase;
+    }
+    db.saveToDisk = async () => {
+      const data = db.export();
+      const writable = await handle.createWritable();
+      await writable.write(data);
+      await writable.close();
+    };
+    return db;
+  }
+
+  const bytes = await idbGet(DB_FILE);
+  const db = bytes
+    ? (new SQL.Database(bytes) as BrainDatabase)
+    : (new SQL.Database() as BrainDatabase);
+  db.saveToDisk = async () => {
+    const data = db.export();
+    await idbSet(DB_FILE, data);
+  };
+  return db;
+}
+


### PR DESCRIPTION
## Summary
- add sql.js dependency for browser-based SQLite usage
- implement `openBrainDb` helper that writes `brain.db` to OPFS when available and persists bytes to IndexedDB otherwise

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cd90b944483268d6aca07ed6b1112