### PR TITLE
feat: add home dashboard and chat-aware HUD sphere

### DIFF
--- a/src/components/avatar/AvatarSphere.tsx
+++ b/src/components/avatar/AvatarSphere.tsx
@@ -10,6 +10,7 @@ interface Props {
   size?: number;
   isThinking?: boolean;
   isSpeaking?: boolean;
+  isListening?: boolean;
   progressPercent?: number;
 }
 
@@ -17,6 +18,7 @@ export function AvatarSphere({
   size = 96,
   isThinking = false,
   isSpeaking = false,
+  isListening = false,
   progressPercent = 0,
 }: Props) {
   const { enabled, sentiment, audio, mood, milestone, streak } = useAvatarStore();
@@ -31,6 +33,7 @@ export function AvatarSphere({
   const streakRef = useRef<number>(0);
   const thinkingRef = useRef(isThinking);
   const speakingRef = useRef(isSpeaking);
+  const listeningRef = useRef(isListening);
   const progressRef = useRef(progressPercent);
   const reduceMotion = useRef(false);
 
@@ -41,6 +44,10 @@ export function AvatarSphere({
   useEffect(() => {
     speakingRef.current = isSpeaking;
   }, [isSpeaking]);
+
+  useEffect(() => {
+    listeningRef.current = isListening;
+  }, [isListening]);
 
   useEffect(() => {
     progressRef.current = progressPercent;
@@ -120,6 +127,10 @@ export function AvatarSphere({
           mesh.rotation.y += 0.005;
           scale *= 1 + Math.sin(time) * 0.05;
         }
+        if (listeningRef.current) {
+          scale *= 1 + Math.sin(time * 4) * 0.03;
+          emissive = Math.max(emissive, 0.05);
+        }
         if (thinkingRef.current) {
           scale *= 1 + Math.sin(time * 2) * 0.05;
         }
@@ -149,7 +160,10 @@ export function AvatarSphere({
       analyserRef.current = null;
       return;
     }
-    const ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+    const AudioCtx =
+      window.AudioContext ||
+      (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    const ctx = new AudioCtx();
     const src = ctx.createMediaElementSource(audio);
     const analyser = ctx.createAnalyser();
     analyser.fftSize = 2048;
@@ -157,8 +171,8 @@ export function AvatarSphere({
     analyser.connect(ctx.destination);
     analyserRef.current = analyser;
     return () => {
-      try { src.disconnect(); } catch {}
-      try { analyser.disconnect(); } catch {}
+      try { src.disconnect(); } catch {/* ignore */}
+      try { analyser.disconnect(); } catch {/* ignore */}
       analyserRef.current = null;
     };
   }, [audio]);

--- a/src/components/game/GameHUD.tsx
+++ b/src/components/game/GameHUD.tsx
@@ -10,7 +10,7 @@ import { useAvatarStore } from "@/state/avatar";
 import { useVoiceStore } from "@/state/voice";
 import SettingsPanel from "../../../frontend/components/SettingsPanel.jsx";
 
-function fire(type: string, payload?: any) {
+function fire<T>(type: string, payload?: T) {
   window.dispatchEvent(new CustomEvent('mos', { detail: { type, payload } }));
 }
 
@@ -34,8 +34,8 @@ export function GameHUD() {
   }, [expanded, isMobile]);
 
   useEffect(() => {
-    const onListen = (e: any) => setListening(Boolean(e.detail));
-    const onProcess = (e: any) => setProcessing(Boolean(e.detail));
+    const onListen = (e: Event) => setListening(Boolean((e as CustomEvent).detail));
+    const onProcess = (e: Event) => setProcessing(Boolean((e as CustomEvent).detail));
     window.addEventListener('voice-listening', onListen);
     window.addEventListener('voice-processing', onProcess);
     return () => {
@@ -59,7 +59,7 @@ export function GameHUD() {
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, []);
+  }, [run]);
 
   return (
     <>
@@ -80,10 +80,11 @@ export function GameHUD() {
           {/* Identity */}
           <div className="flex items-center gap-3 min-w-0 shrink">
             {avatarEnabled && (
-              <AvatarSphere
+                <AvatarSphere
                 size={44}
                 isThinking={processing}
                 isSpeaking={isSpeaking}
+                isListening={listening}
                 progressPercent={stats.xp}
               />
             )}

--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -10,7 +10,7 @@ import { useSwipeNav } from "@/hooks/useSwipeNav";
 import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
 import useDailyCheckIn from "@/hooks/useDailyCheckIn";
 import useWeeklyBrainBackup from "@/hooks/useWeeklyBrainBackup";
-import ControlView from "@/views/ControlView";
+import HomeView from "@/views/HomeView";
 export default function AppShell() {
   const { user, initializing } = useSupabaseAuth();
   const loc = useLocation();
@@ -102,8 +102,8 @@ export default function AppShell() {
       <div className="os-bg" />
       <AnimatePresence mode="wait">
         <Routes location={loc} key={loc.pathname + loc.search}>
-          <Route index element={<ControlView />} />
-          {views.filter((v) => v.id !== "control").map((v) => (
+          <Route index element={<HomeView />} />
+          {views.filter((v) => v.id !== "home").map((v) => (
             <Route
               key={v.id}
               path={v.path || undefined}

--- a/src/state/view.ts
+++ b/src/state/view.ts
@@ -9,7 +9,7 @@ type NavState = {
 };
 
 export const useView = create<NavState>((set) => ({
-  current: "control",
+  current: "home",
   set: (v) => {
     console.debug('[useView] set current view', v);
     set({ current: v });

--- a/src/views/HomeView.tsx
+++ b/src/views/HomeView.tsx
@@ -1,0 +1,96 @@
+import { Button } from "@/components/ui/button";
+import { useViewNav } from "@/state/view";
+import { Target, Waves, StickyNote, Mic, Pencil, type LucideIcon } from "lucide-react";
+import type { ViewId } from "@/views/registry";
+import React from "react";
+
+function ProgressRing({ value }: { value: number }) {
+  return (
+    <div className="relative w-16 h-16">
+      <div
+        className="absolute inset-0 rounded-full"
+        style={{
+          background: `conic-gradient(hsl(var(--primary)) ${value}%, hsl(var(--muted)/0.2) ${value}% 100%)`,
+        }}
+      />
+      <div className="absolute inset-1 rounded-full bg-background/80 flex items-center justify-center text-sm font-medium">
+        {value}%
+      </div>
+    </div>
+  );
+}
+
+export default function HomeView() {
+  const open = useViewNav();
+
+  const mission = {
+    title: "Ship Aurora MVP",
+    description: "Finish core features and polish",
+  };
+  const nextCommitment = "Write Home view components";
+  const progress = 42;
+  const changes = [
+    { id: 1, text: "Logged a voice note", time: "2h ago" },
+    { id: 2, text: "Completed focus session", time: "Yesterday" },
+  ];
+
+  const pods: { id: ViewId; label: string; icon: LucideIcon }[] = [
+    { id: "focus", label: "Focus", icon: Target },
+    { id: "hypno", label: "Hypno", icon: Waves },
+    { id: "notes", label: "Notes", icon: StickyNote },
+    { id: "voice", label: "Voice", icon: Mic },
+  ];
+
+  return (
+    <div className="min-h-svh bg-slate-950 text-foreground px-4 py-6 space-y-6">
+      {/* Mission card */}
+      <div className="glass-panel rounded-xl p-6 flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-semibold mb-1">{mission.title}</h2>
+          <p className="text-sm opacity-80 leading-relaxed">{mission.description}</p>
+        </div>
+        <Button size="sm" variant="secondary" className="shrink-0" aria-label="Edit mission">
+          <Pencil className="w-4 h-4" />
+        </Button>
+      </div>
+
+      {/* Today bar */}
+      <div className="glass-panel rounded-xl p-6 flex items-center gap-4">
+        <ProgressRing value={progress} />
+        <div className="flex-1">
+          <div className="text-sm opacity-80">Next:</div>
+          <div className="font-medium">{nextCommitment}</div>
+        </div>
+        <Button onClick={() => open("focus")}>Start Focus</Button>
+      </div>
+
+      {/* Quick pods */}
+      <div className="flex gap-4">
+        {pods.map((p) => (
+          <button
+            key={p.id}
+            onClick={() => open(p.id)}
+            className="flex-1 glass-panel rounded-xl p-4 flex flex-col items-center gap-2 hover-scale"
+          >
+            <p.icon className="w-6 h-6" />
+            <span className="text-sm font-medium">{p.label}</span>
+          </button>
+        ))}
+      </div>
+
+      {/* Recent changes */}
+      <div className="glass-panel rounded-xl p-6">
+        <h3 className="font-medium mb-4">Recent Changes</h3>
+        <ul className="space-y-3 text-sm">
+          {changes.map((c) => (
+            <li key={c.id} className="flex items-center justify-between">
+              <span>{c.text}</span>
+              <span className="opacity-50 text-xs">{c.time}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+

--- a/src/views/registry.tsx
+++ b/src/views/registry.tsx
@@ -1,8 +1,8 @@
 import { lazy } from "react";
 
 export type ViewId =
-  | "control" | "focus" | "hypno" | "voice" | "notes"
-  | "browser" | "portal" | "archive" | "settings" | "agent" | "runner" | "plan";
+  | "home" | "focus" | "hypno" | "voice" | "notes"
+  | "browser" | "portal" | "archive" | "settings" | "agent" | "runner" | "plan" | "control";
 
 export type ViewMeta = {
   id: ViewId;
@@ -15,7 +15,7 @@ export type ViewMeta = {
 
 export const views: ViewMeta[] = [
 
-  { id: "control", label: "Control", path: "",            component: lazy(() => import("./ControlView")) },
+  { id: "home",    label: "Home",    path: "",            component: lazy(() => import("./HomeView")) },
   { id: "focus",   label: "Focus",   path: "focus",      component: lazy(() => import("./FocusView")) },
   { id: "hypno",   label: "Hypno",   path: "hypno",      component: lazy(() => import("./HypnoView")) },
   { id: "voice",   label: "Voice",   path: "voice",      component: lazy(() => import("./VoiceView")) },
@@ -27,4 +27,5 @@ export const views: ViewMeta[] = [
   { id: "agent",   label: "Agent",   path: "agent",      component: lazy(() => import("./AgentFullView")) },
   { id: "plan",    label: "Plan",    path: "plan",       component: lazy(() => import("./PlanView")) },
   { id: "runner",  label: "Node",    path: "node/:id",   component: lazy(() => import("../pages/NodeRunner")) },
+  { id: "control", label: "Control", path: "control",    component: lazy(() => import("./ControlView")) },
 ];


### PR DESCRIPTION
## Summary
- add Home view with mission, daily progress, quick pods, and recent changes
- wire navigation registry and shell to new home view
- connect HUD avatar sphere to chat listening state

## Testing
- `npm run lint` (fails: 203 errors)
- `npx eslint src/views/HomeView.tsx src/components/avatar/AvatarSphere.tsx src/components/game/GameHUD.tsx src/views/registry.tsx src/routes/AppShell.tsx src/state/view.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d2f9cb39c83268f3be5d95a526363