### PR TITLE
feat: add app shell layout with persistent chat

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,9 @@ import HypnoShell from "@/routes/hypno/HypnoShell";
 import ExtensionPage from "@/pages/Extension";
 import StackPage from "./pages/Stack";
 import AppShell from "@/routes/AppShell";
-import PersonaSetup from "./pages/PersonaSetup";
+import HomeView from "@/views/HomeView";
+import { views } from "@/views/registry";
+import LiveShell from "@/routes/live/LiveShell";
 const queryClient = new QueryClient();
 
 const App = () => (
@@ -22,7 +24,14 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Navigate to="/app" replace />} />
-          <Route path="/app/*" element={<AppShell />} />
+          <Route path="/app" element={<AppShell />}>
+            <Route index element={<HomeView />} />
+            {views.filter((v) => v.id !== "home").map((v) => (
+              <Route key={v.id} path={v.path || undefined} element={<v.component />} />
+            ))}
+            <Route path="live" element={<LiveShell />} />
+            <Route path="*" element={<Navigate to="/app" replace />} />
+          </Route>
           <Route path="/world" element={<MindWorldDashboard />} />
           <Route path="/auth" element={<AuthPage />} />
           <Route path="/browser" element={<Navigate to="/app/browser" replace />} />

--- a/src/components/chat/AnchoredChatBar.tsx
+++ b/src/components/chat/AnchoredChatBar.tsx
@@ -59,7 +59,7 @@ export function AnchoredChatBar() {
     <div
       className="fixed left-3 right-3"
       style={{
-        bottom: `calc(var(--hud-h) + var(--hud-gap) + env(safe-area-inset-bottom))`,
+        bottom: `calc(var(--dock-h) + var(--hud-gap) + env(safe-area-inset-bottom))`,
         zIndex: "var(--z-hud)",
       }}
     >

--- a/src/components/game/GameHUD.tsx
+++ b/src/components/game/GameHUD.tsx
@@ -67,7 +67,7 @@ export function GameHUD() {
       <div
         className="fixed left-3 right-3"
         style={{
-          bottom: 'max(12px, env(safe-area-inset-bottom))',
+          top: 'max(12px, env(safe-area-inset-top))',
           zIndex: 'var(--z-hud)',
           pointerEvents: 'auto',
         }}

--- a/src/components/mindworld/HubScene.tsx
+++ b/src/components/mindworld/HubScene.tsx
@@ -50,7 +50,7 @@ export default function HubScene({ children }: PropsWithChildren) {
       <div className="absolute inset-0 world-particles pointer-events-none" aria-hidden />
 
       {/* Content overlay */}
-      <div className="relative z-[var(--z-content)] w-full h-full" style={{ paddingBottom: 'var(--hud-h)' }}>{children}</div>
+      <div className="relative z-[var(--z-content)] w-full h-full" style={{ paddingTop: 'var(--hud-h)' }}>{children}</div>
     </div>
   );
 }

--- a/src/components/navigation/PersistentDock.tsx
+++ b/src/components/navigation/PersistentDock.tsx
@@ -1,0 +1,45 @@
+import { useEffect } from "react";
+import { NavLink } from "react-router-dom";
+import { Home, Brain, NotebookText, Radio, MoreHorizontal } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const items = [
+  { to: "/app", label: "Home", icon: Home },
+  { to: "/app/brain", label: "Brain", icon: Brain },
+  { to: "/app/notes", label: "Journal", icon: NotebookText },
+  { to: "/app/live", label: "Live", icon: Radio },
+  { to: "/app/settings", label: "More", icon: MoreHorizontal },
+];
+
+export function PersistentDock() {
+  useEffect(() => {
+    document.documentElement.style.setProperty("--dock-h", "56px");
+  }, []);
+
+  return (
+    <nav
+      className="fixed bottom-0 left-0 right-0 z-[var(--z-hud)] border-t border-border bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60"
+      aria-label="Primary"
+    >
+      <ul className="flex justify-around py-2">
+        {items.map(({ to, label, icon: Icon }) => (
+          <li key={to}>
+            <NavLink
+              to={to}
+              className={({ isActive }) =>
+                cn(
+                  "flex flex-col items-center gap-1 px-3 text-xs text-muted-foreground hover:text-foreground",
+                  isActive && "text-foreground"
+                )
+              }
+            >
+              <Icon className="h-5 w-5" />
+              <span className="text-[10px]">{label}</span>
+            </NavLink>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}
+

--- a/src/game/GameCanvas.tsx
+++ b/src/game/GameCanvas.tsx
@@ -107,7 +107,7 @@ export default function GameCanvas({ inputVec, actionTick, overlayId, onEnter }:
       {/* Camera viewport clamped above HUD */}
       <div
         className="absolute inset-x-0 top-0"
-        style={{ bottom: `calc(var(--hud-h) + var(--hud-gap))` }}
+        style={{ top: `calc(var(--hud-h) + var(--hud-gap))` }}
         aria-label="CSS World Canvas"
       >
         <div className="world-canvas smooth" style={{ transform: `scale(${zoom})`, transformOrigin: '50% 85%' }}>

--- a/src/game/hud/HUDBar.tsx
+++ b/src/game/hud/HUDBar.tsx
@@ -40,7 +40,6 @@ export default function HUDBar() {
                 <button className="hud-icon settings hover-scale smooth hover:brightness-110 active:scale-95" aria-label="Settings"/>
                 <button className="hud-icon bag hover-scale smooth hover:brightness-110 active:scale-95" aria-label="Bag"/>
                 <button className="hud-icon map hover-scale smooth hover:brightness-110 active:scale-95" aria-label="Map" onClick={()=>run('openMap' as any)}/>
-                <button className="hud-icon chat hover-scale smooth hover:brightness-110 active:scale-95" aria-label="Chat"/>
                 <button className="hud-icon stick hover-scale smooth hover:brightness-110 active:scale-95" aria-label="Joystick" onClick={() => window.dispatchEvent(new CustomEvent('mos', { detail: { type: 'toggleJoystick' } }))}/>
               </div>
 

--- a/src/index.css
+++ b/src/index.css
@@ -377,10 +377,6 @@ All colors MUST be HSL.
   linear-gradient(45deg, hsl(var(--accent)) 50%, hsl(var(--primary)) 50%);
   clip-path: polygon(10% 80%,35% 20%,60% 75%,85% 30%,90% 80%,10% 80%);
 }
-.hud-icon.chat { background:
-  radial-gradient(circle at 50% 45%, hsl(0 0% 100%) 55%, transparent 56%);
-  clip-path: polygon(15% 20%,85% 20%,85% 70%,55% 70%,45% 86%,40% 70%,15% 70%);
-}
 .hud-icon.stick {
   background: radial-gradient(circle, hsl(var(--primary)) 45%, transparent 46%);
   box-shadow: inset 0 0 0 6px hsl(0 0% 100% / 0.27);

--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -1,9 +1,10 @@
 import { Suspense, useEffect, useMemo } from "react";
-import { Route, Routes, useLocation, Navigate } from "react-router-dom";
+import { Outlet, useLocation, Navigate } from "react-router-dom";
 import { AnimatePresence, motion } from "framer-motion";
-import { views, type ViewId } from "@/views/registry";
 import { GameHUD } from "@/components/game/GameHUD";
 import { AnchoredChatBar } from "@/components/chat/AnchoredChatBar";
+import { PersistentDock } from "@/components/navigation/PersistentDock";
+import { views, type ViewId } from "@/views/registry";
 import { bus } from "@/utils/bus";
 import { useViewNav } from "@/state/view";
 import { useXPChime } from "@/hooks/useXPChime";
@@ -11,7 +12,7 @@ import { useSwipeNav } from "@/hooks/useSwipeNav";
 import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
 import useDailyCheckIn from "@/hooks/useDailyCheckIn";
 import useWeeklyBrainBackup from "@/hooks/useWeeklyBrainBackup";
-import HomeView from "@/views/HomeView";
+
 export default function AppShell() {
   const { user, initializing } = useSupabaseAuth();
   const loc = useLocation();
@@ -32,54 +33,56 @@ export default function AppShell() {
   useWeeklyBrainBackup();
 
   useEffect(() => {
-    const off = bus.on('nav:view', ({ id, params }: { id: ViewId; params?: Record<string, string> }) => open(id, params));
+    const off = bus.on(
+      "nav:view",
+      ({ id, params }: { id: ViewId; params?: Record<string, string> }) => open(id, params)
+    );
     return off;
   }, [open]);
 
   useEffect(() => {
-
     const onMos = (e: Event) => {
       const t = (e as CustomEvent).detail?.type as string | undefined;
-      if (t === 'openBrowser') {
-        const last = localStorage.getItem('lastBrowserUrl') || 'https://www.notion.so/';
-        open('browser', { url: last });
+      if (t === "openBrowser") {
+        const last = localStorage.getItem("lastBrowserUrl") || "https://www.notion.so/";
+        open("browser", { url: last });
         return;
       }
       const map: Record<string, ViewId> = {
-        startFocus: 'focus',
-        startHypnosis: 'hypno',
-        voiceNote: 'voice',
-        addNote: 'notes',
-        openMap: 'portal',
-        openBrain: 'brain',
+        startFocus: "focus",
+        startHypnosis: "hypno",
+        voiceNote: "voice",
+        addNote: "notes",
+        openMap: "portal",
+        openBrain: "brain",
       };
       const vid = t ? map[t] : undefined;
       if (vid) open(vid);
     };
-    window.addEventListener('mos', onMos);
+    window.addEventListener("mos", onMos);
     return () => {
-      window.removeEventListener('mos', onMos);
+      window.removeEventListener("mos", onMos);
     };
   }, [open]);
 
   useEffect(() => {
-    const meta = views.find(v => loc.pathname.startsWith(v.path));
+    const meta = views.find((v) => loc.pathname.startsWith(v.path));
     if (meta) {
       document.title = `Aurora OS — ${meta.label}`;
       // SEO: update description and canonical
       const description = `Aurora OS — ${meta.label} room for focus, voice, and hypnosis.`;
       let md = document.querySelector('meta[name="description"]') as HTMLMetaElement | null;
       if (!md) {
-        md = document.createElement('meta');
-        md.name = 'description';
+        md = document.createElement("meta");
+        md.name = "description";
         document.head.appendChild(md);
       }
       md.content = description;
 
       let link = document.querySelector('link[rel="canonical"]') as HTMLLinkElement | null;
       if (!link) {
-        link = document.createElement('link');
-        link.rel = 'canonical';
+        link = document.createElement("link");
+        link.rel = "canonical";
         document.head.appendChild(link);
       }
       link.href = window.location.origin + loc.pathname + loc.search;
@@ -102,36 +105,26 @@ export default function AppShell() {
   return (
     <div className={`relative min-h-svh room-${currentRoom}`} {...swipe}>
       <div className="os-bg" />
-      <AnimatePresence mode="wait">
-        <Routes location={loc} key={loc.pathname + loc.search}>
-          <Route index element={<HomeView />} />
-          {views.filter((v) => v.id !== "home").map((v) => (
-            <Route
-              key={v.id}
-              path={v.path || undefined}
-              index={v.path === "" ? true : undefined}
-              element={
-                <motion.div
-                  initial={{ opacity: 0, y: 12 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, y: -8 }}
-                  transition={{ duration: 0.18 }}
-                  className="pb-[calc(var(--hud-h)+var(--hud-gap)+var(--chatbar-h)+env(safe-area-inset-bottom))]"
-                >
-                  <Suspense fallback={<div className="p-6 opacity-70">Loading…</div>}>
-                    <v.component />
-                  </Suspense>
-                </motion.div>
-              }
-            />
-          ))}
-          <Route path="*" element={<Navigate to="/app" replace />} />
-        </Routes>
-      </AnimatePresence>
-
+      <main className="pt-[calc(var(--hud-h)+var(--hud-gap))] pb-[calc(var(--chatbar-h)+var(--dock-h)+env(safe-area-inset-bottom))]">
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={loc.pathname + loc.search}
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            transition={{ duration: 0.18 }}
+          >
+            <Suspense fallback={<div className="p-6 opacity-70">Loading…</div>}>
+              <Outlet />
+            </Suspense>
+          </motion.div>
+        </AnimatePresence>
+      </main>
 
       <GameHUD />
       <AnchoredChatBar />
+      <PersistentDock />
     </div>
   );
 }
+

--- a/src/styles/vars.css
+++ b/src/styles/vars.css
@@ -2,7 +2,8 @@
 :root {
   --compass-size: 72px;
   --chatbar-h: 56px; /* chat bar */
+  --dock-h: 56px;    /* persistent dock */
   --fab-size: 56px;    /* new task */
   --gap: 12px;
-  --compass-bottom: calc(var(--hud-h) + var(--hud-gap) + var(--chatbar-h) + var(--gap));
+  --compass-bottom: calc(var(--chatbar-h) + var(--dock-h) + var(--gap));
 }


### PR DESCRIPTION
## Summary
- add AppShell layout with top HUD, dock, and anchored chat bar
- route app views through AppShell so chat persists across navigation
- drop old chat triggers and styles

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, Empty block statement, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689d3373cf4483268c46814e5adc2113