### PR TITLE
feat: enhance brain memory manager

### DIFF
--- a/src/components/settings/BrainBackupPanel.tsx
+++ b/src/components/settings/BrainBackupPanel.tsx
@@ -25,7 +25,7 @@ export default function BrainBackupPanel() {
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      a.download = 'brain.enc';
+      a.download = 'brain.aurora';
       a.click();
       URL.revokeObjectURL(url);
       toast({ title: 'Brain exported', description: 'Encrypted brain downloaded.' });
@@ -44,6 +44,7 @@ export default function BrainBackupPanel() {
     }
     const input = document.createElement('input');
     input.type = 'file';
+    input.accept = '.aurora';
     input.onchange = async () => {
       const file = input.files?.[0];
       if (!file) return;

--- a/src/memory/brainBackup.test.ts
+++ b/src/memory/brainBackup.test.ts
@@ -1,0 +1,24 @@
+import { exportEncryptedBrain, importEncryptedBrain } from './brainBackup';
+import { openBrainDb, closeBrainDb, __setMemoryDb } from './brainDb';
+
+describe('brain backup round trip', () => {
+  it('exports and restores memories', async () => {
+    __setMemoryDb(null);
+    const db = await openBrainDb();
+    db.run("CREATE TABLE IF NOT EXISTS memories (id INTEGER PRIMARY KEY AUTOINCREMENT, content TEXT)");
+    db.run("INSERT INTO memories (content) VALUES ('hello')");
+    await db.saveToDisk();
+    const blob = await exportEncryptedBrain('pass');
+    await closeBrainDb();
+    __setMemoryDb(null);
+    await importEncryptedBrain(blob, 'pass');
+    const db2 = await openBrainDb();
+    const stmt = db2.prepare("SELECT content FROM memories");
+    let content = '';
+    if (stmt.step()) {
+      content = String(stmt.getAsObject().content || '');
+    }
+    stmt.free();
+    expect(content).toBe('hello');
+  });
+});

--- a/src/memory/brainBackup.ts
+++ b/src/memory/brainBackup.ts
@@ -1,4 +1,5 @@
-import { openBrainDb } from './brainDb';
+import { openBrainDb, __setMemoryDb } from './brainDb';
+import { toast } from '@/hooks/use-toast';
 
 const DB_FILE = 'brain.db';
 
@@ -28,33 +29,47 @@ export async function exportEncryptedBrain(passphrase: string): Promise<Blob> {
   out.set(salt, 0);
   out.set(iv, salt.length);
   out.set(encrypted, salt.length + iv.length);
-  return new Blob([out], { type: 'application/octet-stream' });
+  return new Blob([out], { type: 'application/x-aurora' });
 }
 
 async function writeBrain(bytes: Uint8Array) {
   const hasOpfs =
     typeof navigator !== 'undefined' && !!(navigator as any).storage?.getDirectory;
   if (hasOpfs) {
-    const root = await (navigator as any).storage.getDirectory();
-    const handle = await root.getFileHandle(DB_FILE, { create: true });
-    const writable = await handle.createWritable();
-    await writable.write(bytes);
-    await writable.close();
-    return;
+    try {
+      const root = await (navigator as any).storage.getDirectory();
+      const handle = await root.getFileHandle(DB_FILE, { create: true });
+      const writable = await handle.createWritable();
+      await writable.write(bytes);
+      await writable.close();
+      return;
+    } catch {
+      toast({ title: 'Storage error', description: 'OPFS write failed' });
+    }
   }
-  const dbReq = indexedDB.open('brain-db', 1);
-  await new Promise<void>((resolve, reject) => {
-    dbReq.onupgradeneeded = () => dbReq.result.createObjectStore('files');
-    dbReq.onsuccess = () => resolve();
-    dbReq.onerror = () => reject(dbReq.error);
-  });
-  const db = dbReq.result;
-  await new Promise<void>((resolve, reject) => {
-    const tx = db.transaction('files', 'readwrite');
-    const req = tx.objectStore('files').put(bytes, DB_FILE);
-    req.onsuccess = () => resolve();
-    req.onerror = () => reject(req.error);
-  });
+  if (typeof indexedDB !== 'undefined') {
+    try {
+      const dbReq = indexedDB.open('brain-db', 1);
+      await new Promise<void>((resolve, reject) => {
+        dbReq.onupgradeneeded = () => dbReq.result.createObjectStore('files');
+        dbReq.onsuccess = () => resolve();
+        dbReq.onerror = () => reject(dbReq.error);
+      });
+      const db = dbReq.result;
+      await new Promise<void>((resolve, reject) => {
+        const tx = db.transaction('files', 'readwrite');
+        const req = tx.objectStore('files').put(bytes, DB_FILE);
+        req.onsuccess = () => resolve();
+        req.onerror = () => reject(req.error);
+      });
+      return;
+    } catch {
+      toast({ title: 'Storage error', description: 'IndexedDB write failed' });
+    }
+  } else {
+    toast({ title: 'Storage unavailable', description: 'IndexedDB not supported' });
+  }
+  __setMemoryDb(bytes);
 }
 
 export async function importEncryptedBrain(blob: Blob, passphrase: string) {

--- a/src/memory/brainDb.ts
+++ b/src/memory/brainDb.ts
@@ -1,4 +1,5 @@
 import initSqlJs, { Database } from "sql.js";
+import { toast } from "@/hooks/use-toast";
 
 const DB_FILE = "brain.db";
 const IDB_NAME = "brain-db";
@@ -11,6 +12,15 @@ export interface BrainDatabase extends Database {
 }
 
 let cachedDb: BrainDatabase | null = null;
+let memoryDb: Uint8Array | null = null; // fallback when storage unavailable
+
+export function __setMemoryDb(bytes: Uint8Array | null) {
+  memoryDb = bytes;
+}
+
+export function __getMemoryDb() {
+  return memoryDb;
+}
 
 function getEncryptionSettings() {
   if (typeof localStorage === "undefined") {
@@ -74,6 +84,9 @@ async function decryptData(data: Uint8Array, passphrase: string) {
 }
 
 async function openIndexedDb(): Promise<IDBDatabase> {
+  if (typeof indexedDB === "undefined") {
+    throw new Error("IndexedDB not supported");
+  }
   return new Promise((resolve, reject) => {
     const request = indexedDB.open(IDB_NAME, 1);
     request.onupgradeneeded = () => {
@@ -85,34 +98,68 @@ async function openIndexedDb(): Promise<IDBDatabase> {
 }
 
 async function idbGet(key: string): Promise<Uint8Array | null> {
-  const db = await openIndexedDb();
-  return new Promise((resolve, reject) => {
-    const tx = db.transaction(IDB_STORE, "readonly");
-    const req = tx.objectStore(IDB_STORE).get(key);
-    req.onsuccess = () => {
-      const result = req.result as ArrayBuffer | undefined;
-      resolve(result ? new Uint8Array(result) : null);
-    };
-    req.onerror = () => reject(req.error);
-  });
+  if (typeof indexedDB === "undefined") {
+    toast({
+      title: "Storage unavailable",
+      description: "IndexedDB not supported; using memory store",
+    });
+    return key === DB_FILE ? memoryDb : null;
+  }
+  try {
+    const db = await openIndexedDb();
+    return await new Promise((resolve, reject) => {
+      const tx = db.transaction(IDB_STORE, "readonly");
+      const req = tx.objectStore(IDB_STORE).get(key);
+      req.onsuccess = () => {
+        const result = req.result as ArrayBuffer | undefined;
+        resolve(result ? new Uint8Array(result) : null);
+      };
+      req.onerror = () => reject(req.error);
+    });
+  } catch (e) {
+    toast({ title: "Storage error", description: "Failed to read from IndexedDB" });
+    return key === DB_FILE ? memoryDb : null;
+  }
 }
 
 async function idbSet(key: string, value: Uint8Array): Promise<void> {
-  const db = await openIndexedDb();
-  return new Promise((resolve, reject) => {
-    const tx = db.transaction(IDB_STORE, "readwrite");
-    const req = tx.objectStore(IDB_STORE).put(value, key);
-    req.onsuccess = () => resolve();
-    req.onerror = () => reject(req.error);
-  });
+  if (typeof indexedDB === "undefined") {
+    toast({
+      title: "Storage unavailable",
+      description: "IndexedDB not supported; using memory store",
+    });
+    if (key === DB_FILE) memoryDb = value;
+    return;
+  }
+  try {
+    const db = await openIndexedDb();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(IDB_STORE, "readwrite");
+      const req = tx.objectStore(IDB_STORE).put(value, key);
+      req.onsuccess = () => resolve();
+      req.onerror = () => reject(req.error);
+    });
+  } catch (e) {
+    toast({ title: "Storage error", description: "Failed to write to IndexedDB" });
+    if (key === DB_FILE) memoryDb = value;
+  }
 }
 
 export async function openBrainDb(): Promise<BrainDatabase> {
   if (cachedDb) return cachedDb;
   try {
+    const importMetaUrl = (() => {
+      try {
+        return eval('import.meta.url') as string;
+      } catch {
+        return undefined;
+      }
+    })();
     const SQL = await initSqlJs({
       locateFile: (file: string) =>
-        new URL(`../../node_modules/sql.js/dist/${file}`, import.meta.url).toString(),
+        importMetaUrl
+          ? new URL(`../../node_modules/sql.js/dist/${file}`, importMetaUrl).toString()
+          : `node_modules/sql.js/dist/${file}`,
     });
 
     let opfsHandle: FileSystemFileHandle | null = null;
@@ -143,6 +190,7 @@ export async function openBrainDb(): Promise<BrainDatabase> {
           ? (new SQL.Database(buffer) as BrainDatabase)
           : (new SQL.Database() as BrainDatabase);
       } catch {
+        toast({ title: "Storage error", description: "Failed to read OPFS" });
         db = new SQL.Database() as BrainDatabase;
       }
     } else {
@@ -170,6 +218,7 @@ export async function openBrainDb(): Promise<BrainDatabase> {
           await writable.write(data);
           await writable.close();
         } catch {
+          toast({ title: "Storage error", description: "OPFS write failed" });
           // fall back to IndexedDB if OPFS write fails
           await idbSet(DB_FILE, data);
         }
@@ -187,6 +236,7 @@ export async function openBrainDb(): Promise<BrainDatabase> {
             await writable.write(data);
             await writable.close();
           } catch {
+            toast({ title: "Storage error", description: "OPFS sync failed" });
             // ignore sync errors
           }
         }
@@ -197,6 +247,7 @@ export async function openBrainDb(): Promise<BrainDatabase> {
     return db;
   } catch (e) {
     console.error("Failed to open brain database", e);
+    toast({ title: "Database error", description: "Could not open brain" });
     throw e;
   }
 }

--- a/src/views/BrainView.tsx
+++ b/src/views/BrainView.tsx
@@ -35,6 +35,8 @@ export default function BrainView() {
   const [query, setQuery] = useState('');
   const [typeFilter, setTypeFilter] = useState<string>('all');
   const [tagFilter, setTagFilter] = useState<string>('all');
+  const [recencyFilter, setRecencyFilter] = useState<string>('all');
+  const [importanceFilter, setImportanceFilter] = useState<string>('all');
   const [editing, setEditing] = useState<Memory | null>(null);
   const [editContent, setEditContent] = useState('');
   const [editTags, setEditTags] = useState('');
@@ -76,23 +78,35 @@ export default function BrainView() {
 
   const filtered = useMemo(() => {
     const q = query.toLowerCase();
+    const now = Date.now() / 1000;
     return memories
-      .filter((m) =>
-        m.content.toLowerCase().includes(q)
-      )
-      .filter((m) =>
-        typeFilter === 'all' ? true : m.type === typeFilter
-      )
+      .filter((m) => m.content.toLowerCase().includes(q))
+      .filter((m) => (typeFilter === 'all' ? true : m.type === typeFilter))
       .filter((m) =>
         tagFilter === 'all'
           ? true
           : m.tags.split(',').map((t) => t.trim()).includes(tagFilter)
       )
+      .filter((m) =>
+        importanceFilter === 'all'
+          ? true
+          : m.importance >= Number(importanceFilter)
+      )
+      .filter((m) => {
+        if (recencyFilter === 'all') return true;
+        const map: Record<string, number> = {
+          '24h': 86400,
+          '7d': 604800,
+          '30d': 2592000,
+        };
+        const limit = map[recencyFilter];
+        return m.ts >= now - limit;
+      })
       .map((m) => ({
         ...m,
         why: q ? `Matches "${query}"` : undefined,
       }));
-  }, [memories, query, typeFilter, tagFilter]);
+  }, [memories, query, typeFilter, tagFilter, recencyFilter, importanceFilter]);
 
   useEffect(() => {
     if (import.meta.env.DEV) {
@@ -169,7 +183,7 @@ export default function BrainView() {
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = 'brain-backup.bin';
+    a.download = 'brain.aurora';
     a.click();
     URL.revokeObjectURL(url);
   };
@@ -213,6 +227,30 @@ export default function BrainView() {
             {uniqueTags.map((t) => (
               <SelectItem key={t} value={t}>
                 {t}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={recencyFilter} onValueChange={setRecencyFilter}>
+          <SelectTrigger className="w-[160px]">
+            <SelectValue placeholder="Recency" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All time</SelectItem>
+            <SelectItem value="24h">Last 24h</SelectItem>
+            <SelectItem value="7d">Last 7d</SelectItem>
+            <SelectItem value="30d">Last 30d</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select value={importanceFilter} onValueChange={setImportanceFilter}>
+          <SelectTrigger className="w-[160px]">
+            <SelectValue placeholder="Importance" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All importance</SelectItem>
+            {[1, 2, 3, 4, 5].map((n) => (
+              <SelectItem key={n} value={String(n)}>
+                {`>= ${n}`}
               </SelectItem>
             ))}
           </SelectContent>
@@ -279,6 +317,7 @@ export default function BrainView() {
           <input
             ref={fileInputRef}
             type="file"
+            accept=".aurora"
             className="hidden"
             onChange={(e) => {
               const f = e.target.files?.[0];


### PR DESCRIPTION
## Summary
- add recency and importance filters to the Brain view
- export and import encrypted `.aurora` brain backups
- surface storage errors via toasts and provide fallback when OPFS/IndexedDB fail
- verify encrypted backup round-trip restores memories

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e09b8c4748326bb7db4478b03c537