### PR TITLE
feat: redesign home view and chat-aware sphere

### DIFF
--- a/src/components/avatar/AvatarSphere.tsx
+++ b/src/components/avatar/AvatarSphere.tsx
@@ -1,10 +1,12 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
 import {
   useAvatarStore,
   type AvatarMood,
   type AvatarMilestone,
 } from '@/state/avatar';
+import { useVoiceStore } from '@/state/voice';
+import { useGameStore } from '@/game/store';
 
 interface Props {
   size?: number;
@@ -16,12 +18,20 @@ interface Props {
 
 export function AvatarSphere({
   size = 96,
-  isThinking = false,
-  isSpeaking = false,
-  isListening = false,
-  progressPercent = 0,
+  isThinking,
+  isSpeaking,
+  isListening,
+  progressPercent,
 }: Props) {
   const { enabled, sentiment, audio, mood, milestone, streak } = useAvatarStore();
+  const storeSpeaking = useVoiceStore((s) => s.isSpeaking);
+  const progressStore = useGameStore((s) => s.stats.xp);
+
+  const [listening, setListening] = useState(isListening ?? false);
+  const [thinking, setThinking] = useState(isThinking ?? false);
+  const speaking = isSpeaking ?? storeSpeaking;
+  const progressPct = progressPercent ?? progressStore;
+
   const mountRef = useRef<HTMLDivElement | null>(null);
   const analyserRef = useRef<AnalyserNode | null>(null);
   const meshRef = useRef<THREE.Mesh | null>(null);
@@ -31,27 +41,45 @@ export function AvatarSphere({
   const moodRef = useRef<AvatarMood>('neutral');
   const milestoneRef = useRef<AvatarMilestone>('none');
   const streakRef = useRef<number>(0);
-  const thinkingRef = useRef(isThinking);
-  const speakingRef = useRef(isSpeaking);
-  const listeningRef = useRef(isListening);
-  const progressRef = useRef(progressPercent);
+  const thinkingRef = useRef(thinking);
+  const speakingRef = useRef(speaking);
+  const listeningRef = useRef(listening);
+  const progressRef = useRef(progressPct);
   const reduceMotion = useRef(false);
 
   useEffect(() => {
-    thinkingRef.current = isThinking;
-  }, [isThinking]);
-
-  useEffect(() => {
-    speakingRef.current = isSpeaking;
-  }, [isSpeaking]);
-
-  useEffect(() => {
-    listeningRef.current = isListening;
+    if (isListening === undefined) {
+      const onListen = (e: Event) => setListening(Boolean((e as CustomEvent).detail));
+      window.addEventListener('voice-listening', onListen);
+      return () => window.removeEventListener('voice-listening', onListen);
+    }
+    setListening(isListening ?? false);
   }, [isListening]);
 
   useEffect(() => {
-    progressRef.current = progressPercent;
-  }, [progressPercent]);
+    if (isThinking === undefined) {
+      const onProcess = (e: Event) => setThinking(Boolean((e as CustomEvent).detail));
+      window.addEventListener('voice-processing', onProcess);
+      return () => window.removeEventListener('voice-processing', onProcess);
+    }
+    setThinking(isThinking ?? false);
+  }, [isThinking]);
+
+  useEffect(() => {
+    thinkingRef.current = thinking;
+  }, [thinking]);
+
+  useEffect(() => {
+    speakingRef.current = speaking;
+  }, [speaking]);
+
+  useEffect(() => {
+    listeningRef.current = listening;
+  }, [listening]);
+
+  useEffect(() => {
+    progressRef.current = progressPct;
+  }, [progressPct]);
 
   useEffect(() => {
     reduceMotion.current = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
@@ -188,7 +216,7 @@ export function AvatarSphere({
     const tint = new THREE.Color().setHSL(p * 0.4, 0.7, 0.5);
     base.lerp(tint, 0.25);
     matRef.current.color.copy(base);
-  }, [sentiment, progressPercent]);
+  }, [sentiment, progressPct]);
 
   // Distort geometry based on sentiment
   useEffect(() => {

--- a/src/components/game/GameHUD.tsx
+++ b/src/components/game/GameHUD.tsx
@@ -7,7 +7,6 @@ import { Mic, ChevronDown, ChevronUp, Loader2 } from "lucide-react";
 import { useTextToSpeech } from "@/voice/useTextToSpeech";
 import { useHUDActions } from "@/game/hud/useHUDActions";
 import { useAvatarStore } from "@/state/avatar";
-import { useVoiceStore } from "@/state/voice";
 import SettingsPanel from "../../../frontend/components/SettingsPanel.jsx";
 
 function fire<T>(type: string, payload?: T) {
@@ -22,7 +21,6 @@ export function GameHUD() {
   const { enabled, enable } = useTextToSpeech();
   const [listening, setListening] = useState(false);
   const [processing, setProcessing] = useState(false);
-  const isSpeaking = useVoiceStore((s) => s.isSpeaking);
 
   // Mobile collapse state
   const isMobile = window.innerWidth <= 768;
@@ -79,15 +77,7 @@ export function GameHUD() {
         <div className="flex items-center gap-3 min-w-0 flex-wrap">
           {/* Identity */}
           <div className="flex items-center gap-3 min-w-0 shrink">
-            {avatarEnabled && (
-                <AvatarSphere
-                size={44}
-                isThinking={processing}
-                isSpeaking={isSpeaking}
-                isListening={listening}
-                progressPercent={stats.xp}
-              />
-            )}
+            {avatarEnabled && <AvatarSphere size={44} />}
             <div className="min-w-0">
               <div className="text-[13px] opacity-90 truncate">
                 Lv. {stats.level} • Streak {stats.streak}

--- a/src/views/HomeView.tsx
+++ b/src/views/HomeView.tsx
@@ -1,8 +1,25 @@
+import React, { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { useViewNav } from "@/state/view";
-import { Target, Waves, StickyNote, Mic, Pencil, type LucideIcon } from "lucide-react";
-import type { ViewId } from "@/views/registry";
-import React from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Target,
+  Waves,
+  StickyNote,
+  Mic,
+  Pencil,
+  type LucideIcon,
+} from "lucide-react";
+import { useGameStore } from "@/game/store";
+import { useHUDActions } from "@/game/hud/useHUDActions";
+import type { QuickActionKey } from "@/game/hud/hud.data";
 
 function ProgressRing({ value }: { value: number }) {
   return (
@@ -21,76 +38,122 @@ function ProgressRing({ value }: { value: number }) {
 }
 
 export default function HomeView() {
-  const open = useViewNav();
+  const { run } = useHUDActions();
+  const progress = useGameStore((s) => s.stats.xp);
 
-  const mission = {
+  const [mission, setMission] = useState({
     title: "Ship Aurora MVP",
     description: "Finish core features and polish",
-  };
+  });
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(mission);
+
   const nextCommitment = "Write Home view components";
-  const progress = 42;
   const changes = [
     { id: 1, text: "Logged a voice note", time: "2h ago" },
     { id: 2, text: "Completed focus session", time: "Yesterday" },
   ];
 
-  const pods: { id: ViewId; label: string; icon: LucideIcon }[] = [
-    { id: "focus", label: "Focus", icon: Target },
-    { id: "hypno", label: "Hypno", icon: Waves },
-    { id: "notes", label: "Notes", icon: StickyNote },
-    { id: "voice", label: "Voice", icon: Mic },
+  const pods: { action: QuickActionKey; label: string; icon: LucideIcon }[] = [
+    { action: "startFocus", label: "Focus", icon: Target },
+    { action: "startHypnosis", label: "Hypno", icon: Waves },
+    { action: "addNote", label: "Notes", icon: StickyNote },
+    { action: "voiceNote", label: "Voice", icon: Mic },
   ];
 
+  const handleSave = () => {
+    setMission(draft);
+    setEditing(false);
+  };
+
   return (
-    <div className="min-h-svh bg-slate-950 text-foreground px-4 py-6 space-y-6">
-      {/* Mission card */}
-      <div className="glass-panel rounded-xl p-6 flex items-start justify-between gap-4">
-        <div>
-          <h2 className="text-lg font-semibold mb-1">{mission.title}</h2>
-          <p className="text-sm opacity-80 leading-relaxed">{mission.description}</p>
-        </div>
-        <Button size="sm" variant="secondary" className="shrink-0" aria-label="Edit mission">
-          <Pencil className="w-4 h-4" />
-        </Button>
-      </div>
-
-      {/* Today bar */}
-      <div className="glass-panel rounded-xl p-6 flex items-center gap-4">
-        <ProgressRing value={progress} />
-        <div className="flex-1">
-          <div className="text-sm opacity-80">Next:</div>
-          <div className="font-medium">{nextCommitment}</div>
-        </div>
-        <Button onClick={() => open("focus")}>Start Focus</Button>
-      </div>
-
-      {/* Quick pods */}
-      <div className="flex gap-4">
-        {pods.map((p) => (
-          <button
-            key={p.id}
-            onClick={() => open(p.id)}
-            className="flex-1 glass-panel rounded-xl p-4 flex flex-col items-center gap-2 hover-scale"
+    <>
+      <div className="min-h-svh bg-slate-950 text-foreground px-4 py-6 space-y-6">
+        {/* Mission card */}
+        <div className="glass-panel rounded-xl p-6 flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-semibold mb-1">{mission.title}</h2>
+            <p className="text-sm opacity-80 leading-relaxed">{mission.description}</p>
+          </div>
+          <Button
+            size="sm"
+            variant="secondary"
+            className="shrink-0"
+            aria-label="Edit mission"
+            onClick={() => {
+              setDraft(mission);
+              setEditing(true);
+            }}
           >
-            <p.icon className="w-6 h-6" />
-            <span className="text-sm font-medium">{p.label}</span>
-          </button>
-        ))}
+            <Pencil className="w-4 h-4" />
+          </Button>
+        </div>
+
+        {/* Today bar */}
+        <div className="glass-panel rounded-xl p-6 flex items-center gap-4">
+          <ProgressRing value={progress} />
+          <div className="flex-1">
+            <div className="text-sm opacity-80">Next:</div>
+            <div className="font-medium">{nextCommitment}</div>
+          </div>
+          <Button onClick={() => run("startFocus")}>Start Focus</Button>
+        </div>
+
+        {/* Quick pods */}
+        <div className="flex gap-4">
+          {pods.map((p) => (
+            <button
+              key={p.action}
+              onClick={() => run(p.action)}
+              className="flex-1 glass-panel rounded-xl p-4 flex flex-col items-center gap-2 hover-scale"
+            >
+              <p.icon className="w-6 h-6" />
+              <span className="text-sm font-medium">{p.label}</span>
+            </button>
+          ))}
+        </div>
+
+        {/* Recent changes */}
+        <div className="glass-panel rounded-xl p-6">
+          <h3 className="font-medium mb-4">Recent Changes</h3>
+          <ul className="space-y-3 text-sm">
+            {changes.map((c) => (
+              <li key={c.id} className="flex items-center justify-between">
+                <span>{c.text}</span>
+                <span className="opacity-50 text-xs">{c.time}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
       </div>
 
-      {/* Recent changes */}
-      <div className="glass-panel rounded-xl p-6">
-        <h3 className="font-medium mb-4">Recent Changes</h3>
-        <ul className="space-y-3 text-sm">
-          {changes.map((c) => (
-            <li key={c.id} className="flex items-center justify-between">
-              <span>{c.text}</span>
-              <span className="opacity-50 text-xs">{c.time}</span>
-            </li>
-          ))}
-        </ul>
-      </div>
-    </div>
+      <Dialog open={editing} onOpenChange={setEditing}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Edit Mission</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <Input
+              value={draft.title}
+              onChange={(e) => setDraft({ ...draft, title: e.target.value })}
+              placeholder="Mission title"
+            />
+            <Textarea
+              value={draft.description}
+              onChange={(e) => setDraft({ ...draft, description: e.target.value })}
+              placeholder="Mission description"
+              rows={3}
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="secondary" onClick={() => setEditing(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleSave}>Save</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- revamp Home view with mission card, Today progress ring, Quick Pods, and recent changes
- add in-place mission editing dialog and action-driven Quick Pods
- make avatar sphere react to chat states and streamline HUD usage

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689d398a7a3c83268521265973cf1222