### PR TITLE
fix: define API base URL env

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,6 +31,7 @@ export default defineConfig(({ mode }) => {
     define: {
       'import.meta.env.VITE_SUPABASE_URL': JSON.stringify(env.VITE_SUPABASE_URL),
       'import.meta.env.VITE_SUPABASE_ANON_KEY': JSON.stringify(env.VITE_SUPABASE_ANON_KEY),
+      'process.env.VITE_API_BASE_URL': JSON.stringify(env.VITE_API_BASE_URL),
     },
     optimizeDeps: {
       exclude: ["@mlc-ai/web-llm"],


### PR DESCRIPTION
## Summary
- inject VITE_API_BASE_URL into Vite `process.env` so browser builds don't crash when `process` is undefined

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_689e1bee5e248326925d30921fcabf7e