### PR TITLE
feat: show avatar sphere on home

### DIFF
--- a/src/views/HomeView.tsx
+++ b/src/views/HomeView.tsx
@@ -17,6 +17,7 @@ import {
   Pencil,
   type LucideIcon,
 } from "lucide-react";
+import { AvatarSphere } from "@/components/avatar/AvatarSphere";
 import { useGameStore } from "@/game/store";
 import { useHUDActions } from "@/game/hud/useHUDActions";
 import type { QuickActionKey } from "@/game/hud/hud.data";
@@ -69,6 +70,9 @@ export default function HomeView() {
   return (
     <>
       <div className="min-h-svh bg-slate-950 text-foreground px-4 py-6 space-y-6">
+        <div className="flex justify-center">
+          <AvatarSphere />
+        </div>
         {/* Mission card */}
         <div className="glass-panel rounded-xl p-6 flex items-start justify-between gap-4">
           <div>


### PR DESCRIPTION
## Summary
- render AvatarSphere at the top of HomeView so avatar reacts to voice events
- import AvatarSphere component

## Testing
- `npm test`
- `npm run lint` *(fails: 199 errors, 22 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689e0dd4c6d08326928cb4837fd74f13