### PR TITLE
feat: make quick pods responsive

### DIFF
--- a/src/views/HomeView.tsx
+++ b/src/views/HomeView.tsx
@@ -100,12 +100,12 @@ export default function HomeView() {
         </div>
 
         {/* Quick pods */}
-        <div className="flex gap-4">
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
           {pods.map((p) => (
             <button
               key={p.action}
               onClick={() => run(p.action)}
-              className="flex-1 glass-panel rounded-xl p-4 flex flex-col items-center gap-2 hover-scale"
+              className="glass-panel rounded-xl p-4 flex flex-col items-center gap-2 hover-scale"
             >
               <p.icon className="w-6 h-6" />
               <span className="text-sm font-medium">{p.label}</span>


### PR DESCRIPTION
## Summary
- use responsive grid layout so quick pods wrap on small screens

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any / other lint errors in unrelated files)*
- `node viewport-check.cjs` *(fails: Playwright missing system dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689e0dee96608326a3363d8511268419