### PR TITLE
feat: improve chat accessibility

### DIFF
--- a/src/components/agent/AgentPanel.tsx
+++ b/src/components/agent/AgentPanel.tsx
@@ -71,13 +71,16 @@ export default function AgentPanel() {
         <div className="glass-panel rounded-xl p-3 text-sm text-muted-foreground">{partial}</div>
       )}
 
-      <div className="grid gap-2">
+      <div className="grid gap-2" role="log" aria-live="polite">
         {messages.map((m, i) => (
           <div key={i} className={`glass-panel rounded-xl p-3 ${m.role === 'assistant' ? '' : ''}`}>
             <div className="text-[11px] text-muted-foreground mb-1">{m.role}</div>
             <div className="text-sm whitespace-pre-wrap">{m.text}</div>
           </div>
         ))}
+      </div>
+      <div aria-live="polite" className="sr-only">
+        {messages.length > 0 ? messages[messages.length - 1].text : ""}
       </div>
     </div>
   );

--- a/src/pages/OnboardingFlow.tsx
+++ b/src/pages/OnboardingFlow.tsx
@@ -412,7 +412,7 @@ export default function OnboardingFlow() {
           </div>
         </div>
         <ScrollArea className="flex-1 px-4">
-          <div className="space-y-3 text-sm">
+          <div className="space-y-3 text-sm" role="log" aria-live="polite">
             {messages.map((m, i) => (
               <div key={i} className={`flex ${m.role === "user" ? "justify-end" : "justify-start"}`}>
                 {m.role === "assistant" && (
@@ -430,6 +430,9 @@ export default function OnboardingFlow() {
               </div>
             ))}
             <div ref={messagesEndRef} />
+          </div>
+          <div aria-live="polite" className="sr-only">
+            {messages.length > 0 ? messages[messages.length - 1].content : ""}
           </div>
         </ScrollArea>
 


### PR DESCRIPTION
## Summary
- add `role="log"` and `aria-live="polite"` to chat message containers
- mirror latest chat message in a hidden live region for screen readers

## Testing
- `npm run lint` (fails: Unexpected any, no-empty, rules-of-hooks, etc.)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e254949f48326b8be6d05677dfd6e