### PR TITLE
Improve memory recall scoring and tracking

### DIFF
--- a/core/brain.py
+++ b/core/brain.py
@@ -95,6 +95,37 @@ class BrainAgent:
         mem_id = save_memory(text, {"role": role})
         self._recent_memory_ids.append(mem_id)
 
+    def _retrieve_memories(self, message: str) -> list[str]:
+        """Fetch relevant memories and track those shown to the user.
+
+        The helper consults :attr:`memory_store` while ensuring that any
+        previously saved or displayed memories are excluded.  Returned
+        memories are limited to five items and any provided ``id`` values are
+        added to ``_recent_memory_ids`` so they won't be surfaced again in
+        the current session.
+        """
+
+        try:
+            raw = list(self.memory_store(message, exclude_ids=self._recent_memory_ids))
+        except Exception:
+            raise
+
+        memories: list[str] = []
+        for mem in raw[:5]:
+            if isinstance(mem, Mapping):
+                text = mem.get("text")
+                mid = mem.get("id")
+                if mid is not None:
+                    try:
+                        self._recent_memory_ids.append(int(mid))
+                    except Exception:
+                        pass
+                if text:
+                    memories.append(str(text))
+            else:
+                memories.append(str(mem))
+        return memories
+
     def process(self, message: str, request_id: str | None = None) -> str:
         """Process a user ``message`` by delegating to a sub-agent.
 
@@ -114,27 +145,16 @@ class BrainAgent:
         persona = self.persona_store() or ""
 
         try:
-            raw_memories = list(
-                self.memory_store(message, exclude_ids=self._recent_memory_ids)
-            )
+            memories = self._retrieve_memories(message)
         except Exception:
             metrics.errors += 1
             logger.exception(
                 "memory store error",
                 extra={"request_id": request_id, "agent": "memory_store"},
             )
-            raw_memories = []
+            memories = []
         else:
             metrics.memory_queries += 1
-
-        memories = []
-        for mem in raw_memories:
-            if isinstance(mem, str):
-                memories.append(mem)
-            elif isinstance(mem, Mapping):
-                text = mem.get("text")
-                if text:
-                    memories.append(str(text))
 
         memory_text = "\n".join(memories)
         style_prompt = style_instructions()

--- a/memory/store.py
+++ b/memory/store.py
@@ -246,6 +246,12 @@ def save_insight(text: str) -> int:
     return save_memory(text, {"tag": "insight"})
 
 # -- Reads ---------------------------------------------------------------
+
+def score_memory(relevance: float, age_days: float, importance: float) -> float:
+    """Return a combined score for a memory candidate."""
+    recency = 1.0 / (1.0 + float(age_days))
+    return float(relevance) * recency * float(importance)
+
 def query_memory(
     query: str,
     k: int = 5,
@@ -289,8 +295,7 @@ def query_memory(
         except Exception:
             meta = {}
         importance = float(meta.get("importance", 1.0))
-        recency = 1.0 / (1.0 + age_days)
-        score = rel * recency * importance
+        score = score_memory(rel, age_days, importance)
         results.append(
             {
                 "id": mid,

--- a/tests/test_memory_recall.py
+++ b/tests/test_memory_recall.py
@@ -65,3 +65,29 @@ def test_brain_avoids_recent_message_echos(monkeypatch):
     brain.process("I love unit tests")
     reply = brain.process("What did I just say?")
     assert "I love unit tests" not in reply
+
+
+def test_brain_avoids_repeating_displayed_memories(monkeypatch):
+    """Previously surfaced memories should be excluded from later recalls."""
+
+    mem.cur.execute("DELETE FROM memories")
+    mem.conn.commit()
+    mem.vector_store.clear()
+
+    mid = mem.save_memory("remember this fact")
+
+    brain = BrainAgent(
+        persona_store=lambda: "",
+        memory_store=lambda msg, exclude_ids=None: mem.query_memory(msg, exclude_ids=exclude_ids),
+        agents=[EchoAgent()],
+    )
+
+    # Avoid saving messages during the test to keep _recent_memory_ids clean
+    monkeypatch.setattr(brain, "_save_memory_async", lambda text, role: None)
+
+    first = brain.process("remember?")
+    assert "remember this fact" in first
+
+    # After being displayed once, the memory ID should now be excluded
+    second = brain.process("remember again?")
+    assert "remember this fact" not in second

--- a/voice/server.py
+++ b/voice/server.py
@@ -31,8 +31,17 @@ def load_persona() -> str:
     return " ".join(part for part in parts if part)
 
 
-def fetch_memories(message: str, exclude_ids: List[int] | None = None) -> List[str]:
-    return [m["text"] for m in query_memory(message, exclude_ids=exclude_ids)]
+def fetch_memories(
+    message: str, exclude_ids: List[int] | None = None
+) -> List[dict]:
+    """Retrieve relevant memories for ``message``.
+
+    The raw records from :func:`memory.store.query_memory` are returned so the
+    :class:`BrainAgent` can track which memory IDs have been shown to the
+    user.  Only the ``id`` and ``text`` fields are required by the agent.
+    """
+
+    return query_memory(message, exclude_ids=exclude_ids)
 
 
 brain = BrainAgent(persona_store=load_persona, memory_store=fetch_memories)


### PR DESCRIPTION
## Summary
- add `score_memory` to combine relevance, recency, and importance for ranking
- track displayed memories in `BrainAgent` to avoid repeats and limit to top 5
- expose full memory records in voice server fetch helper

## Testing
- `PYTHONPATH=. pytest tests/test_memory_recall.py::test_brain_avoids_repeating_displayed_memories -q`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ce98c1d9083269e8f5556a47908d8