### PR TITLE
Add quick-action modals and state hook

### DIFF
--- a/src/components/overlays/AnalyticsModal.tsx
+++ b/src/components/overlays/AnalyticsModal.tsx
@@ -1,0 +1,25 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { useQuickActionModals } from "@/state/quickActions";
+import { useProgressStore } from "@/state/progress";
+
+export default function AnalyticsModal() {
+  const { analyticsOpen, setAnalyticsOpen } = useQuickActionModals();
+  const { xp, level, streak, notes } = useProgressStore();
+
+  return (
+    <Dialog open={analyticsOpen} onOpenChange={setAnalyticsOpen}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Analytics</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-2 text-sm">
+          <div>XP: {xp}</div>
+          <div>Level: {level}</div>
+          <div>Streak: {streak}</div>
+          <div>Notes recorded: {notes.length}</div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/src/components/overlays/GoalsModal.tsx
+++ b/src/components/overlays/GoalsModal.tsx
@@ -1,0 +1,23 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import GoalsList from "@/components/goals/GoalsList";
+import GoalForm from "@/components/goals/GoalForm";
+import { useQuickActionModals } from "@/state/quickActions";
+
+export default function GoalsModal() {
+  const { goalsOpen, setGoalsOpen } = useQuickActionModals();
+
+  return (
+    <Dialog open={goalsOpen} onOpenChange={setGoalsOpen}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Goals</DialogTitle>
+        </DialogHeader>
+        <div className="grid gap-4">
+          <GoalForm />
+          <GoalsList />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/src/components/overlays/SettingsModal.tsx
+++ b/src/components/overlays/SettingsModal.tsx
@@ -1,0 +1,17 @@
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { useQuickActionModals } from "@/state/quickActions";
+// @ts-ignore
+import SettingsPanel from "../../../frontend/components/SettingsPanel.jsx";
+
+export default function SettingsModal() {
+  const { settingsOpen, setSettingsOpen } = useQuickActionModals();
+
+  return (
+    <Dialog open={settingsOpen} onOpenChange={setSettingsOpen}>
+      <DialogContent className="p-0 sm:max-w-lg">
+        <SettingsPanel open={settingsOpen} onClose={() => setSettingsOpen(false)} />
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/src/components/overlays/TasksModal.tsx
+++ b/src/components/overlays/TasksModal.tsx
@@ -1,0 +1,23 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import TasksManager from "@/components/control/TasksManager";
+import { useQuickActionModals } from "@/state/quickActions";
+
+export default function TasksModal() {
+  const { tasksOpen, setTasksOpen, tasksRoadmapId } = useQuickActionModals();
+
+  return (
+    <Dialog open={tasksOpen} onOpenChange={setTasksOpen}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Tasks</DialogTitle>
+        </DialogHeader>
+        {tasksRoadmapId ? (
+          <TasksManager roadmapId={tasksRoadmapId} />
+        ) : (
+          <div className="text-sm text-muted-foreground">No roadmap selected.</div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/src/state/quickActions.ts
+++ b/src/state/quickActions.ts
@@ -1,0 +1,34 @@
+import { create } from "zustand";
+
+interface QuickActionModalsState {
+  tasksOpen: boolean;
+  goalsOpen: boolean;
+  analyticsOpen: boolean;
+  settingsOpen: boolean;
+  tasksRoadmapId: string | null;
+  setTasksOpen: (open: boolean) => void;
+  openTasks: (roadmapId?: string) => void;
+  setGoalsOpen: (open: boolean) => void;
+  openGoals: () => void;
+  setAnalyticsOpen: (open: boolean) => void;
+  openAnalytics: () => void;
+  setSettingsOpen: (open: boolean) => void;
+  openSettings: () => void;
+}
+
+export const useQuickActionModals = create<QuickActionModalsState>((set) => ({
+  tasksOpen: false,
+  goalsOpen: false,
+  analyticsOpen: false,
+  settingsOpen: false,
+  tasksRoadmapId: null,
+  setTasksOpen: (open) => set({ tasksOpen: open }),
+  openTasks: (roadmapId) => set({ tasksOpen: true, tasksRoadmapId: roadmapId ?? null }),
+  setGoalsOpen: (open) => set({ goalsOpen: open }),
+  openGoals: () => set({ goalsOpen: true }),
+  setAnalyticsOpen: (open) => set({ analyticsOpen: open }),
+  openAnalytics: () => set({ analyticsOpen: true }),
+  setSettingsOpen: (open) => set({ settingsOpen: open }),
+  openSettings: () => set({ settingsOpen: true }),
+}));
+


### PR DESCRIPTION
## Summary
- add zustand hook to manage quick-action modals
- introduce Tasks, Goals, Analytics, and Settings modals using shared Dialog
- expose hook to open these modals from quick-action bar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e149794c8832687e6c380a812f2f7