### PR TITLE
Focus chat input after closing modals

### DIFF
--- a/src/components/chat/AnchoredChatBar.tsx
+++ b/src/components/chat/AnchoredChatBar.tsx
@@ -5,6 +5,7 @@ import { Mic, Send, Volume2 } from "lucide-react";
 import { useChat } from "@/state/chat";
 import { useTextToSpeech } from "@/voice/useTextToSpeech";
 import { EvolvingSphere } from "@/components/effects/EvolvingSphere";
+import { setChatInputRef } from "@/hooks/useChatInputFocus";
 
 export function AnchoredChatBar() {
   const { send, sending, messages, recall } = useChat();
@@ -17,7 +18,10 @@ export function AnchoredChatBar() {
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
-    inputRef.current?.focus();
+    const ref = inputRef.current;
+    setChatInputRef(ref);
+    ref?.focus();
+    return () => setChatInputRef(null);
   }, []);
 
   useEffect(() => {

--- a/src/components/control/RoadmapsManager.tsx
+++ b/src/components/control/RoadmapsManager.tsx
@@ -13,6 +13,7 @@ import { ProgressBar } from "@/components/live/ProgressBar";
 import { useRoadmapProgress } from "@/hooks/useRoadmapProgress";
 import QuickAddTaskFAB from "@/components/tasks/QuickAddTaskFAB";
 import { setActiveRoadmap, fetchNextTask } from "@/modules/roadmaps";
+import { useChatInputFocus } from "@/hooks/useChatInputFocus";
  
 export default function RoadmapsManager() {
   const { user } = useSupabaseAuth();
@@ -21,6 +22,7 @@ export default function RoadmapsManager() {
   const [showAll, setShowAll] = useState(false);
   const [newOpen, setNewOpen] = useState(false);
   const isMobile = useIsMobile();
+  const focusChatInput = useChatInputFocus();
 
   const fetchRoadmaps = async () => {
     if (!user) { setItems([]); return; }
@@ -95,7 +97,13 @@ export default function RoadmapsManager() {
   if (items.length === 0) {
     const Creator = (
       isMobile ? (
-        <Drawer open={newOpen} onOpenChange={setNewOpen}>
+        <Drawer
+          open={newOpen}
+          onOpenChange={(o) => {
+            setNewOpen(o);
+            if (!o) focusChatInput();
+          }}
+        >
           <DrawerTrigger asChild>
             <Button>New Roadmap</Button>
           </DrawerTrigger>
@@ -109,11 +117,24 @@ export default function RoadmapsManager() {
           </DrawerContent>
         </Drawer>
       ) : (
-        <Dialog open={newOpen} onOpenChange={setNewOpen}>
+        <Dialog
+          open={newOpen}
+          onOpenChange={(o) => {
+            setNewOpen(o);
+            if (!o) focusChatInput();
+          }}
+        >
           <DialogTrigger asChild>
             <Button>New Roadmap</Button>
           </DialogTrigger>
-          <DialogContent className="sm:max-w-md">
+          <DialogContent
+            className="sm:max-w-md"
+            onEscapeKeyDown={(e) => {
+              e.preventDefault();
+              setNewOpen(false);
+              focusChatInput();
+            }}
+          >
             <DialogHeader>
               <DialogTitle>Create roadmap</DialogTitle>
             </DialogHeader>
@@ -135,7 +156,13 @@ export default function RoadmapsManager() {
 
   const CreatorControl = (
     isMobile ? (
-      <Drawer open={newOpen} onOpenChange={setNewOpen}>
+      <Drawer
+        open={newOpen}
+        onOpenChange={(o) => {
+          setNewOpen(o);
+          if (!o) focusChatInput();
+        }}
+      >
         <DrawerTrigger asChild>
           <Button size="sm">New</Button>
         </DrawerTrigger>
@@ -149,11 +176,24 @@ export default function RoadmapsManager() {
         </DrawerContent>
       </Drawer>
     ) : (
-      <Dialog open={newOpen} onOpenChange={setNewOpen}>
+      <Dialog
+        open={newOpen}
+        onOpenChange={(o) => {
+          setNewOpen(o);
+          if (!o) focusChatInput();
+        }}
+      >
         <DialogTrigger asChild>
           <Button size="sm">New</Button>
         </DialogTrigger>
-        <DialogContent className="sm:max-w-md">
+        <DialogContent
+          className="sm:max-w-md"
+          onEscapeKeyDown={(e) => {
+            e.preventDefault();
+            setNewOpen(false);
+            focusChatInput();
+          }}
+        >
           <DialogHeader>
             <DialogTitle>Create roadmap</DialogTitle>
           </DialogHeader>

--- a/src/components/live/QuickActionsBar.tsx
+++ b/src/components/live/QuickActionsBar.tsx
@@ -8,6 +8,7 @@ import { toast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
 import { awardXPRemote } from "@/integrations/supabase/gameSync";
 import { useEffect, useRef, useState } from "react";
+import { useChatInputFocus } from "@/hooks/useChatInputFocus";
 
 type Task = {
   id: string;
@@ -21,9 +22,10 @@ type Track = {
   description: string | null;
 };
 
-  export function QuickActionsBar({ currentTask }: { currentTask: Task | null }) {
+export function QuickActionsBar({ currentTask }: { currentTask: Task | null }) {
   const [tracks, setTracks] = useState<Track[]>([]);
   const [tracksLoading, setTracksLoading] = useState(false);
+  const focusChatInput = useChatInputFocus();
   useEffect(() => {
     let mounted = true;
     (async () => {
@@ -174,8 +176,21 @@ type Track = {
       <Button size="sm" onClick={() => setPreOpen(true)}>Start Hypnosis</Button>
 
       {/* Pre-roll dialog */}
-      <Dialog open={preOpen} onOpenChange={setPreOpen}>
-        <DialogContent className="sm:max-w-md">
+      <Dialog
+        open={preOpen}
+        onOpenChange={(v) => {
+          setPreOpen(v);
+          if (!v) focusChatInput();
+        }}
+      >
+        <DialogContent
+          className="sm:max-w-md"
+          onEscapeKeyDown={(e) => {
+            e.preventDefault();
+            setPreOpen(false);
+            focusChatInput();
+          }}
+        >
           <DialogHeader>
             <DialogTitle>Get ready</DialogTitle>
           </DialogHeader>
@@ -195,8 +210,21 @@ type Track = {
       </Dialog>
 
       {/* Library dialog */}
-      <Dialog open={libraryOpen} onOpenChange={setLibraryOpen}>
-        <DialogContent className="sm:max-w-md">
+      <Dialog
+        open={libraryOpen}
+        onOpenChange={(v) => {
+          setLibraryOpen(v);
+          if (!v) focusChatInput();
+        }}
+      >
+        <DialogContent
+          className="sm:max-w-md"
+          onEscapeKeyDown={(e) => {
+            e.preventDefault();
+            setLibraryOpen(false);
+            focusChatInput();
+          }}
+        >
           <DialogHeader>
             <DialogTitle>Hypnosis library</DialogTitle>
           </DialogHeader>
@@ -223,11 +251,24 @@ type Track = {
       </Dialog>
 
       {/* Voice Note */}
-      <Dialog open={voiceOpen} onOpenChange={setVoiceOpen}>
+      <Dialog
+        open={voiceOpen}
+        onOpenChange={(v) => {
+          setVoiceOpen(v);
+          if (!v) focusChatInput();
+        }}
+      >
         <DialogTrigger asChild>
           <Button size="sm" variant="ghost">Voice Note</Button>
         </DialogTrigger>
-        <DialogContent className="sm:max-w-md">
+        <DialogContent
+          className="sm:max-w-md"
+          onEscapeKeyDown={(e) => {
+            e.preventDefault();
+            setVoiceOpen(false);
+            focusChatInput();
+          }}
+        >
           <DialogHeader>
             <DialogTitle>Record voice note</DialogTitle>
           </DialogHeader>
@@ -248,11 +289,24 @@ type Track = {
       </Dialog>
 
       {/* Notes */}
-      <Dialog open={noteOpen} onOpenChange={setNoteOpen}>
+      <Dialog
+        open={noteOpen}
+        onOpenChange={(v) => {
+          setNoteOpen(v);
+          if (!v) focusChatInput();
+        }}
+      >
         <DialogTrigger asChild>
           <Button size="sm" variant="ghost">Notes</Button>
         </DialogTrigger>
-        <DialogContent className="sm:max-w-md">
+        <DialogContent
+          className="sm:max-w-md"
+          onEscapeKeyDown={(e) => {
+            e.preventDefault();
+            setNoteOpen(false);
+            focusChatInput();
+          }}
+        >
           <DialogHeader>
             <DialogTitle>Quick note</DialogTitle>
           </DialogHeader>

--- a/src/components/settings/MemoryPanel.tsx
+++ b/src/components/settings/MemoryPanel.tsx
@@ -14,8 +14,10 @@ import {
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { useChatInputFocus } from "@/hooks/useChatInputFocus";
 
 export default function MemoryPanel() {
+  const focusChatInput = useChatInputFocus();
   const [bucket, setBucket] = useState<MemoryBucket>("semantic");
   const [search, setSearch] = useState("");
   const [memories, setMemories] = useState<MemoryEntry[]>([]);
@@ -174,8 +176,22 @@ export default function MemoryPanel() {
         </TableBody>
       </Table>
 
-      <Dialog open={!!editing} onOpenChange={() => setEditing(null)}>
-        <DialogContent>
+      <Dialog
+        open={!!editing}
+        onOpenChange={(open) => {
+          if (!open) {
+            setEditing(null);
+            focusChatInput();
+          }
+        }}
+      >
+        <DialogContent
+          onEscapeKeyDown={(e) => {
+            e.preventDefault();
+            setEditing(null);
+            focusChatInput();
+          }}
+        >
           <DialogHeader>
             <DialogTitle>Edit Memory</DialogTitle>
           </DialogHeader>

--- a/src/components/share/ShareCard.tsx
+++ b/src/components/share/ShareCard.tsx
@@ -6,6 +6,7 @@ import * as htmlToImage from "html-to-image";
 import { toast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
 import { startOfTodayISO } from "@/lib/utils";
+import { useChatInputFocus } from "@/hooks/useChatInputFocus";
 
 interface Props {
   open: boolean;
@@ -15,6 +16,7 @@ interface Props {
 
 export default function ShareCard({ open, onOpenChange, progressPercent }: Props) {
   const { user } = useSupabaseAuth();
+  const focusChatInput = useChatInputFocus();
   const nodeRef = useRef<HTMLDivElement | null>(null);
   const [imgUrl, setImgUrl] = useState<string | null>(null);
   const [streak, setStreak] = useState<number>(0);
@@ -120,8 +122,21 @@ export default function ShareCard({ open, onOpenChange, progressPercent }: Props
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg">
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        onOpenChange(v);
+        if (!v) focusChatInput();
+      }}
+    >
+      <DialogContent
+        className="sm:max-w-lg"
+        onEscapeKeyDown={(e) => {
+          e.preventDefault();
+          onOpenChange(false);
+          focusChatInput();
+        }}
+      >
         <DialogHeader>
           <DialogTitle>Share your progress</DialogTitle>
         </DialogHeader>

--- a/src/components/tasks/QuickAddTaskFAB.tsx
+++ b/src/components/tasks/QuickAddTaskFAB.tsx
@@ -7,6 +7,7 @@ import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "@/hooks/use-toast";
 import { Plus } from "lucide-react";
+import { useChatInputFocus } from "@/hooks/useChatInputFocus";
 
 interface Props {
   roadmapId: string | null;
@@ -17,6 +18,7 @@ interface Props {
 // Priority is prefixed to the title for now (e.g., "[High] Title") to avoid schema changes.
 export default function QuickAddTaskFAB({ roadmapId, onCreated }: Props) {
   const { user } = useSupabaseAuth();
+  const focusChatInput = useChatInputFocus();
   const [open, setOpen] = useState(false);
   const [title, setTitle] = useState("");
   const [due, setDue] = useState<string>("");
@@ -99,8 +101,21 @@ export default function QuickAddTaskFAB({ roadmapId, onCreated }: Props) {
         <Plus className="w-6 h-6" />
       </button>
 
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="sm:max-w-md">
+      <Dialog
+        open={open}
+        onOpenChange={(v) => {
+          setOpen(v);
+          if (!v) focusChatInput();
+        }}
+      >
+        <DialogContent
+          className="sm:max-w-md"
+          onEscapeKeyDown={(e) => {
+            e.preventDefault();
+            setOpen(false);
+            focusChatInput();
+          }}
+        >
           <DialogHeader>
             <DialogTitle>Quick add task</DialogTitle>
           </DialogHeader>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -16,6 +16,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
+import { useChatInputFocus } from "@/hooks/useChatInputFocus"
 
 const SIDEBAR_COOKIE_NAME = "sidebar:state"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
@@ -174,6 +175,7 @@ const Sidebar = React.forwardRef<
     ref
   ) => {
     const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
+    const focusChatInput = useChatInputFocus()
 
     if (collapsible === "none") {
       return (
@@ -192,7 +194,14 @@ const Sidebar = React.forwardRef<
 
     if (isMobile) {
       return (
-        <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
+        <Sheet
+          open={openMobile}
+          onOpenChange={(open) => {
+            setOpenMobile(open)
+            if (!open) focusChatInput()
+          }}
+          {...props}
+        >
           <SheetContent
             data-sidebar="sidebar"
             data-mobile="true"

--- a/src/hooks/useChatInputFocus.ts
+++ b/src/hooks/useChatInputFocus.ts
@@ -1,0 +1,16 @@
+import { useCallback } from "react";
+
+let focusChatInput = () => {};
+
+export function setChatInputRef(ref: HTMLInputElement | null) {
+  focusChatInput = () => {
+    ref?.focus();
+  };
+}
+
+export function useChatInputFocus() {
+  return useCallback(() => {
+    focusChatInput();
+  }, []);
+}
+

--- a/src/memory/MemoryManager.tsx
+++ b/src/memory/MemoryManager.tsx
@@ -23,12 +23,14 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { useChatInputFocus } from "@/hooks/useChatInputFocus";
 
 interface Props {
   bucket?: MemoryBucket;
 }
 
 export default function MemoryManager({ bucket = "semantic" }: Props) {
+  const focusChatInput = useChatInputFocus();
   const [memories, setMemories] = useState<MemoryEntry[]>([]);
   const [editing, setEditing] = useState<MemoryEntry | null>(null);
   const [content, setContent] = useState("");
@@ -103,8 +105,22 @@ export default function MemoryManager({ bucket = "semantic" }: Props) {
         </TableBody>
       </Table>
 
-      <Dialog open={!!editing} onOpenChange={() => setEditing(null)}>
-        <DialogContent>
+      <Dialog
+        open={!!editing}
+        onOpenChange={(open) => {
+          if (!open) {
+            setEditing(null);
+            focusChatInput();
+          }
+        }}
+      >
+        <DialogContent
+          onEscapeKeyDown={(e) => {
+            e.preventDefault();
+            setEditing(null);
+            focusChatInput();
+          }}
+        >
           <DialogHeader>
             <DialogTitle>Edit Memory</DialogTitle>
           </DialogHeader>

--- a/src/modules/payments/components/SubscriptionManager.tsx
+++ b/src/modules/payments/components/SubscriptionManager.tsx
@@ -20,6 +20,7 @@ import { useSubscription } from '@/modules/payments/hooks/useSubscription'
 import { toast } from '@/hooks/use-toast'
 import { formatDistanceToNow } from 'date-fns';
 import { useFeatureFlags } from '@/state/featureFlags';
+import { useChatInputFocus } from '@/hooks/useChatInputFocus';
 
 export function SubscriptionManager() {
   return <SubscriptionManagerUI />;
@@ -30,6 +31,7 @@ function SubscriptionManagerUI() {
   const [showCancelDialog, setShowCancelDialog] = useState(false);
   const [isCanceling, setIsCanceling] = useState(false);
   const isPro = useFeatureFlags((s) => s.isPro);
+  const focusChatInput = useChatInputFocus();
 
   const handleCancelSubscription = async (cancelAtPeriodEnd: boolean) => {
     try {
@@ -256,8 +258,21 @@ function SubscriptionManagerUI() {
       </Card>
 
       {/* Cancel Subscription Dialog */}
-      <Dialog open={showCancelDialog} onOpenChange={setShowCancelDialog}>
-        <DialogContent className="bg-white dark:bg-gray-900">
+      <Dialog
+        open={showCancelDialog}
+        onOpenChange={(v) => {
+          setShowCancelDialog(v);
+          if (!v) focusChatInput();
+        }}
+      >
+        <DialogContent
+          className="bg-white dark:bg-gray-900"
+          onEscapeKeyDown={(e) => {
+            e.preventDefault();
+            setShowCancelDialog(false);
+            focusChatInput();
+          }}
+        >
           <DialogHeader>
             <DialogTitle className="text-xl font-semibold text-gray-900 dark:text-white">
               Cancel Subscription

--- a/src/views/BrainView.tsx
+++ b/src/views/BrainView.tsx
@@ -11,6 +11,7 @@ import {
   DialogTitle,
   DialogFooter,
 } from '@/components/ui/dialog';
+import { useChatInputFocus } from '@/hooks/useChatInputFocus';
 import {
   Select,
   SelectContent,
@@ -31,6 +32,7 @@ interface Memory {
 }
 
 export default function BrainView() {
+  const focusChatInput = useChatInputFocus();
   const [memories, setMemories] = useState<Memory[]>([]);
   const [query, setQuery] = useState('');
   const [typeFilter, setTypeFilter] = useState<string>('all');
@@ -327,8 +329,22 @@ export default function BrainView() {
         </div>
       </div>
 
-      <Dialog open={!!editing} onOpenChange={() => setEditing(null)}>
-        <DialogContent>
+      <Dialog
+        open={!!editing}
+        onOpenChange={(open) => {
+          if (!open) {
+            setEditing(null);
+            focusChatInput();
+          }
+        }}
+      >
+        <DialogContent
+          onEscapeKeyDown={(e) => {
+            e.preventDefault();
+            setEditing(null);
+            focusChatInput();
+          }}
+        >
           <DialogHeader>
             <DialogTitle>Edit Memory</DialogTitle>
           </DialogHeader>

--- a/src/views/MasterPlanView.tsx
+++ b/src/views/MasterPlanView.tsx
@@ -5,6 +5,7 @@ import HabitTracker from "@/components/habits/HabitTracker";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { useChatInputFocus } from "@/hooks/useChatInputFocus";
 import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { supabase } from "@/integrations/supabase/client";
@@ -57,6 +58,7 @@ interface DBHabit {
 }
 
 export default function MasterPlanView() {
+  const focusChatInput = useChatInputFocus();
   const { user } = useSupabaseAuth();
   const [dbPlan, setDbPlan] = useState<MasterPlan | null>(null);
   const { plan: plan, update } = usePlanUpdater(dbPlan as any);
@@ -307,8 +309,22 @@ export default function MasterPlanView() {
         <p className="text-sm text-muted-foreground">No plan generated yet.</p>
       )}
 
-      <Dialog open={!!editField} onOpenChange={(v) => !v && setEditField(null)}>
-        <DialogContent>
+      <Dialog
+        open={!!editField}
+        onOpenChange={(v) => {
+          if (!v) {
+            setEditField(null);
+            focusChatInput();
+          }
+        }}
+      >
+        <DialogContent
+          onEscapeKeyDown={(e) => {
+            e.preventDefault();
+            setEditField(null);
+            focusChatInput();
+          }}
+        >
           <DialogHeader>
             <DialogTitle>Edit {editField}</DialogTitle>
           </DialogHeader>


### PR DESCRIPTION
## Summary
- add `useChatInputFocus` hook and register input in `AnchoredChatBar`
- call chat input focus when modals close and on ESC
- ensure mobile sidebar sheet also refocuses chat input

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e149b78d08326aa1ff1272596412b