### PR TITLE
feat: add persistent focus timer

### DIFF
--- a/src/components/chat/AnchoredChatBar.tsx
+++ b/src/components/chat/AnchoredChatBar.tsx
@@ -95,7 +95,7 @@ export function AnchoredChatBar() {
               void handleSend();
             }
           }}
-          placeholder="Ask anything…"
+          placeholder="Need a nudge?"
           aria-label="Message input"
           className="flex-1"
         />

--- a/src/components/live/FocusTimer.tsx
+++ b/src/components/live/FocusTimer.tsx
@@ -1,0 +1,30 @@
+import { Button } from '@/components/ui/button';
+import { useFocusTimer, formatTime } from '@/state/focusTimer';
+import { TimerRing } from './TimerRing';
+
+export function FocusTimer() {
+  const { remaining, progress, running, start, pause, resume, mode, toggleMode } = useFocusTimer();
+
+  const handleStart = () => start();
+  const handlePauseResume = () => {
+    if (running) pause();
+    else resume();
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <TimerRing percent={progress} time={formatTime(remaining)} />
+      <div className="flex items-center gap-2">
+        {!running && remaining === 25 * 60 * 1000 && (
+          <Button onClick={handleStart}>Start</Button>
+        )}
+        {remaining < 25 * 60 * 1000 && (
+          <Button onClick={handlePauseResume}>{running ? 'Pause' : 'Resume'}</Button>
+        )}
+        <Button variant="ghost" onClick={toggleMode}>
+          {mode === 'pomodoro' ? 'Pomodoro' : 'Free'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/live/LiveFocusView.tsx
+++ b/src/components/live/LiveFocusView.tsx
@@ -3,19 +3,9 @@ import { useSupabaseAuth } from '@/hooks/useSupabaseAuth';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from '@/hooks/use-toast';
 import { Button } from '@/components/ui/button';
-import { CurrentFocusCard } from './CurrentFocusCard';
-import { QuickActionsBar } from './QuickActionsBar';
-import HeroCard from './HeroCard';
-import { MoodCarousel } from './MoodCarousel';
-import ActionDock from './ActionDock';
-import PreviewCards from './PreviewCards';
-
-import { useRoadmapProgress } from '@/hooks/useRoadmapProgress';
-import { PanelHeaderUnified } from '@/components/layout/PanelHeaderUnified';
-import QuickAddTaskFAB from '@/components/tasks/QuickAddTaskFAB';
-import { StreakBadge } from '@/components/live/StreakBadge';
-import { setActiveRoadmap, fetchNextTask } from '@/modules/roadmaps';
 import { useCurrentTask, type Task } from '@/state/task';
+import { FocusTimer } from './FocusTimer';
+import { useViewNav } from '@/state/view';
 
 type Roadmap = {
   id: string;
@@ -26,20 +16,12 @@ type Roadmap = {
 };
 
 
-export default function LiveFocusView({
-  onManageRoadmaps,
-}: {
-  onManageRoadmaps?: () => void;
-}) {
+export default function LiveFocusView() {
   const { user, initializing } = useSupabaseAuth();
   const [activeRoadmap, setActiveRoadmap] = useState<Roadmap | null>(null);
   const [roadmaps, setRoadmaps] = useState<Roadmap[]>([]);
   const [task, setTask] = useState<Task | null>(null);
   const [loading, setLoading] = useState(true);
-  const { percent, refresh: refreshProgress } = useRoadmapProgress(
-    user?.id ?? null,
-    activeRoadmap?.id ?? null
-  );
   const [reloadKey, setReloadKey] = useState(0);
   const setCurrentTaskStore = useCurrentTask((s) => s.setCurrentTask);
 
@@ -186,130 +168,16 @@ export default function LiveFocusView({
     };
   }, [user]);
 
-  const switchActive = async (roadmapId: string) => {
-    if (!user) {
-      toast({
-        title: 'Sign in required',
-        description: 'Connect Supabase to manage roadmaps.',
-      });
-      return;
-    }
-    try {
-      await setActiveRoadmap(user.id, roadmapId);
-    } catch (e) {
-      console.error(e);
-      toast({ title: 'Error', description: 'Could not activate roadmap.' });
-      return;
-    }
-    toast({ title: 'Activated', description: 'Roadmap set as live.' });
-    // Reload minimal state
-    const newActive = roadmaps.find((r) => r.id === roadmapId) ?? null;
-    if (newActive) newActive.status = 'active';
-    setActiveRoadmap(newActive);
-    // Force pick next task for new roadmap
-    if (newActive) {
-      const nextTask = await fetchNextTask(user.id, newActive.id);
-      setTask(nextTask);
-      await supabase.from('current_focus').upsert({
-        user_id: user.id,
-        task_id: nextTask ? nextTask.id : null,
-        started_at: new Date().toISOString(),
-      });
-    }
-  };
-
-  const handleAdvance = async () => {
-    if (!user || !activeRoadmap) { setTask(null); return; }
-    const nextTask = await fetchNextTask(user.id, activeRoadmap.id);
-    setTask(nextTask);
-    await supabase.from('current_focus').upsert({
-      user_id: user.id,
-      task_id: nextTask ? nextTask.id : null,
-      started_at: new Date().toISOString(),
-    });
-    toast({
-      title: nextTask ? 'Great job!' : 'Well done',
-      description: nextTask ? `Next up: ${nextTask.title}` : 'No more tasks in this roadmap.',
-    });
-    refreshProgress();
-  };
-
+  const open = useViewNav();
   return (
-    <section className="w-full h-full flex flex-col">
-      <PanelHeaderUnified
-        title="Live"
-        subtitle="Focus on one thing, right now."
-        actions={
-          <>
-            <StreakBadge />
-            <select
-              className="text-sm bg-background border border-border rounded px-3 py-2"
-              value={activeRoadmap?.id ?? ''}
-              onChange={(e) => switchActive(e.target.value)}
-            >
-              <option value="" disabled>
-                Select roadmap…
-              </option>
-              {roadmaps.map((r) => (
-                <option key={r.id} value={r.id}>
-                  {r.title} {r.status === 'active' ? '•' : ''}
-                </option>
-              ))}
-            </select>
-            <Button
-              variant="secondary"
-              onClick={() => {
-                if (onManageRoadmaps) onManageRoadmaps();
-                else
-                  toast({
-                    title: 'Roadmaps',
-                    description:
-                      'Manage your roadmaps and tasks in the Control panel for now.',
-                  });
-              }}
-            >
-              Manage
-            </Button>
-          </>
-        }
-      />
-
-      <main className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-4 p-6 max-w-3xl mx-auto w-full">
-        {!user && !initializing && (
-          <div className="glass-panel rounded-xl p-6 text-center">
-            <div className="text-sm text-muted-foreground">
-              Sign in to enable Live Focus, background sound, and quick capture.
-            </div>
-          </div>
-        )}
-
-        <HeroCard taskTitle={task?.title ?? null} />
-
-        <div
-          key={task?.id ?? 'none'}
-          className="animate-in fade-in-50 duration-300"
-        >
-          <CurrentFocusCard
-            activeRoadmap={activeRoadmap}
-            task={task}
-            progressPercent={percent}
-            onAdvance={handleAdvance}
-          />
-        </div>
-
-        <QuickActionsBar currentTask={task} />
-
-        <MoodCarousel />
-        <PreviewCards progressPercent={percent} />
-      </main>
-      <ActionDock
-        onStart={() =>
-          toast({
-            title: 'Focus Session',
-            description: 'Starting focus mode soon.',
-          })
-        }
-      />
+    <section className="w-full h-full flex flex-col items-center justify-center p-6 gap-6">
+      <Button variant="ghost" className="self-start" onClick={() => open('home')}>
+        Back
+      </Button>
+      <h2 className="text-xl font-semibold">
+        {task ? task.title : 'No task selected'}
+      </h2>
+      <FocusTimer />
     </section>
   );
 }

--- a/src/components/live/TimerRing.tsx
+++ b/src/components/live/TimerRing.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+export function TimerRing({ percent, time }: { percent: number; time: string }) {
+  const radius = 60;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference - (percent / 100) * circumference;
+  return (
+    <svg viewBox="0 0 150 150" className="w-40 h-40">
+      <circle cx={75} cy={75} r={radius} stroke="#e5e5e5" strokeWidth={10} fill="none" />
+      <circle
+        cx={75}
+        cy={75}
+        r={radius}
+        stroke="currentColor"
+        strokeWidth={10}
+        fill="none"
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        className="transition-all duration-1000 ease-linear"
+      />
+      <text
+        x="50%"
+        y="50%"
+        dy="0.3em"
+        textAnchor="middle"
+        className="text-xl font-bold"
+      >
+        {time}
+      </text>
+    </svg>
+  );
+}

--- a/src/components/navigation/TimerHudChip.tsx
+++ b/src/components/navigation/TimerHudChip.tsx
@@ -1,0 +1,16 @@
+import { useFocusTimer, formatTime } from '@/state/focusTimer';
+import { useViewNav } from '@/state/view';
+
+export function TimerHudChip() {
+  const { running, remaining } = useFocusTimer();
+  const open = useViewNav();
+  if (!running) return null;
+  return (
+    <button
+      onClick={() => open('focus')}
+      className="fixed top-2 right-2 z-[var(--z-hud)] bg-secondary text-secondary-foreground px-3 py-1 rounded-full text-xs pointer-events-auto"
+    >
+      {formatTime(remaining)}
+    </button>
+  );
+}

--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -5,6 +5,7 @@ import { views, type ViewId } from "@/views/registry";
 import { GameHUD } from "@/components/game/GameHUD";
 import { AnchoredChatBar } from "@/components/chat/AnchoredChatBar";
 import BottomDock from "@/components/navigation/BottomDock";
+import { TimerHudChip } from "@/components/navigation/TimerHudChip";
 import { ChatProvider } from "@/state/chat";
 import { bus } from "@/utils/bus";
 import { useViewNav } from "@/state/view";
@@ -137,6 +138,7 @@ export default function AppShell() {
       <GameHUD />
       <BottomDock />
       <AnchoredChatBar />
+      <TimerHudChip />
     </div>
     </ChatProvider>
   );

--- a/src/state/focusTimer.ts
+++ b/src/state/focusTimer.ts
@@ -1,0 +1,78 @@
+import { create } from 'zustand';
+
+export type TimerMode = 'pomodoro' | 'free';
+
+interface TimerState {
+  mode: TimerMode;
+  duration: number; // ms
+  remaining: number; // ms
+  running: boolean;
+  interval?: number;
+  progress: number; // 0-100
+  start: (mode?: TimerMode) => void;
+  pause: () => void;
+  resume: () => void;
+  toggleMode: () => void;
+}
+
+const POMODORO_MS = 25 * 60 * 1000;
+
+export const useFocusTimer = create<TimerState>((set, get) => ({
+  mode: 'pomodoro',
+  duration: POMODORO_MS,
+  remaining: POMODORO_MS,
+  running: false,
+  progress: 0,
+  start: (m) => {
+    const mode = m ?? get().mode;
+    const dur = mode === 'pomodoro' ? POMODORO_MS : 0;
+    const rem = dur;
+    const tick = () => {
+      set((s) => {
+        if (!s.running) return s;
+        const next = s.remaining - 1000;
+        if (next <= 0) {
+          clearInterval(get().interval);
+          return { ...s, remaining: 0, running: false, interval: undefined, progress: 100 };
+        }
+        return { ...s, remaining: next, progress: s.duration ? ((s.duration - next) / s.duration) * 100 : 0 };
+      });
+    };
+    const id = window.setInterval(tick, 1000);
+    set({ mode, duration: dur, remaining: rem, running: true, interval: id, progress: 0 });
+  },
+  pause: () => {
+    const id = get().interval;
+    if (id) clearInterval(id);
+    set({ running: false, interval: undefined });
+  },
+  resume: () => {
+    if (get().running || get().remaining <= 0) return;
+    const tick = () => {
+      set((s) => {
+        if (!s.running) return s;
+        const next = s.remaining - 1000;
+        if (next <= 0) {
+          clearInterval(get().interval);
+          return { ...s, remaining: 0, running: false, interval: undefined, progress: 100 };
+        }
+        return { ...s, remaining: next, progress: s.duration ? ((s.duration - next) / s.duration) * 100 : 0 };
+      });
+    };
+    const id = window.setInterval(tick, 1000);
+    set({ running: true, interval: id });
+  },
+  toggleMode: () => {
+    const next = get().mode === 'pomodoro' ? 'free' : 'pomodoro';
+    get().pause();
+    const dur = next === 'pomodoro' ? POMODORO_MS : 0;
+    set({ mode: next, duration: dur, remaining: dur, progress: 0 });
+  },
+}));
+
+export function formatTime(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const m = Math.floor(total / 60).toString().padStart(2, '0');
+  const s = (total % 60).toString().padStart(2, '0');
+  return `${m}:${s}`;
+}


### PR DESCRIPTION
## Summary
- add global pomodoro/free focus timer with start/pause/resume
- show minimal live view with task, timer and back navigation
- surface running timer in HUD chip and add "Need a nudge?" chat hint

## Testing
- `npm test > /tmp/unit.log 2>&1 && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_689df563b3cc832685df18047f7985e8