### PR TITLE
feat: unify system prompt builder

### DIFF
--- a/core/prompt.js
+++ b/core/prompt.js
@@ -1,16 +1,26 @@
 export function buildPrompt(
   persona,
+  brainPolicy,
   memories,
   behaviorStyle = "",
   skills = [],
   filters = [],
 ) {
-  const parts = [
-    "You are the idealized version of the user.",
-    `Persona: ${persona}`,
-    "Relevant memories:",
-    memories.join("\n"),
-  ];
+  const parts = [brainPolicy.trim()];
+
+  if (typeof persona === "string") {
+    if (persona) parts.push(`Persona: ${persona}`);
+  } else if (persona && Object.keys(persona).length) {
+    const entries = Object.entries(persona).filter(([, v]) => v);
+    if (entries.length) {
+      parts.push("Persona fields:");
+      for (const [key, value] of entries.sort((a, b) => a[0].localeCompare(b[0]))) {
+        parts.push(`${key}: ${value}`);
+      }
+    }
+  }
+
+  parts.push("Relevant memories:", memories.join("\n"));
   if (behaviorStyle) parts.push(`Behavior style: ${behaviorStyle}`);
   if (skills.length) parts.push(`Available skills: ${skills.join("; ")}`);
   if (filters.length) parts.push(`Applied filters: ${filters.join(", ")}`);

--- a/core/prompt.py
+++ b/core/prompt.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 from typing import Iterable, Sequence
 
 
+from typing import Iterable, Mapping, Sequence
+
+
 def build_prompt(
-    persona: str,
+    persona: str | Mapping[str, str] | None,
+    brain_policy: str,
     memories: Iterable[str],
     behavior_style: str = "",
     skills: Sequence[str] | None = None,
@@ -16,7 +20,9 @@ def build_prompt(
     Parameters
     ----------
     persona:
-        Description of the user's ideal persona.
+        Description of the user's ideal persona or mapping of persona fields.
+    brain_policy:
+        Text of the Brain Policy governing responses.
     memories:
         Iterable of memory snippets relevant to the current conversation.
     behavior_style:
@@ -29,12 +35,20 @@ def build_prompt(
 
     skills = skills or []
     filters = filters or []
-    parts = [
-        "You are the idealized version of the user.",
-        f"Persona: {persona}",
-        "Relevant memories:",
-        "\n".join(memories),
-    ]
+    parts: list[str] = [brain_policy.strip()]
+
+    if isinstance(persona, str):
+        if persona:
+            parts.append(f"Persona: {persona}")
+    elif persona:
+        items = [(k, v) for k, v in persona.items() if v]
+        if items:
+            parts.append("Persona fields:")
+            for key, value in sorted(items):
+                parts.append(f"{key}: {value}")
+
+    parts.append("Relevant memories:")
+    parts.append("\n".join(memories))
     if behavior_style:
         parts.append(f"Behavior style: {behavior_style}")
     if skills:

--- a/core/prompt.ts
+++ b/core/prompt.ts
@@ -1,16 +1,26 @@
 export function buildPrompt(
-  persona: string,
+  persona: Record<string, string> | string,
+  brainPolicy: string,
   memories: string[],
   behaviorStyle: string = "",
   skills: string[] = [],
   filters: string[] = [],
 ): string {
-  const parts = [
-    "You are the idealized version of the user.",
-    `Persona: ${persona}`,
-    "Relevant memories:",
-    memories.join("\n"),
-  ];
+  const parts = [brainPolicy.trim()];
+
+  if (typeof persona === "string") {
+    if (persona) parts.push(`Persona: ${persona}`);
+  } else if (persona && Object.keys(persona).length) {
+    const entries = Object.entries(persona).filter(([, v]) => v);
+    if (entries.length) {
+      parts.push("Persona fields:");
+      for (const [key, value] of entries.sort((a, b) => a[0].localeCompare(b[0]))) {
+        parts.push(`${key}: ${value}`);
+      }
+    }
+  }
+
+  parts.push("Relevant memories:", memories.join("\n"));
   if (behaviorStyle) parts.push(`Behavior style: ${behaviorStyle}`);
   if (skills.length) parts.push(`Available skills: ${skills.join("; ")}`);
   if (filters.length) parts.push(`Applied filters: ${filters.join(", ")}`);

--- a/src/utils/auroraChat.ts
+++ b/src/utils/auroraChat.ts
@@ -1,51 +1,32 @@
-import { loadProfile, UserProfile, summarizeProfile } from '@/data/profile';
+import { loadProfile, UserProfile } from '@/data/profile';
 import brain from '@/brain/Brain';
 import { getFilterName } from '@/brain/filters';
 import { routeChat } from '@/agent/router';
 import type { ChatMessage, ChatOptions } from '@/types/chat';
 import { supabase } from '@/integrations/supabase/client';
 import { useModelPreference } from '@/state/modelPreference';
+import { buildPrompt } from '../../core/prompt.ts';
 
 function buildSystemMessages(profile: UserProfile | null): ChatMessage[] {
-  const systemMessages: ChatMessage[] = [
-    { role: 'system', content: brain.cognition.systemPrompt },
-  ];
-
-  if (brain.cognition.contextPrompt) {
-    systemMessages.push({ role: 'system', content: brain.cognition.contextPrompt });
-  }
-
-  systemMessages.push({
-    role: 'system',
-    content: `Behavior style: ${brain.behavior.style}`,
-  });
-
-  const skillPrompt = brain.skills
-    .map((s) => `${s.name}: ${s.description}`)
-    .join('; ');
-  if (skillPrompt) {
-    systemMessages.push({
-      role: 'system',
-      content: `Available skills: ${skillPrompt}`,
-    });
-  }
-
-  const profileSummary = summarizeProfile(profile);
-  if (profileSummary) {
-    systemMessages.unshift({
-      role: 'system',
-      content: `User profile: ${profileSummary}`,
-    });
-  }
-
   const filterNames = brain.filters
     .map((f) => getFilterName(f))
     .filter((n): n is string => Boolean(n));
-  if (filterNames.length > 0) {
-    systemMessages.push({
-      role: 'system',
-      content: `Applied filters: ${filterNames.join(', ')}`,
-    });
+  const skills = brain.skills.map((s) => `${s.name}: ${s.description}`);
+  const personaFields = profile ? (({ history, ...rest }) => rest)(profile) : {};
+
+  const builtPrompt = buildPrompt(
+    personaFields,
+    brain.cognition.systemPrompt,
+    [],
+    brain.behavior.style,
+    skills,
+    filterNames,
+  );
+
+  const systemMessages: ChatMessage[] = [{ role: 'system', content: builtPrompt }];
+
+  if (brain.cognition.contextPrompt) {
+    systemMessages.push({ role: 'system', content: brain.cognition.contextPrompt });
   }
 
   return systemMessages;

--- a/supabase/functions/aurora-chat/index.ts
+++ b/supabase/functions/aurora-chat/index.ts
@@ -4,7 +4,7 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
 import brain from "../../../src/brain/Brain.ts";
 import { getFilterName } from "../../../src/brain/filters.ts";
-import { summarizeProfile, UserProfile } from "../../../src/data/profile.ts";
+import { UserProfile } from "../../../src/data/profile.ts";
 import { analyzeSentiment } from "../../../src/utils/sentiment.ts";
 import { buildPrompt } from "../../../core/prompt.ts";
 
@@ -54,14 +54,16 @@ serve(async (req) => {
 
     const usedModel = model || "o4-mini-2025-04-16"; // cost-effective default
 
-    const profileSummary = summarizeProfile(profile);
     const filterNames = brain.filters
       .map((f) => getFilterName(f))
       .filter((n): n is string => Boolean(n));
     const skills = brain.skills.map((s) => `${s.name}: ${s.description}`);
 
+    const personaFields = profile ? (({ history, ...rest }) => rest)(profile) : {};
+
     const builtPrompt = buildPrompt(
-      profileSummary || "",
+      personaFields,
+      brain.cognition.systemPrompt,
       [],
       brain.behavior.style,
       skills,
@@ -69,14 +71,12 @@ serve(async (req) => {
     );
 
     const systemMessages = [
-      { role: "system", content: brain.cognition.systemPrompt },
+      { role: "system", content: builtPrompt },
     ];
 
     if (brain.cognition.contextPrompt) {
       systemMessages.push({ role: "system", content: brain.cognition.contextPrompt });
     }
-
-    systemMessages.push({ role: "system", content: builtPrompt });
 
     const payload = messages && Array.isArray(messages)
       ? { model: usedModel, messages: [...systemMessages, ...messages] }

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -1,5 +1,5 @@
-import subprocess
 import json
+import subprocess
 import importlib.util
 from pathlib import Path
 
@@ -12,10 +12,11 @@ spec.loader.exec_module(prompt)
 build_prompt = prompt.build_prompt
 
 
-def run_js_builder(persona, memories, behavior_style, skills, filters):
+def run_js_builder(persona, brain_policy, memories, behavior_style, skills, filters):
     script = (
         "import { buildPrompt } from './core/prompt.js';\n"
-        f"console.log(buildPrompt({json.dumps(persona)}, {json.dumps(memories)}, {json.dumps(behavior_style)}, {json.dumps(skills)}, {json.dumps(filters)}));"
+        "const persona = " + json.dumps(persona) + ";\n"
+        f"console.log(buildPrompt(persona, {json.dumps(brain_policy)}, {json.dumps(memories)}, {json.dumps(behavior_style)}, {json.dumps(skills)}, {json.dumps(filters)}));"
     )
     result = subprocess.run(
         ["node", "--input-type=module", "-e", script],
@@ -27,13 +28,14 @@ def run_js_builder(persona, memories, behavior_style, skills, filters):
 
 
 def test_prompt_builder_matches_js():
-    persona = "Confident coder"
+    persona = {"goals": "Finish project", "values": "Curiosity"}
+    brain_policy = "Be kind and concise."
     memories = ["Finished project", "Won hackathon"]
     behavior_style = "supportive"
     skills = ["coding", "debugging"]
     filters = ["sarcasm"]
 
-    py_prompt = build_prompt(persona, memories, behavior_style, skills, filters)
-    js_prompt = run_js_builder(persona, memories, behavior_style, skills, filters)
+    py_prompt = build_prompt(persona, brain_policy, memories, behavior_style, skills, filters)
+    js_prompt = run_js_builder(persona, brain_policy, memories, behavior_style, skills, filters)
 
     assert py_prompt == js_prompt


### PR DESCRIPTION
## Summary
- add shared `buildPrompt` that composes brain policy, persona fields, skills and filters
- use `buildPrompt` in Supabase edge chat function and local runtime chat helper
- test parity between JS and Python prompt builders

## Testing
- `npm test`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ce9891d9c8326906cce3579a7d3b6