### PR TITLE
feat: add quick action registry

### DIFF
--- a/src/components/navigation/QuickActionBar.tsx
+++ b/src/components/navigation/QuickActionBar.tsx
@@ -1,0 +1,20 @@
+import { QuickAction, useQuickActions } from "./quickActions";
+
+export function QuickActionBar() {
+  const actions = useQuickActions();
+  if (!actions.length) return null;
+  return (
+    <div className="flex items-center gap-2">
+      {actions.map(({ id, label, icon: Icon, onClick }: QuickAction) => (
+        <button
+          key={id}
+          onClick={onClick}
+          className="p-2 rounded-md hover:bg-accent"
+          aria-label={label}
+        >
+          <Icon className="w-5 h-5" />
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/navigation/quickActions.ts
+++ b/src/components/navigation/quickActions.ts
@@ -1,0 +1,29 @@
+import { useSyncExternalStore } from "react";
+
+export interface QuickAction {
+  id: string;
+  label: string;
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  onClick: () => void;
+}
+
+const actions: QuickAction[] = [];
+const listeners = new Set<() => void>();
+
+export function registerQuickAction(action: QuickAction) {
+  actions.push(action);
+  listeners.forEach((l) => l());
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function getSnapshot() {
+  return actions;
+}
+
+export function useQuickActions() {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}


### PR DESCRIPTION
## Summary
- add QuickAction type with registry and subscription
- export registerQuickAction for extending quick actions
- add QuickActionBar component to render registered actions

## Testing
- `npm run lint` (fails: Unexpected any etc.)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e14ad643483268a04cd32c03f54af