### PR TITLE
feat: add UI store for modal state

### DIFF
--- a/src/state/ui.ts
+++ b/src/state/ui.ts
@@ -1,0 +1,16 @@
+import { create } from 'zustand';
+
+export type ModalId = 'brain' | 'journal' | 'live' | 'analytics' | 'more';
+
+export interface UIState {
+  activeModal: ModalId | null;
+  openModal: (id: ModalId) => void;
+  closeModal: () => void;
+}
+
+export const useUIStore = create<UIState>((set) => ({
+  activeModal: null,
+  openModal: (id) => set({ activeModal: id }),
+  closeModal: () => set({ activeModal: null }),
+}));
+


### PR DESCRIPTION
## Summary
- add zustand-based UI store with activeModal and helper methods

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689e4d1d974883268ef4b0b48ba4c328