### PR TITLE
feat: add voice flags and draggable sphere

### DIFF
--- a/src/components/avatar/AvatarSphere.tsx
+++ b/src/components/avatar/AvatarSphere.tsx
@@ -14,6 +14,7 @@ interface Props {
   isSpeaking?: boolean;
   isListening?: boolean;
   progressPercent?: number;
+  draggable?: boolean;
 }
 
 export function AvatarSphere({
@@ -22,17 +23,23 @@ export function AvatarSphere({
   isSpeaking,
   isListening,
   progressPercent,
+  draggable = true,
 }: Props) {
   const { enabled, sentiment, audio, mood, milestone, streak } = useAvatarStore();
-  const storeSpeaking = useVoiceStore((s) => s.isSpeaking);
+  const store = useVoiceStore();
+  const storeSpeaking = store.isSpeaking;
+  const storeListening = store.isListening;
+  const storeThinking = store.isThinking;
   const progressStore = useGameStore((s) => s.stats.xp);
 
-  const [listening, setListening] = useState(isListening ?? false);
-  const [thinking, setThinking] = useState(isThinking ?? false);
+  const listening = isListening ?? storeListening;
+  const thinking = isThinking ?? storeThinking;
   const speaking = isSpeaking ?? storeSpeaking;
   const progressPct = progressPercent ?? progressStore;
 
   const mountRef = useRef<HTMLDivElement | null>(null);
+  const [pos, setPos] = useState({ x: 0, y: 0 });
+  const posRef = useRef(pos);
   const analyserRef = useRef<AnalyserNode | null>(null);
   const meshRef = useRef<THREE.Mesh | null>(null);
   const matRef = useRef<THREE.MeshStandardMaterial | null>(null);
@@ -48,22 +55,22 @@ export function AvatarSphere({
   const reduceMotion = useRef(false);
 
   useEffect(() => {
-    if (isListening === undefined) {
-      const onListen = (e: Event) => setListening(Boolean((e as CustomEvent).detail));
-      window.addEventListener('voice-listening', onListen);
-      return () => window.removeEventListener('voice-listening', onListen);
+    posRef.current = pos;
+    if (draggable && mountRef.current) {
+      mountRef.current.style.transform = `translate3d(${pos.x}px, ${pos.y}px, 0)`;
     }
-    setListening(isListening ?? false);
-  }, [isListening]);
+  }, [pos, draggable]);
 
   useEffect(() => {
-    if (isThinking === undefined) {
-      const onProcess = (e: Event) => setThinking(Boolean((e as CustomEvent).detail));
-      window.addEventListener('voice-processing', onProcess);
-      return () => window.removeEventListener('voice-processing', onProcess);
+    const isMobile = window.matchMedia('(max-width: 768px)').matches;
+    let x = Number(window.localStorage.getItem('aurora.sphere.x') || 0);
+    let y = Number(window.localStorage.getItem('aurora.sphere.y') || 0);
+    if (isMobile || isNaN(x) || isNaN(y)) {
+      x = window.innerWidth - size - 16;
+      y = window.innerHeight - size - 16;
     }
-    setThinking(isThinking ?? false);
-  }, [isThinking]);
+    setPos({ x, y });
+  }, [size, draggable]);
 
   useEffect(() => {
     thinkingRef.current = thinking;
@@ -84,6 +91,67 @@ export function AvatarSphere({
   useEffect(() => {
     reduceMotion.current = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   }, []);
+
+  useEffect(() => {
+    if (!draggable || !mountRef.current) return;
+    const el = mountRef.current;
+    const start = { x: 0, y: 0 };
+    const pointer = { x: 0, y: 0 };
+    let frame = 0;
+    const move = { x: 0, y: 0 };
+    const onPointerMove = (e: PointerEvent) => {
+      if (frame) return;
+      move.x = start.x + (e.clientX - pointer.x);
+      move.y = start.y + (e.clientY - pointer.y);
+      frame = requestAnimationFrame(() => {
+        setPos({ x: move.x, y: move.y });
+        frame = 0;
+      });
+    };
+    const onPointerUp = (e: PointerEvent) => {
+      el.releasePointerCapture(e.pointerId);
+      window.removeEventListener('pointermove', onPointerMove);
+      window.removeEventListener('pointerup', onPointerUp);
+      const { x, y } = posRef.current;
+      const w = window.innerWidth;
+      const h = window.innerHeight;
+      const isMobile = w <= 768;
+      const nearEdge = x < 40 || x > w - size - 40;
+      if (isMobile || nearEdge) {
+        const snapX = w - size - 16;
+        const snapY = h - size - 16;
+        setPos({ x: snapX, y: snapY });
+        try {
+          localStorage.setItem('aurora.sphere.x', String(snapX));
+          localStorage.setItem('aurora.sphere.y', String(snapY));
+        } catch {
+          /* ignore */
+        }
+      } else {
+        try {
+          localStorage.setItem('aurora.sphere.x', String(x));
+          localStorage.setItem('aurora.sphere.y', String(y));
+        } catch {
+          /* ignore */
+        }
+      }
+    };
+    const onPointerDown = (e: PointerEvent) => {
+      start.x = posRef.current.x;
+      start.y = posRef.current.y;
+      pointer.x = e.clientX;
+      pointer.y = e.clientY;
+      el.setPointerCapture(e.pointerId);
+      window.addEventListener('pointermove', onPointerMove);
+      window.addEventListener('pointerup', onPointerUp);
+    };
+    el.addEventListener('pointerdown', onPointerDown);
+    return () => {
+      el.removeEventListener('pointerdown', onPointerDown);
+      window.removeEventListener('pointermove', onPointerMove);
+      window.removeEventListener('pointerup', onPointerUp);
+    };
+  }, [draggable, size]);
 
   // Setup scene
   useEffect(() => {
@@ -276,7 +344,20 @@ export function AvatarSphere({
   }, [streak]);
 
   if (!enabled) return null;
-  return <div ref={mountRef} style={{ width: size, height: size }} />;
+  return (
+    <div
+      ref={mountRef}
+      style={{
+        width: size,
+        height: size,
+        position: draggable ? 'fixed' : undefined,
+        left: draggable ? 0 : undefined,
+        top: draggable ? 0 : undefined,
+        willChange: draggable ? 'transform' : undefined,
+        touchAction: draggable ? 'none' : undefined,
+      }}
+    />
+  );
 }
 
 export default AvatarSphere;

--- a/src/components/game/GameHUD.tsx
+++ b/src/components/game/GameHUD.tsx
@@ -77,7 +77,7 @@ export function GameHUD() {
         <div className="flex items-center gap-3 min-w-0 flex-wrap">
           {/* Identity */}
           <div className="flex items-center gap-3 min-w-0 shrink">
-            {avatarEnabled && <AvatarSphere size={44} />}
+            {avatarEnabled && <AvatarSphere size={44} draggable={false} />}
             <div className="min-w-0">
               <div className="text-[13px] opacity-90 truncate">
                 Lv. {stats.level} • Streak {stats.streak}

--- a/src/state/chat.tsx
+++ b/src/state/chat.tsx
@@ -3,6 +3,7 @@ import { auroraChat } from "@/utils/auroraChat";
 import type { ChatMessage } from "@/types/chat";
 import { useAvatarStore } from "@/state/avatar";
 import { useTextToSpeech } from "@/voice/useTextToSpeech";
+import { useVoiceStore } from "@/state/voice";
 import {
   memoryStore,
   retrieveRelevantMemories,
@@ -33,6 +34,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     const userMsg: ChatEntry = { id: crypto.randomUUID(), role: "user", content: text };
     setMessages(prev => [...prev, userMsg]);
     window.dispatchEvent(new CustomEvent('voice-processing', { detail: true }));
+    useVoiceStore.getState().setThinking(true);
     setSending(true);
     void (async () => {
       try {
@@ -88,6 +90,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       } finally {
         setSending(false);
         window.dispatchEvent(new CustomEvent('voice-processing', { detail: false }));
+        useVoiceStore.getState().setThinking(false);
       }
     })();
     return Promise.resolve();

--- a/src/state/voice.ts
+++ b/src/state/voice.ts
@@ -16,6 +16,8 @@ type VoiceMode =
   | "off";
 
 type VoiceState = {
+  isListening: boolean;
+  isThinking: boolean;
   isSpeaking: boolean;
   voiceId: string | null;
   mode: VoiceMode;
@@ -24,6 +26,8 @@ type VoiceState = {
   pitch: number;
   expression: number;
   emotion: string;
+  setListening: (v: boolean) => void;
+  setThinking: (v: boolean) => void;
   setSpeaking: (v: boolean) => void;
   setVoiceId: (id: string | null) => void;
   setMode: (m: VoiceMode) => void;
@@ -35,6 +39,8 @@ type VoiceState = {
 };
 
 export const useVoiceStore = create<VoiceState>((set) => ({
+  isListening: false,
+  isThinking: false,
   isSpeaking: false,
   voiceId:
     typeof window !== "undefined"
@@ -65,6 +71,8 @@ export const useVoiceStore = create<VoiceState>((set) => ({
     typeof window !== "undefined"
       ? window.localStorage.getItem(VOICE_EMOTION_KEY) || "neutral"
       : "neutral",
+  setListening: (v) => set({ isListening: v }),
+  setThinking: (v) => set({ isThinking: v }),
   setSpeaking: (v) => set({ isSpeaking: v }),
   setVoiceId: (id) => {
     try {
@@ -84,14 +92,6 @@ export const useVoiceStore = create<VoiceState>((set) => ({
       }
     }
     set({ mode });
-  },
-  setLocale: (locale) => {
-    try {
-      window.localStorage.setItem(VOICE_LOCALE_KEY, locale);
-    } catch {
-      /* ignore */
-    }
-    set({ locale });
   },
   setLocale: (locale) => {
     try {

--- a/src/voice/useTextToSpeech.ts
+++ b/src/voice/useTextToSpeech.ts
@@ -8,6 +8,9 @@ import { guardPremiumAction } from "@/modules/payments/guard";
 
 function fire(type: string, detail: boolean) {
   window.dispatchEvent(new CustomEvent(type, { detail }));
+  const store = useVoiceStore.getState();
+  if (type === "voice-listening") store.setListening(detail);
+  if (type === "voice-processing") store.setThinking(detail);
 }
 
 const ELEVENLABS_DEFAULT_VOICE_ID =

--- a/src/voice/useVoiceInput.ts
+++ b/src/voice/useVoiceInput.ts
@@ -1,7 +1,11 @@
 import { useState, useRef, useCallback } from 'react'
+import { useVoiceStore } from '@/state/voice'
 
 function fire(type: string, detail: boolean) {
   window.dispatchEvent(new CustomEvent(type, { detail }))
+  const store = useVoiceStore.getState()
+  if (type === 'voice-listening') store.setListening(detail)
+  if (type === 'voice-processing') store.setThinking(detail)
 }
 
 export function useVoiceInput() {

--- a/src/voice/voiceio.ts
+++ b/src/voice/voiceio.ts
@@ -6,6 +6,9 @@ import { ttsFallbackToast } from "@/voice/ttsFallbackToast";
 
 function fire(type: string, detail: boolean) {
   window.dispatchEvent(new CustomEvent(type, { detail }));
+  const store = useVoiceStore.getState();
+  if (type === "voice-listening") store.setListening(detail);
+  if (type === "voice-processing") store.setThinking(detail);
 }
 
 export type VoiceCallbacks = {


### PR DESCRIPTION
## Summary
- track listening and thinking status in voice store
- drive avatar animations from store flags and persist drag position
- sync voice modules with store and disable dragging in HUD

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, no-empty, prefer-const, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689e252d70748326a9dc73d403b39d3c