### PR TITLE
feat: add premium action guard

### DIFF
--- a/src/modules/payments/__tests__/guard.test.ts
+++ b/src/modules/payments/__tests__/guard.test.ts
@@ -1,0 +1,46 @@
+import { jest } from '@jest/globals';
+import { guardPremiumAction } from '../guard';
+import { logEvent } from '@/integrations/supabase/gameSync';
+
+jest.mock('@/integrations/supabase/gameSync', () => ({
+  logEvent: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('guardPremiumAction', () => {
+  const originalConfirm = global.confirm;
+  afterEach(() => {
+    global.confirm = originalConfirm;
+    (logEvent as jest.Mock).mockClear();
+  });
+
+  it('allows pro users without prompting', async () => {
+    const result = await guardPremiumAction(() => true, 'voice_features', 'voice_clone', 'use default voice');
+    expect(result).toBe('pro');
+    expect(logEvent).not.toHaveBeenCalled();
+  });
+
+  it('prompts and logs when feature is unavailable', async () => {
+    global.confirm = jest.fn(() => true);
+    const result = await guardPremiumAction(() => false, 'voice_features', 'voice_clone', 'use default voice');
+    expect(result).toBe('free');
+    expect(logEvent).toHaveBeenCalledWith('pro_action_upsell', { action: 'voice_clone' });
+  });
+
+  it('returns null when user cancels', async () => {
+    global.confirm = jest.fn(() => false);
+    const result = await guardPremiumAction(() => false, 'voice_features', 'voice_clone', 'use default voice');
+    expect(result).toBeNull();
+    expect(logEvent).toHaveBeenCalledWith('pro_action_upsell', { action: 'voice_clone' });
+  });
+
+  it('executes free alternative after confirmation', async () => {
+    global.confirm = jest.fn(() => true);
+    const result = await guardPremiumAction(() => false, 'voice_features', 'voice_clone', 'use default voice');
+    const alternative = jest.fn();
+    if (result === 'free') {
+      alternative();
+    }
+    expect(alternative).toHaveBeenCalled();
+  });
+});
+

--- a/src/modules/payments/guard.ts
+++ b/src/modules/payments/guard.ts
@@ -1,0 +1,22 @@
+import { logEvent } from '@/integrations/supabase/gameSync';
+
+export async function guardPremiumAction(
+  canAccess: (feature: string) => boolean,
+  feature: string,
+  actionName: string,
+  freeAlternative: string
+): Promise<'pro' | 'free' | null> {
+  if (canAccess(feature)) {
+    return 'pro';
+  }
+  try {
+    await logEvent('pro_action_upsell', { action: actionName });
+  } catch {
+    /* ignore logging errors */
+  }
+  const confirmFn = typeof globalThis.confirm === 'function' ? globalThis.confirm : () => true;
+  const proceed = confirmFn(
+    `That's a Pro action. Upgrade to enable it—or I can ${freeAlternative}. Proceed?`
+  );
+  return proceed ? 'free' : null;
+}

--- a/src/voice/useTextToSpeech.ts
+++ b/src/voice/useTextToSpeech.ts
@@ -3,6 +3,8 @@ import { useVoiceStore } from "@/state/voice";
 import { playClonedVoice } from "./voiceClone";
 import { ttsFallbackToast } from "@/voice/ttsFallbackToast";
 import { ttsAutoplayToast } from "@/voice/ttsAutoplayToast";
+import { useSubscription } from "@/modules/payments/hooks/useSubscription";
+import { guardPremiumAction } from "@/modules/payments/guard";
 
 function fire(type: string, detail: boolean) {
   window.dispatchEvent(new CustomEvent(type, { detail }));
@@ -31,6 +33,7 @@ export function useTextToSpeech() {
       setMode: s.setMode,
 
     }));
+  const { canAccessFeature } = useSubscription();
 
   // Allow enabling via first user gesture (click/keydown) OR explicit call
   useEffect(() => {
@@ -84,6 +87,21 @@ export function useTextToSpeech() {
 
       while (current && current !== "off") {
         if (current === "cloned") {
+          const result = await guardPremiumAction(
+            canAccessFeature,
+            "voice_features",
+            "voice_clone",
+            "use the default voice instead",
+          );
+          if (result === null) {
+            fire('voice-processing', false);
+            return;
+          }
+          if (result === 'free') {
+            current = "eleven-default";
+            setMode("eleven-default", false);
+            continue;
+          }
           if (!voiceId) {
             current = "eleven-default";
             setMode("eleven-default", false);


### PR DESCRIPTION
## Summary
- add guardPremiumAction to log and prompt when non-Pro users try premium features
- use guard for voice cloning, falling back to default voice when necessary
- test guard to ensure free alternatives run without upgrade

## Testing
- `npm test`
- `npm run lint` *(fails: 226 problems)*

------
https://chatgpt.com/codex/tasks/task_e_689d051d17c08326bd40d88ec3c591e9