### PR TITLE
Add dialog accessibility and dismissal tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
         "@tailwindcss/typography": "^0.5.16",
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^30.0.0",
         "@types/node": "^22.16.5",
         "@types/react": "^18.3.3",
@@ -6161,6 +6162,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -69,20 +69,21 @@
     "react-router-dom": "^6.30.1",
     "recharts": "^2.15.4",
     "sonner": "^1.7.4",
+    "sql.js": "^1.13.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "three": "^0.179.1",
     "vaul": "1.1.2",
     "vite-plugin-pwa": "^0.20.5",
     "zod": "^3.25.76",
-    "zustand": "^4.5.7",
-    "sql.js": "^1.13.0"
+    "zustand": "^4.5.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",
     "@tailwindcss/typography": "^0.5.16",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.16.5",
     "@types/react": "^18.3.3",

--- a/src/components/ui/dialog.test.tsx
+++ b/src/components/ui/dialog.test.tsx
@@ -1,0 +1,63 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+function SetupDialog({ onOpenChange }: { onOpenChange: (open: boolean) => void }) {
+  return (
+    <Dialog onOpenChange={onOpenChange} modal={true}>
+      <DialogTrigger data-testid="trigger">Open</DialogTrigger>
+      <DialogContent>
+        <DialogTitle>Test Dialog</DialogTitle>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+describe('Dialog', () => {
+  test('clicking backdrop closes dialog and restores focus', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = jest.fn();
+    render(<SetupDialog onOpenChange={onOpenChange} />);
+
+    const trigger = screen.getByTestId('trigger');
+    await user.click(trigger);
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+
+    const dialog = screen.getByRole('dialog', { name: 'Test Dialog' });
+    expect(dialog).toBeInTheDocument();
+
+    const overlay = document.querySelector('[data-state="open"][data-aria-hidden="true"]') as HTMLElement;
+    await user.click(overlay);
+
+    await waitFor(() => expect(onOpenChange).toHaveBeenLastCalledWith(false));
+    await waitFor(() => expect(trigger).toHaveFocus());
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  test('pressing ESC closes dialog and restores focus', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = jest.fn();
+    render(<SetupDialog onOpenChange={onOpenChange} />);
+
+    const trigger = screen.getByTestId('trigger');
+    await user.click(trigger);
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+
+    const dialog = screen.getByRole('dialog', { name: 'Test Dialog' });
+    expect(dialog).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => expect(onOpenChange).toHaveBeenLastCalledWith(false));
+    await waitFor(() => expect(trigger).toHaveFocus());
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -4,7 +4,10 @@ import { X } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-const Dialog = DialogPrimitive.Root
+const Dialog = (
+  props: React.ComponentProps<typeof DialogPrimitive.Root>
+) => <DialogPrimitive.Root modal {...props} />
+Dialog.displayName = DialogPrimitive.Root.displayName
 
 const DialogTrigger = DialogPrimitive.Trigger
 
@@ -36,6 +39,8 @@ const DialogContent = React.forwardRef<
     <DialogOverlay />
     <DialogPrimitive.Content
       ref={ref}
+      role="dialog"
+      aria-modal="true"
       className={cn(
         "fixed left-[50%] top-[50%] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className


### PR DESCRIPTION
## Summary
- ensure Dialog primitive defaults to modal
- add explicit role and aria-modal for accessibility
- verify backdrop and ESC close with focus restoration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e14a044988326b5f47278b4cbc3e5