### PR TITLE
Add account plan page and unify Pro checks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import MindWorldDashboard from "@/components/mindworld/MindWorldDashboard";
 import HypnoShell from "@/routes/hypno/HypnoShell";
 import ExtensionPage from "@/pages/Extension";
 import StackPage from "./pages/Stack";
+import AccountPlanPage from "./pages/AccountPlan";
 import AppShell from "@/routes/AppShell";
 import HomeView from "@/views/HomeView";
 import { views } from "@/views/registry";
@@ -38,6 +39,7 @@ const App = () => (
           <Route path="/hypno" element={<HypnoShell />} />
           <Route path="/extension" element={<ExtensionPage />} />
           <Route path="/stack" element={<StackPage />} />
+          <Route path="/plan" element={<AccountPlanPage />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/control/TasksManager.tsx
+++ b/src/components/control/TasksManager.tsx
@@ -9,6 +9,7 @@ import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { toast } from "@/hooks/use-toast";
 import { useRoadmapProgress } from "@/hooks/useRoadmapProgress";
 import { scheduleTaskTriggers } from "@/lib/triggers";
+import { requirePro } from "@/state/featureFlags";
 
 export type Task = {
   id: string;
@@ -22,6 +23,14 @@ export type Task = {
 
 export default function TasksManager({ roadmapId }: { roadmapId: string }) {
   const { user } = useSupabaseAuth();
+  if (!requirePro()) {
+    return (
+      <div className="p-4 text-center space-y-2">
+        <p className="text-sm text-muted-foreground">Task management is a Pro feature.</p>
+        <Button onClick={() => (window.location.href = '/plan')}>Upgrade</Button>
+      </div>
+    );
+  }
   const [tasks, setTasks] = useState<Task[]>([]);
   const [loading, setLoading] = useState(true);
 

--- a/src/modules/payments/components/PricingPage.tsx
+++ b/src/modules/payments/components/PricingPage.tsx
@@ -31,7 +31,7 @@ export function PricingPage() {
   return null;
 }
 
-const PRICING_TIERS: PricingTier[] = [
+export const PRICING_TIERS: PricingTier[] = [
   {
     id: 'freemium',
     name: 'Freemium',

--- a/src/modules/payments/components/SubscriptionManager.tsx
+++ b/src/modules/payments/components/SubscriptionManager.tsx
@@ -19,6 +19,7 @@ import {
 import { useSubscription } from '@/modules/payments/hooks/useSubscription'
 import { toast } from '@/hooks/use-toast'
 import { formatDistanceToNow } from 'date-fns';
+import { useFeatureFlags } from '@/state/featureFlags';
 
 export function SubscriptionManager() {
   return <SubscriptionManagerUI />;
@@ -28,6 +29,7 @@ function SubscriptionManagerUI() {
   const { subscription, usage, isLoading, isOnTrial, trialDaysLeft, cancelSubscription, refetch } = useSubscription();
   const [showCancelDialog, setShowCancelDialog] = useState(false);
   const [isCanceling, setIsCanceling] = useState(false);
+  const isPro = useFeatureFlags((s) => s.isPro);
 
   const handleCancelSubscription = async (cancelAtPeriodEnd: boolean) => {
     try {
@@ -201,7 +203,7 @@ function SubscriptionManagerUI() {
                 />
               </div>
 
-              {subscription.planId === 'pro' && (
+              {isPro && (
                 <div>
                   <div className="flex items-center justify-between mb-2">
                     <div className="flex items-center space-x-2">

--- a/src/modules/payments/hooks/useSubscription.ts
+++ b/src/modules/payments/hooks/useSubscription.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { Subscription, UsageStats } from '@/modules/payments/types/subscription'
 import { getSubscription, cancelSubscription, updateSubscription } from '@/modules/payments/api/subscription'
+import { useFeatureFlags } from '@/state/featureFlags'
 
 export function useSubscription() {
   const [subscription, setSubscription] = useState<Subscription | null>(null);
@@ -13,8 +14,10 @@ export function useSubscription() {
       setIsLoading(true);
       setError(null);
       const response = await getSubscription();
-      setSubscription((response as any).subscription);
+      const sub = (response as any).subscription as Subscription | null;
+      setSubscription(sub);
       setUsage((response as any).usage);
+      useFeatureFlags.setState({ isPro: !!sub && sub.planId !== 'freemium' });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch subscription');
     } finally {
@@ -29,7 +32,9 @@ export function useSubscription() {
   const cancelSub = useCallback(async (cancelAtPeriodEnd: boolean = true) => {
     try {
       const response = await cancelSubscription(cancelAtPeriodEnd);
-      setSubscription((response as any).subscription);
+      const sub = (response as any).subscription as Subscription | null;
+      setSubscription(sub);
+      useFeatureFlags.setState({ isPro: !!sub && sub.planId !== 'freemium' });
       return response;
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to cancel subscription');
@@ -40,7 +45,9 @@ export function useSubscription() {
   const updateSub = useCallback(async (priceId: string, billingCycle: 'monthly' | 'yearly') => {
     try {
       const response = await updateSubscription(priceId, billingCycle);
-      setSubscription((response as any).subscription);
+      const sub = (response as any).subscription as Subscription | null;
+      setSubscription(sub);
+      useFeatureFlags.setState({ isPro: !!sub && sub.planId !== 'freemium' });
       return response;
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to update subscription');

--- a/src/pages/AccountPlan.tsx
+++ b/src/pages/AccountPlan.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+import AppHeader from '@/components/layout/AppHeader';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { PRICING_TIERS } from '@/modules/payments/components/PricingPage';
+import BrainBackupPanel from '@/components/settings/BrainBackupPanel';
+import { memoryStore } from '@/memory/indexedDbMemory';
+import { toast } from '@/hooks/use-toast';
+
+export default function AccountPlan() {
+  const freeTier = PRICING_TIERS.find((t) => t.id === 'freemium');
+  const proTier = PRICING_TIERS.find((t) => t.id === 'pro');
+  const [clearing, setClearing] = useState(false);
+
+  const handleClear = async () => {
+    setClearing(true);
+    try {
+      memoryStore.importAll({ semantic: [], episodic: [], procedural: [] });
+      toast({ title: 'Brain cleared', description: 'All local memories removed.' });
+    } finally {
+      setClearing(false);
+    }
+  };
+
+  return (
+    <div className="relative min-h-svh">
+      <div className="os-bg" />
+      <AppHeader />
+      <main className="pt-24 pb-16 px-4 sm:px-6 max-w-5xl mx-auto space-y-8">
+        <section>
+          <h1 className="text-2xl font-semibold mb-4">Account Plan</h1>
+          <div className="grid gap-4 md:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <CardTitle>Free</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className="list-disc pl-5 space-y-1 text-sm">
+                  {freeTier?.features.map((f) => (
+                    <li key={f}>{f}</li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Pro</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className="list-disc pl-5 space-y-1 text-sm">
+                  {proTier?.features.map((f) => (
+                    <li key={f}>{f}</li>
+                  ))}
+                </ul>
+                {proTier && (
+                  <Button className="mt-4" onClick={() => (window.location.href = '/pricing')}>
+                    {`Upgrade – $${proTier.price.monthly}/mo`}
+                  </Button>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+        <section>
+          <h2 className="text-xl font-semibold mb-2">Privacy</h2>
+          <p className="text-sm text-muted-foreground mb-3">
+            Your brain lives on this device.
+          </p>
+          <div className="flex flex-col gap-4">
+            <Button variant="destructive" onClick={handleClear} disabled={clearing} className="w-fit">
+              {clearing ? 'Clearing…' : 'Clear'}
+            </Button>
+            <BrainBackupPanel />
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/state/featureFlags.ts
+++ b/src/state/featureFlags.ts
@@ -4,7 +4,9 @@ interface FlagsState {
   hypnosisScripts: boolean;
   cloudRouting: boolean;
   voiceStorage: boolean;
-  toggle: (key: keyof Omit<FlagsState, 'toggle'>) => void;
+  isPro: boolean;
+  toggle: (key: keyof Omit<FlagsState, 'toggle' | 'setPro'>) => void;
+  setPro: (value: boolean) => void;
 }
 
 const STORAGE_KEY = 'featureFlags';
@@ -16,6 +18,7 @@ export const useFeatureFlags = create<FlagsState>((set) => {
     : { hypnosisScripts: false, cloudRouting: false, voiceStorage: false };
   return {
     ...initial,
+    isPro: false,
     toggle: (key) =>
       set((state) => {
         const next = { ...state, [key]: !state[key] } as FlagsState;
@@ -28,5 +31,14 @@ export const useFeatureFlags = create<FlagsState>((set) => {
         } catch {}
         return next;
       }),
+    setPro: (value) => set({ isPro: value }),
   };
 });
+
+export function requirePro() {
+  const { isPro } = useFeatureFlags.getState();
+  if (!isPro) {
+    window.location.href = '/plan';
+  }
+  return isPro;
+}


### PR DESCRIPTION
## Summary
- add Account Plan route with Free vs. Pro feature comparison and privacy tools
- centralize Pro gating with feature flag and requirePro helper
- replace inline plan checks in subscription and tasks views

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689df98a0b0083269e7dda5af8c823fa