### PR TITLE
Handle safe-area in bottom bar and modals

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Mind OS – Calm Focus & Progress Tracker</title>
     <meta name="description" content="Mind OS: calm, playful productivity with Twitter-blue accents. Track focus, roadmaps, and progress with smooth animations." />
     <meta name="author" content="Lovable" />

--- a/src/components/live/QuickActionsBar.tsx
+++ b/src/components/live/QuickActionsBar.tsx
@@ -169,7 +169,10 @@ type Track = {
   }, [mode]);
 
   return (
-    <div className="glass-panel rounded-xl p-3 elev flex flex-wrap items-center gap-2 sm:gap-3">
+    <div
+      className="glass-panel rounded-xl p-3 elev flex flex-wrap items-center gap-2 sm:gap-3 pb-safe"
+      style={{ height: `calc(100% + env(safe-area-inset-bottom))` }}
+    >
       {/* Hypnosis quick-play */}
       <Button size="sm" onClick={() => setPreOpen(true)}>Start Hypnosis</Button>
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -37,10 +37,10 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] grid w-full max-w-screen h-dvh translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:max-w-lg sm:h-auto sm:rounded-lg",
         className
       )}
-      style={{ zIndex: 'var(--z-modal)' }}
+      style={{ zIndex: 'var(--z-modal)', paddingBottom: 'env(safe-area-inset-bottom)' }}
       {...props}
     >
       {children}


### PR DESCRIPTION
## Summary
- add pb-safe and safe-area height to `QuickActionsBar`
- make modal content responsive and respect iOS safe area
- include viewport-fit to enable safe-area support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e14a64d588326b4f70b7681cc0062