### PR TITLE
Remove duplicate setLocale implementation in voice store

### DIFF
--- a/src/state/voice.ts
+++ b/src/state/voice.ts
@@ -93,14 +93,6 @@ export const useVoiceStore = create<VoiceState>((set) => ({
     }
     set({ locale });
   },
-  setLocale: (locale) => {
-    try {
-      window.localStorage.setItem(VOICE_LOCALE_KEY, locale);
-    } catch {
-      /* ignore */
-    }
-    set({ locale });
-  },
   setSpeed: (speed) => {
     try {
       window.localStorage.setItem(VOICE_SPEED_KEY, String(speed));


### PR DESCRIPTION
## Summary
- remove duplicated `setLocale` handler from voice state store
- keep single `setLocale` that updates state and persists to localStorage

## Testing
- `npm run lint src/state/voice.ts` *(fails: command doesn't take file arg; run default lint and passes? hmm we didn't run)*
- `npx eslint src/state/voice.ts`
- `npm run lint` *(fails: numerous pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e25345a948326b9fdaa567ab08050