### PR TITLE
feat: expose brain backup options

### DIFF
--- a/src/components/settings/BrainBackupPanel.tsx
+++ b/src/components/settings/BrainBackupPanel.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { toast } from '@/hooks/use-toast';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+import { exportEncryptedBrain, importEncryptedBrain } from '@/memory/brainBackup';
+
+export default function BrainBackupPanel() {
+  const [passphrase, setPassphrase] = useLocalStorage<string>('brain.backup.passphrase', '');
+  const [enabled, setEnabled] = useLocalStorage<boolean>('brain.backup.enabled', false);
+  const [busy, setBusy] = useState(false);
+
+  const download = async () => {
+    if (!passphrase) {
+      toast({ title: 'Passphrase required', description: 'Set a passphrase first.' });
+      return;
+    }
+    setBusy(true);
+    try {
+      const blob = await exportEncryptedBrain(passphrase);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'brain.enc';
+      a.click();
+      URL.revokeObjectURL(url);
+      toast({ title: 'Brain exported', description: 'Encrypted brain downloaded.' });
+    } catch (e) {
+      console.error(e);
+      toast({ title: 'Export failed', description: 'Could not export brain.' });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const restore = () => {
+    if (!passphrase) {
+      toast({ title: 'Passphrase required', description: 'Set a passphrase first.' });
+      return;
+    }
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.onchange = async () => {
+      const file = input.files?.[0];
+      if (!file) return;
+      setBusy(true);
+      try {
+        await importEncryptedBrain(file, passphrase);
+        toast({ title: 'Brain restored', description: 'Reloading…' });
+        location.reload();
+      } catch (e) {
+        console.error(e);
+        toast({ title: 'Restore failed', description: 'Could not restore brain.' });
+      } finally {
+        setBusy(false);
+      }
+    };
+    input.click();
+  };
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-semibold">Brain Backup</h2>
+      <div className="space-y-2 max-w-sm">
+        <Label htmlFor="brain-pass">Passphrase</Label>
+        <Input
+          id="brain-pass"
+          type="password"
+          value={passphrase}
+          onChange={(e) => setPassphrase(e.target.value)}
+        />
+      </div>
+      <div className="flex items-center gap-2">
+        <Switch id="brain-weekly" checked={enabled} onCheckedChange={setEnabled} />
+        <Label htmlFor="brain-weekly">Upload weekly to Supabase</Label>
+      </div>
+      <div className="flex gap-2">
+        <Button variant="outline" onClick={download} disabled={busy}>
+          Download Brain
+        </Button>
+        <Button variant="outline" onClick={restore} disabled={busy}>
+          Restore Brain
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useWeeklyBrainBackup.ts
+++ b/src/hooks/useWeeklyBrainBackup.ts
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { useLocalStorage } from './useLocalStorage';
+import { useSupabaseAuth } from './useSupabaseAuth';
+import { supabase } from '@/integrations/supabase/client';
+import { exportEncryptedBrain } from '@/memory/brainBackup';
+
+export default function useWeeklyBrainBackup() {
+  const { user } = useSupabaseAuth();
+  const [enabled] = useLocalStorage<boolean>('brain.backup.enabled', false);
+  const [passphrase] = useLocalStorage<string>('brain.backup.passphrase', '');
+
+  useEffect(() => {
+    if (!user || !enabled || !passphrase) return;
+    const key = 'brain.backup.last';
+    const last = localStorage.getItem(key);
+    const now = new Date();
+    if (last) {
+      const diff = now.getTime() - new Date(last).getTime();
+      if (diff < 7 * 24 * 60 * 60 * 1000) return;
+    }
+    const run = async () => {
+      try {
+        const blob = await exportEncryptedBrain(passphrase);
+        const path = `${user.id}/${now.toISOString()}.bin`;
+        await supabase.storage.from('brain-backups').upload(path, blob);
+      } catch (e) {
+        console.error('Weekly brain backup failed', e);
+      } finally {
+        localStorage.setItem(key, now.toISOString());
+      }
+    };
+    run();
+  }, [user, enabled, passphrase]);
+}

--- a/src/memory/brainBackup.ts
+++ b/src/memory/brainBackup.ts
@@ -1,0 +1,70 @@
+import { openBrainDb } from './brainDb';
+
+const DB_FILE = 'brain.db';
+
+async function deriveKey(passphrase: string, salt: Uint8Array) {
+  const enc = new TextEncoder();
+  const keyMaterial = await crypto.subtle.importKey('raw', enc.encode(passphrase), 'PBKDF2', false, ['deriveKey']);
+  return crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt, iterations: 100000, hash: 'SHA-256' },
+    keyMaterial,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+}
+
+export async function exportEncryptedBrain(passphrase: string): Promise<Blob> {
+  const db = await openBrainDb();
+  await db.saveToDisk();
+  const data = db.export();
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const key = await deriveKey(passphrase, salt);
+  const encrypted = new Uint8Array(
+    await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, data)
+  );
+  const out = new Uint8Array(salt.length + iv.length + encrypted.length);
+  out.set(salt, 0);
+  out.set(iv, salt.length);
+  out.set(encrypted, salt.length + iv.length);
+  return new Blob([out], { type: 'application/octet-stream' });
+}
+
+async function writeBrain(bytes: Uint8Array) {
+  const hasOpfs =
+    typeof navigator !== 'undefined' && !!(navigator as any).storage?.getDirectory;
+  if (hasOpfs) {
+    const root = await (navigator as any).storage.getDirectory();
+    const handle = await root.getFileHandle(DB_FILE, { create: true });
+    const writable = await handle.createWritable();
+    await writable.write(bytes);
+    await writable.close();
+    return;
+  }
+  const dbReq = indexedDB.open('brain-db', 1);
+  await new Promise<void>((resolve, reject) => {
+    dbReq.onupgradeneeded = () => dbReq.result.createObjectStore('files');
+    dbReq.onsuccess = () => resolve();
+    dbReq.onerror = () => reject(dbReq.error);
+  });
+  const db = dbReq.result;
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction('files', 'readwrite');
+    const req = tx.objectStore('files').put(bytes, DB_FILE);
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function importEncryptedBrain(blob: Blob, passphrase: string) {
+  const buf = new Uint8Array(await blob.arrayBuffer());
+  const salt = buf.slice(0, 16);
+  const iv = buf.slice(16, 28);
+  const data = buf.slice(28);
+  const key = await deriveKey(passphrase, salt);
+  const decrypted = new Uint8Array(
+    await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, data)
+  );
+  await writeBrain(decrypted);
+}

--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -12,6 +12,7 @@ import { useSwipeNav } from "@/hooks/useSwipeNav";
 import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
 import { supabase } from "@/integrations/supabase/client";
 import useDailyCheckIn from "@/hooks/useDailyCheckIn";
+import useWeeklyBrainBackup from "@/hooks/useWeeklyBrainBackup";
 import ControlView from "@/views/ControlView";
 export default function AppShell() {
   const { user, initializing } = useSupabaseAuth();
@@ -47,6 +48,7 @@ export default function AppShell() {
   useXPChime();
   const swipe = useSwipeNav();
   useDailyCheckIn();
+  useWeeklyBrainBackup();
 
   useEffect(() => {
     const off = bus.on('nav:view', ({ id, params }: { id: ViewId; params?: Record<string, string> }) => open(id, params));

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -18,6 +18,7 @@ import TriggersPanel from "@/components/settings/TriggersPanel";
 import ModelPanel from "@/components/settings/ModelPanel";
 import DataSourcesPanel from "@/components/settings/DataSourcesPanel";
 import MemoryPanel from "@/components/settings/MemoryPanel";
+import BrainBackupPanel from "@/components/settings/BrainBackupPanel";
 import ApiCallLogPanel from "@/components/settings/ApiCallLogPanel";
 import FeatureFlagsPanel from "@/components/settings/FeatureFlagsPanel";
 import DeviceManagerPanel from "@/components/settings/DeviceManagerPanel";
@@ -114,6 +115,7 @@ export default function SettingsView() {
             <DataSourcesPanel />
             <TriggersPanel />
             <ModelPanel />
+            <BrainBackupPanel />
             <MemoryPanel />
             <DeviceManagerPanel />
             <ApiCallLogPanel />


### PR DESCRIPTION
## Summary
- add BrainBackupPanel with passphrase, download and restore controls
- encrypt brain.db with AES-GCM + PBKDF2 for export and import
- weekly encrypted snapshots to Supabase Storage via hook

## Testing
- `npm test`
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689cde7841988326862b8e7a80148b1a