### PR TITLE
feat(ui): global app shell wrapper

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { useFeatureFlags } from "@/state/featureFlags";
 import NotFound from "./pages/NotFound";
 import AuthPage from "./pages/Auth";
 import MindWorldDashboard from "@/components/mindworld/MindWorldDashboard";
@@ -17,35 +18,71 @@ import { views } from "@/views/registry";
 import LiveShell from "@/routes/live/LiveShell";
 const queryClient = new QueryClient();
 
-const App = () => (
-  <QueryClientProvider client={queryClient}>
-    <TooltipProvider>
-      <Toaster />
-      <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Navigate to="/app" replace />} />
-          <Route path="/app" element={<AppShell />}>
-            <Route index element={<HomeView />} />
-            {views.filter((v) => v.id !== "home").map((v) => (
-              <Route key={v.id} path={v.path || undefined} element={<v.component />} />
-            ))}
-            <Route path="live" element={<LiveShell />} />
-            <Route path="*" element={<Navigate to="/app" replace />} />
-          </Route>
-          <Route path="/world" element={<MindWorldDashboard />} />
-          <Route path="/auth" element={<AuthPage />} />
-          <Route path="/browser" element={<Navigate to="/app/browser" replace />} />
-          <Route path="/hypno" element={<HypnoShell />} />
-          <Route path="/extension" element={<ExtensionPage />} />
-          <Route path="/stack" element={<StackPage />} />
-          <Route path="/plan" element={<AccountPlanPage />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
-    </TooltipProvider>
-  </QueryClientProvider>
-);
+function AppRoutesWithShell() {
+  return (
+    <Routes>
+      <Route element={<AppShell />}>
+        <Route path="/" element={<Navigate to="/app" replace />} />
+        <Route path="/app">
+          <Route index element={<HomeView />} />
+          {views.filter((v) => v.id !== "home").map((v) => (
+            <Route key={v.id} path={v.path || undefined} element={<v.component />} />
+          ))}
+          <Route path="live" element={<LiveShell />} />
+          <Route path="*" element={<Navigate to="/app" replace />} />
+        </Route>
+        <Route path="/world" element={<MindWorldDashboard />} />
+        <Route path="/auth" element={<AuthPage />} />
+        <Route path="/browser" element={<Navigate to="/app/browser" replace />} />
+        <Route path="/hypno" element={<HypnoShell />} />
+        <Route path="/extension" element={<ExtensionPage />} />
+        <Route path="/stack" element={<StackPage />} />
+        <Route path="/plan" element={<AccountPlanPage />} />
+        {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+        <Route path="*" element={<NotFound />} />
+      </Route>
+    </Routes>
+  );
+}
+
+function LegacyRoutes() {
+  return (
+    <Routes>
+      <Route path="/" element={<Navigate to="/app" replace />} />
+      <Route path="/app" element={<AppShell />}>
+        <Route index element={<HomeView />} />
+        {views.filter((v) => v.id !== "home").map((v) => (
+          <Route key={v.id} path={v.path || undefined} element={<v.component />} />
+        ))}
+        <Route path="live" element={<LiveShell />} />
+        <Route path="*" element={<Navigate to="/app" replace />} />
+      </Route>
+      <Route path="/world" element={<MindWorldDashboard />} />
+      <Route path="/auth" element={<AuthPage />} />
+      <Route path="/browser" element={<Navigate to="/app/browser" replace />} />
+      <Route path="/hypno" element={<HypnoShell />} />
+      <Route path="/extension" element={<ExtensionPage />} />
+      <Route path="/stack" element={<StackPage />} />
+      <Route path="/plan" element={<AccountPlanPage />} />
+      {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+      <Route path="*" element={<NotFound />} />
+    </Routes>
+  );
+}
+
+const App = () => {
+  const appShell = useFeatureFlags((s) => s.appShell);
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <Toaster />
+        <Sonner />
+        <BrowserRouter>
+          {appShell ? <AppRoutesWithShell /> : <LegacyRoutes />}
+        </BrowserRouter>
+      </TooltipProvider>
+    </QueryClientProvider>
+  );
+};
 
 export default App;

--- a/src/components/settings/FeatureFlagsPanel.tsx
+++ b/src/components/settings/FeatureFlagsPanel.tsx
@@ -3,7 +3,7 @@ import { Switch } from '@/components/ui/switch';
 import { useFeatureFlags } from '@/state/featureFlags';
 
 export default function FeatureFlagsPanel() {
-  const { hypnosisScripts, cloudRouting, voiceStorage, toggle } = useFeatureFlags();
+  const { hypnosisScripts, cloudRouting, voiceStorage, appShell, toggle } = useFeatureFlags();
   return (
     <div className="space-y-2">
       <h2 className="text-lg font-semibold">Feature Toggles</h2>
@@ -18,6 +18,10 @@ export default function FeatureFlagsPanel() {
       <div className="flex items-center justify-between max-w-sm">
         <Label htmlFor="flag-voice">Voice Storage</Label>
         <Switch id="flag-voice" checked={voiceStorage} onCheckedChange={() => toggle('voiceStorage')} />
+      </div>
+      <div className="flex items-center justify-between max-w-sm">
+        <Label htmlFor="flag-appshell">App Shell</Label>
+        <Switch id="flag-appshell" checked={appShell} onCheckedChange={() => toggle('appShell')} />
       </div>
     </div>
   );

--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useEffect, useMemo } from "react";
-import { Route, Routes, useLocation, Navigate } from "react-router-dom";
+import { useLocation, Navigate, Outlet } from "react-router-dom";
 import { AnimatePresence, motion } from "framer-motion";
 import { views, type ViewId } from "@/views/registry";
 import { GameHUD } from "@/components/game/GameHUD";
@@ -15,7 +15,7 @@ import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
 import useDailyCheckIn from "@/hooks/useDailyCheckIn";
 import useWeeklyBrainBackup from "@/hooks/useWeeklyBrainBackup";
 import { useKeyboardOffset } from "@/hooks/useKeyboardOffset";
-import HomeView from "@/views/HomeView";
+
 export default function AppShell() {
   const { user, initializing } = useSupabaseAuth();
   const loc = useLocation();
@@ -42,7 +42,6 @@ export default function AppShell() {
   }, [open]);
 
   useEffect(() => {
-
     const onMos = (e: Event) => {
       const t = (e as CustomEvent).detail?.type as string | undefined;
       if (t === 'openBrowser') {
@@ -100,7 +99,7 @@ export default function AppShell() {
     );
   }
 
-  if (!user) {
+  if (!user && loc.pathname !== '/auth') {
     return <Navigate to="/auth" replace />;
   }
 
@@ -109,37 +108,26 @@ export default function AppShell() {
       <div className={`relative min-h-svh room-${currentRoom}`} {...swipe}>
         <div className="os-bg" />
         <AnimatePresence mode="wait">
-          <Routes location={loc} key={loc.pathname + loc.search}>
-          <Route index element={<HomeView />} />
-          {views.filter((v) => v.id !== "home").map((v) => (
-            <Route
-              key={v.id}
-              path={v.path || undefined}
-              index={v.path === "" ? true : undefined}
-              element={
-                <motion.div
-                  initial={{ opacity: 0, y: 12 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, y: -8 }}
-                  transition={{ duration: 0.18 }}
-                  className="pb-[calc(var(--hud-h)+var(--dock-h)+var(--hud-gap)+var(--chatbar-h)+var(--kb-offset)+env(safe-area-inset-bottom))]"
-                >
-                  <Suspense fallback={<div className="p-6 opacity-70">Loading…</div>}>
-                    <v.component />
-                  </Suspense>
-                </motion.div>
-              }
-            />
-          ))}
-          <Route path="*" element={<Navigate to="/app" replace />} />
-        </Routes>
-      </AnimatePresence>
+          <motion.div
+            key={loc.pathname + loc.search}
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            transition={{ duration: 0.18 }}
+            className="pb-[calc(var(--hud-h)+var(--dock-h)+var(--hud-gap)+var(--chatbar-h)+var(--kb-offset)+env(safe-area-inset-bottom))]"
+          >
+            <Suspense fallback={<div className="p-6 opacity-70">Loading…</div>}>
+              <Outlet />
+            </Suspense>
+          </motion.div>
+        </AnimatePresence>
 
-      <GameHUD />
-      <BottomDock />
-      <AnchoredChatBar />
-      <TimerHudChip />
-    </div>
+        <GameHUD />
+        <BottomDock />
+        <AnchoredChatBar />
+        <TimerHudChip />
+      </div>
     </ChatProvider>
   );
 }
+

--- a/src/state/featureFlags.ts
+++ b/src/state/featureFlags.ts
@@ -4,6 +4,7 @@ interface FlagsState {
   hypnosisScripts: boolean;
   cloudRouting: boolean;
   voiceStorage: boolean;
+  appShell: boolean;
   isPro: boolean;
   toggle: (key: keyof Omit<FlagsState, 'toggle' | 'setPro'>) => void;
   setPro: (value: boolean) => void;
@@ -14,8 +15,8 @@ const STORAGE_KEY = 'featureFlags';
 export const useFeatureFlags = create<FlagsState>((set) => {
   const raw = typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null;
   const initial = raw
-    ? JSON.parse(raw)
-    : { hypnosisScripts: false, cloudRouting: false, voiceStorage: false };
+    ? { hypnosisScripts: false, cloudRouting: false, voiceStorage: false, appShell: true, ...JSON.parse(raw) }
+    : { hypnosisScripts: false, cloudRouting: false, voiceStorage: false, appShell: true };
   return {
     ...initial,
     isPro: false,
@@ -23,10 +24,10 @@ export const useFeatureFlags = create<FlagsState>((set) => {
       set((state) => {
         const next = { ...state, [key]: !state[key] } as FlagsState;
         try {
-          const { hypnosisScripts, cloudRouting, voiceStorage } = next;
+          const { hypnosisScripts, cloudRouting, voiceStorage, appShell } = next;
           localStorage.setItem(
             STORAGE_KEY,
-            JSON.stringify({ hypnosisScripts, cloudRouting, voiceStorage })
+            JSON.stringify({ hypnosisScripts, cloudRouting, voiceStorage, appShell })
           );
         } catch {}
         return next;


### PR DESCRIPTION
## Summary
- add `appShell` feature flag with UI toggle for safe rollout
- refactor `AppShell` into persistent layout wrapping all routes and chat
- route through `AppShell` globally when `appShell` flag is enabled

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, no-empty, prefer-const, no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_689e060e58ac83269a54be70f5612f7b