### PR TITLE
feat: add retry backoff for memory and network calls

### DIFF
--- a/src/lib/loggedFetch.ts
+++ b/src/lib/loggedFetch.ts
@@ -1,7 +1,8 @@
 import { useApiCallLog } from '@/state/apiCallLog';
+import { retryWithBackoff } from '@/utils/retry';
 
 export function loggedFetch(input: RequestInfo | URL, init?: RequestInit, reason = '') {
   const endpoint = typeof input === 'string' ? input : input.toString();
   useApiCallLog.getState().add(endpoint, reason);
-  return fetch(input, init);
+  return retryWithBackoff(() => fetch(input, init));
 }

--- a/src/memory/indexedDbMemory.ts
+++ b/src/memory/indexedDbMemory.ts
@@ -1,5 +1,6 @@
 import { auroraChat } from '@/utils/auroraChat';
 import { toast } from '@/hooks/use-toast';
+import { retryWithBackoff } from '@/utils/retry';
 // Removed Node crypto usage for browser compatibility
 
 export type MemoryBucket = 'semantic' | 'episodic' | 'procedural';
@@ -74,19 +75,21 @@ function cosineSimilarity(a: number[], b: number[]) {
 
 export async function getEmbedding(text: string): Promise<number[]> {
   try {
-    const { content } = await auroraChat(
-      [
-        {
-          role: 'system',
-          content:
-            'You are an embedding service. Return a JSON array of numbers representing the embedding of the user text.',
-        },
-        { role: 'user', content: text },
-      ],
-      { model: 'embedding' }
+    const { content } = await retryWithBackoff(() =>
+      auroraChat(
+        [
+          {
+            role: 'system',
+            content:
+              'You are an embedding service. Return a JSON array of numbers representing the embedding of the user text.',
+          },
+          { role: 'user', content: text },
+        ],
+        { model: 'embedding' }
+      )
     );
     const parsed = JSON.parse(content);
-    if (Array.isArray(parsed)) return parsed.map((n: any) => Number(n));
+    if (Array.isArray(parsed)) return parsed.map((n: unknown) => Number(n));
   } catch (e) {
     // fall back to simple deterministic embedding when auroraChat is unavailable
     return Array.from(text).map((c) => c.charCodeAt(0) / 255);
@@ -125,16 +128,16 @@ export class IndexedDbMemory {
   }
 
   private persist() {
-    try {
+    retryWithBackoff(async () => {
       const data = JSON.stringify(this.memories);
       memoryStorage.setItem(STORAGE_KEY, encrypt(data));
-    } catch (err) {
+    }).catch(() => {
       toast({
         title: 'Storage error',
         description: 'Failed to save memories',
         variant: 'destructive',
       });
-    }
+    });
   }
 
   private async prune(bucket: MemoryBucket, limit = 200) {

--- a/src/memory/sync.ts
+++ b/src/memory/sync.ts
@@ -1,4 +1,5 @@
 import type { MemoryBucket, MemoryEntry } from './indexedDbMemory';
+import { retryWithBackoff } from '@/utils/retry';
 
 export interface SyncAdapter {
   pull(): Promise<Record<MemoryBucket, MemoryEntry[]>>;
@@ -44,7 +45,7 @@ export class CloudSyncAdapter implements SyncAdapter {
 
   async pull() {
     try {
-      const res = await fetch(this.endpoint);
+      const res = await retryWithBackoff(() => fetch(this.endpoint));
       if (!res.ok) throw new Error('failed');
       return (await res.json()) as Record<MemoryBucket, MemoryEntry[]>;
     } catch {
@@ -54,11 +55,13 @@ export class CloudSyncAdapter implements SyncAdapter {
 
   async push(data: Record<MemoryBucket, MemoryEntry[]>) {
     try {
-      await fetch(this.endpoint, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      });
+      await retryWithBackoff(() =>
+        fetch(this.endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(data),
+        }),
+      );
     } catch {
       // ignore
     }

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,0 +1,35 @@
+import { toast } from '@/hooks/use-toast';
+
+type ToastHandle = ReturnType<typeof toast>;
+
+export async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  maxRetries = 3,
+  initialDelay = 500,
+): Promise<T> {
+  let attempt = 0;
+  let t: ToastHandle | undefined;
+  while (attempt <= maxRetries) {
+    try {
+      const result = await fn();
+      if (t && attempt > 0) {
+        t.update({ description: 'Success' });
+        setTimeout(() => t?.dismiss(), 2000);
+      }
+      return result;
+    } catch (err) {
+      if (!t) {
+        t = toast({ description: 'Something went wrong—retrying' });
+      }
+      attempt++;
+      if (attempt > maxRetries) {
+        t.update({ description: 'Failed', variant: 'destructive' });
+        setTimeout(() => t?.dismiss(), 2000);
+        throw err;
+      }
+      const delay = initialDelay * Math.pow(2, attempt - 1);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+  throw new Error('retryWithBackoff reached unexpected state');
+}


### PR DESCRIPTION
## Summary
- add `retryWithBackoff` utility with exponential backoff and toast notifications
- wrap network fetches with retry logic via `loggedFetch`
- retry embedding generation and memory persistence with graceful fallbacks
- add retry support to cloud memory sync operations

## Testing
- `npx eslint src/lib/loggedFetch.ts src/memory/indexedDbMemory.ts src/memory/sync.ts src/utils/retry.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d05244ca0832685dcfc14600e063c