### PR TITLE
Gate speech output on user interaction and make voice cloning optional

### DIFF
--- a/src/views/VoiceView.tsx
+++ b/src/views/VoiceView.tsx
@@ -3,7 +3,6 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { toast } from "@/components/ui/use-toast";
 import { Mic, MicOff, Save, Sparkles, Send } from "lucide-react";
-import VoiceSetup from "@/components/VoiceSetup";
 import { useViewNav } from "@/state/view";
 import { VoiceIO } from "@/voice/voiceio";
 
@@ -97,9 +96,6 @@ export default function VoiceView() {
             </Button>
           </CardContent>
         </Card>
-      </div>
-      <div className="mt-6">
-        <VoiceSetup />
       </div>
     </div>
   );

--- a/src/voice/ttsAutoplayToast.ts
+++ b/src/voice/ttsAutoplayToast.ts
@@ -1,0 +1,11 @@
+import { toast } from "@/hooks/use-toast";
+
+let shown = false;
+
+export function ttsAutoplayToast() {
+  if (shown) return;
+  shown = true;
+  toast({
+    description: "Tap to play my response.",
+  });
+}

--- a/src/voice/useTextToSpeech.ts
+++ b/src/voice/useTextToSpeech.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useVoiceStore } from "@/state/voice";
 import { playClonedVoice } from "./voiceClone";
 import { ttsFallbackToast } from "@/voice/ttsFallbackToast";
+import { ttsAutoplayToast } from "@/voice/ttsAutoplayToast";
 
 function fire(type: string, detail: boolean) {
   window.dispatchEvent(new CustomEvent(type, { detail }));
@@ -52,9 +53,30 @@ export function useTextToSpeech() {
     };
   }, [enabled]);
 
+  const enable = useCallback(() => {
+    setEnabled(true);
+    localStorage.setItem("aurora_voice_enabled", "1");
+    try {
+      window.speechSynthesis.getVoices();
+      window.speechSynthesis.resume();
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
   const speak = useCallback(
     async (text: string) => {
-      if (!enabled || !text?.trim()) return; // gate prevents NotAllowedError
+      if (!text?.trim()) return;
+      if (!enabled) {
+        ttsAutoplayToast();
+        const resume = () => {
+          enable();
+          void speak(text);
+        };
+        window.addEventListener("pointerdown", resume, { once: true });
+        window.addEventListener("keydown", resume, { once: true });
+        return;
+      }
       fire('voice-processing', true);
 
       let current = mode;
@@ -80,6 +102,15 @@ export function useTextToSpeech() {
           });
           if (audio) {
             audioRef.current = audio;
+            if ((error as any)?.name === "NotAllowedError") {
+              fire('voice-processing', false);
+              ttsAutoplayToast();
+              const resume = () => {
+                audio.play().catch(() => {});
+              };
+              window.addEventListener("pointerdown", resume, { once: true });
+              window.addEventListener("keydown", resume, { once: true });
+            }
             return;
           }
           const status = (error as { status?: number } | undefined)?.status;
@@ -89,7 +120,7 @@ export function useTextToSpeech() {
           continue;
         }
         if (current === "eleven-default") {
-          const { audio } = await playClonedVoice(
+          const { audio, error } = await playClonedVoice(
             text,
             ELEVENLABS_DEFAULT_VOICE_ID,
             {
@@ -106,6 +137,15 @@ export function useTextToSpeech() {
           );
           if (audio) {
             audioRef.current = audio;
+            if ((error as any)?.name === "NotAllowedError") {
+              fire('voice-processing', false);
+              ttsAutoplayToast();
+              const resume = () => {
+                audio.play().catch(() => {});
+              };
+              window.addEventListener("pointerdown", resume, { once: true });
+              window.addEventListener("keydown", resume, { once: true });
+            }
             return;
           }
           current = "browser-tts";
@@ -142,7 +182,20 @@ export function useTextToSpeech() {
             };
             u.onend = () => setIsSpeaking(false);
             u.onerror = () => setIsSpeaking(false);
-            window.speechSynthesis.speak(u);
+            try {
+              window.speechSynthesis.speak(u);
+            } catch (err) {
+              fire('voice-processing', false);
+              if ((err as any)?.name === "NotAllowedError") {
+                ttsAutoplayToast();
+                const resume = () => {
+                  window.speechSynthesis.speak(u);
+                };
+                window.addEventListener("pointerdown", resume, { once: true });
+                window.addEventListener("keydown", resume, { once: true });
+              }
+              return;
+            }
             return;
           } catch {
             current = "off";
@@ -158,7 +211,7 @@ export function useTextToSpeech() {
       }
       fire('voice-processing', false);
     },
-    [enabled, mode, voiceId, emotion, speed, pitch, expression, setMode],
+    [enabled, mode, voiceId, emotion, speed, pitch, expression, setMode, enable],
 
   );
 
@@ -171,17 +224,6 @@ export function useTextToSpeech() {
       /* ignore */
     }
     setIsSpeaking(false);
-  }, []);
-
-  const enable = useCallback(() => {
-    setEnabled(true);
-    localStorage.setItem("aurora_voice_enabled", "1");
-    try {
-      window.speechSynthesis.getVoices();
-      window.speechSynthesis.resume();
-    } catch {
-      /* ignore */
-    }
   }, []);
 
   return { speak, cancel, isSpeaking, enabled, enable };

--- a/src/voice/voiceClone.ts
+++ b/src/voice/voiceClone.ts
@@ -67,8 +67,12 @@ export async function playClonedVoice(
         audio.onended = onEnd;
         audio.onerror = onEnd;
       }
-      await audio.play();
-      return { audio };
+      try {
+        await audio.play();
+        return { audio };
+      } catch (err) {
+        return { audio, error: err };
+      }
     }
 
     const { data, error } = await supabase.functions.invoke("tts-generate", {
@@ -89,8 +93,12 @@ export async function playClonedVoice(
         audio.onended = onEnd;
         audio.onerror = onEnd;
       }
-      await audio.play();
-      return { audio };
+      try {
+        await audio.play();
+        return { audio };
+      } catch (err) {
+        return { audio, error: err };
+      }
     }
     if (error) {
       return { audio: null, error };


### PR DESCRIPTION
## Summary
- Require a user click or key press before enabling text-to-speech and show a "Tap to play my response" toast when autoplay is blocked
- Handle autoplay rejections when synthesizing speech and retry playback after user interaction
- Remove voice cloning from the Voice view so users can opt in via Settings instead

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, no-empty, and other lint errors across repo)*

------
https://chatgpt.com/codex/tasks/task_e_689cf3ece19c8326bed3fd0d01d42dc0