### PR TITLE
feat: add keyboard-safe bottom dock

### DIFF
--- a/src/components/chat/AnchoredChatBar.tsx
+++ b/src/components/chat/AnchoredChatBar.tsx
@@ -69,7 +69,7 @@ export function AnchoredChatBar() {
     <div
       className="fixed left-3 right-3 relative"
       style={{
-        bottom: `calc(var(--hud-h) + var(--dock-h) + var(--hud-gap) + env(safe-area-inset-bottom))`,
+        bottom: `calc(var(--hud-h) + var(--dock-h) + var(--hud-gap) + var(--kb-offset) + env(safe-area-inset-bottom))`,
         zIndex: "var(--z-hud)",
       }}
     >

--- a/src/components/navigation/BottomDock.tsx
+++ b/src/components/navigation/BottomDock.tsx
@@ -21,7 +21,7 @@ export default function BottomDock() {
     <nav
       className="fixed left-0 right-0"
       style={{
-        bottom: `calc(var(--hud-h) + env(safe-area-inset-bottom))`,
+        bottom: `calc(var(--hud-h) + var(--kb-offset) + env(safe-area-inset-bottom))`,
         zIndex: "var(--z-hud)",
         height: "var(--dock-h)",
       }}

--- a/src/hooks/useKeyboardOffset.ts
+++ b/src/hooks/useKeyboardOffset.ts
@@ -1,0 +1,22 @@
+import { useEffect } from "react";
+
+// Updates CSS variable --kb-offset to avoid the on-screen keyboard
+export function useKeyboardOffset() {
+  useEffect(() => {
+    const viewport = window.visualViewport;
+    if (!viewport) return;
+
+    const update = () => {
+      const offset = Math.max(0, window.innerHeight - viewport.height - viewport.offsetTop);
+      document.documentElement.style.setProperty("--kb-offset", `${offset}px`);
+    };
+
+    update();
+    viewport.addEventListener("resize", update);
+    viewport.addEventListener("scroll", update);
+    return () => {
+      viewport.removeEventListener("resize", update);
+      viewport.removeEventListener("scroll", update);
+    };
+  }, []);
+}

--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -13,6 +13,7 @@ import { useSwipeNav } from "@/hooks/useSwipeNav";
 import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
 import useDailyCheckIn from "@/hooks/useDailyCheckIn";
 import useWeeklyBrainBackup from "@/hooks/useWeeklyBrainBackup";
+import { useKeyboardOffset } from "@/hooks/useKeyboardOffset";
 import HomeView from "@/views/HomeView";
 export default function AppShell() {
   const { user, initializing } = useSupabaseAuth();
@@ -32,6 +33,7 @@ export default function AppShell() {
   const swipe = useSwipeNav();
   useDailyCheckIn();
   useWeeklyBrainBackup();
+  useKeyboardOffset();
 
   useEffect(() => {
     const off = bus.on('nav:view', ({ id, params }: { id: ViewId; params?: Record<string, string> }) => open(id, params));
@@ -119,7 +121,7 @@ export default function AppShell() {
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -8 }}
                   transition={{ duration: 0.18 }}
-                  className="pb-[calc(var(--hud-h)+var(--dock-h)+var(--hud-gap)+var(--chatbar-h)+env(safe-area-inset-bottom))]"
+                  className="pb-[calc(var(--hud-h)+var(--dock-h)+var(--hud-gap)+var(--chatbar-h)+var(--kb-offset)+env(safe-area-inset-bottom))]"
                 >
                   <Suspense fallback={<div className="p-6 opacity-70">Loading…</div>}>
                     <v.component />

--- a/src/styles/vars.css
+++ b/src/styles/vars.css
@@ -5,5 +5,6 @@
   --dock-h: 56px; /* bottom dock */
   --fab-size: 56px;    /* new task */
   --gap: 12px;
+  --kb-offset: 0px; /* keyboard height offset */
   --compass-bottom: calc(var(--hud-h) + var(--dock-h) + var(--hud-gap) + var(--chatbar-h) + var(--gap));
 }


### PR DESCRIPTION
## Summary
- track mobile keyboard height and expose as `--kb-offset`
- shift bottom dock, chat bar and page padding above on-screen keyboard
- wire keyboard offset into AppShell

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and empty block statements)*

------
https://chatgpt.com/codex/tasks/task_e_689d3be79f1c83269f56fcf2671e0fd4