### PR TITLE
feat: inline mission editing

### DIFF
--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -9,6 +9,7 @@ export type GameState = {
   stats: Stats;
   mood: "Calm" | "Focused" | "Confident" | "Stressed" | "Tired";
   quests: Record<string, boolean>;
+  mission: { title: string; description: string };
   setPos: (x: number, y: number) => void;
   setMood: (m: GameState["mood"]) => void;
   awardXP: (amount: number) => void;
@@ -16,6 +17,8 @@ export type GameState = {
   incStreak: () => void;
   resetDaily: () => void;
   setStats: (s: Partial<Stats>) => void;
+  setMissionTitle: (title: string) => void;
+  setMissionDescription: (description: string) => void;
   fetchStats: () => Promise<void>;
 };
 
@@ -24,6 +27,7 @@ const defaults: GameState = {
   stats: { hp: 78, mp: 62, xp: 35, level: 7, streak: 1 },
   mood: "Focused",
   quests: {},
+  mission: { title: "", description: "" },
   setPos() {},
   setMood() {},
   awardXP() {},
@@ -31,6 +35,8 @@ const defaults: GameState = {
   incStreak() {},
   resetDaily() {},
   setStats() {},
+  setMissionTitle() {},
+  setMissionDescription() {},
   fetchStats: async () => {},
 };
 
@@ -114,6 +120,14 @@ export const useGameStore = create<GameState>((set, get) => {
     setStats: (s) => {
       const cur = get().stats;
       persist({ stats: { ...cur, ...s } });
+    },
+    setMissionTitle: (title) => {
+      const m = get().mission;
+      persist({ mission: { ...m, title } });
+    },
+    setMissionDescription: (description) => {
+      const m = get().mission;
+      persist({ mission: { ...m, description } });
     },
   };
 });

--- a/src/views/HomeView.tsx
+++ b/src/views/HomeView.tsx
@@ -1,12 +1,5 @@
 import React, { useState } from "react";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -40,11 +33,9 @@ function ProgressRing({ value }: { value: number }) {
 export default function HomeView() {
   const { run } = useHUDActions();
   const progress = useGameStore((s) => s.stats.xp);
-
-  const [mission, setMission] = useState({
-    title: "Ship Aurora MVP",
-    description: "Finish core features and polish",
-  });
+  const mission = useGameStore((s) => s.mission);
+  const setMissionTitle = useGameStore((s) => s.setMissionTitle);
+  const setMissionDescription = useGameStore((s) => s.setMissionDescription);
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(mission);
 
@@ -62,7 +53,8 @@ export default function HomeView() {
   ];
 
   const handleSave = () => {
-    setMission(draft);
+    setMissionTitle(draft.title);
+    setMissionDescription(draft.description);
     setEditing(false);
   };
 
@@ -71,22 +63,54 @@ export default function HomeView() {
       <div className="min-h-svh bg-slate-950 text-foreground px-4 py-6 space-y-6">
         {/* Mission card */}
         <div className="glass-panel rounded-xl p-6 flex items-start justify-between gap-4">
-          <div>
-            <h2 className="text-lg font-semibold mb-1">{mission.title}</h2>
-            <p className="text-sm opacity-80 leading-relaxed">{mission.description}</p>
+          <div className="flex-1">
+            {editing ? (
+              <>
+                <Input
+                  value={draft.title}
+                  onChange={(e) => setDraft({ ...draft, title: e.target.value })}
+                  onBlur={() => setMissionTitle(draft.title)}
+                  placeholder="Mission title"
+                  className="mb-2"
+                />
+                <Textarea
+                  value={draft.description}
+                  onChange={(e) => setDraft({ ...draft, description: e.target.value })}
+                  onBlur={() => setMissionDescription(draft.description)}
+                  placeholder="Mission description"
+                  rows={3}
+                />
+              </>
+            ) : (
+              <>
+                <h2 className="text-lg font-semibold mb-1">{mission.title}</h2>
+                <p className="text-sm opacity-80 leading-relaxed">{mission.description}</p>
+              </>
+            )}
           </div>
-          <Button
-            size="sm"
-            variant="secondary"
-            className="shrink-0"
-            aria-label="Edit mission"
-            onClick={() => {
-              setDraft(mission);
-              setEditing(true);
-            }}
-          >
-            <Pencil className="w-4 h-4" />
-          </Button>
+          {editing ? (
+            <Button
+              size="sm"
+              variant="secondary"
+              className="shrink-0"
+              onClick={handleSave}
+            >
+              Save
+            </Button>
+          ) : (
+            <Button
+              size="sm"
+              variant="secondary"
+              className="shrink-0"
+              aria-label="Edit mission"
+              onClick={() => {
+                setDraft(mission);
+                setEditing(true);
+              }}
+            >
+              <Pencil className="w-4 h-4" />
+            </Button>
+          )}
         </div>
 
         {/* Today bar */}
@@ -127,32 +151,6 @@ export default function HomeView() {
         </div>
       </div>
 
-      <Dialog open={editing} onOpenChange={setEditing}>
-        <DialogContent className="max-w-md">
-          <DialogHeader>
-            <DialogTitle>Edit Mission</DialogTitle>
-          </DialogHeader>
-          <div className="space-y-4">
-            <Input
-              value={draft.title}
-              onChange={(e) => setDraft({ ...draft, title: e.target.value })}
-              placeholder="Mission title"
-            />
-            <Textarea
-              value={draft.description}
-              onChange={(e) => setDraft({ ...draft, description: e.target.value })}
-              placeholder="Mission description"
-              rows={3}
-            />
-          </div>
-          <DialogFooter>
-            <Button variant="secondary" onClick={() => setEditing(false)}>
-              Cancel
-            </Button>
-            <Button onClick={handleSave}>Save</Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add mission title/description state and setter functions to game store
- edit mission inline in HomeView with inputs tied to store

## Testing
- `npm test`
- `npm run lint` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e0dce2d94832685c5be76370e40ca