### PR TITLE
feat: add chat event bus

### DIFF
--- a/src/components/game/GameHUD.tsx
+++ b/src/components/game/GameHUD.tsx
@@ -8,6 +8,7 @@ import { useTextToSpeech } from "@/voice/useTextToSpeech";
 import { useHUDActions } from "@/game/hud/useHUDActions";
 import { useAvatarStore } from "@/state/avatar";
 import SettingsPanel from "../../../frontend/components/SettingsPanel.jsx";
+import { bus } from "@/utils/bus";
 
 function fire<T>(type: string, payload?: T) {
   window.dispatchEvent(new CustomEvent('mos', { detail: { type, payload } }));
@@ -33,12 +34,11 @@ export function GameHUD() {
 
   useEffect(() => {
     const onListen = (e: Event) => setListening(Boolean((e as CustomEvent).detail));
-    const onProcess = (e: Event) => setProcessing(Boolean((e as CustomEvent).detail));
     window.addEventListener('voice-listening', onListen);
-    window.addEventListener('voice-processing', onProcess);
+    const off = bus.on('voice/state:set', ({ state }) => setProcessing(state === 'thinking'));
     return () => {
       window.removeEventListener('voice-listening', onListen);
-      window.removeEventListener('voice-processing', onProcess);
+      off();
     };
   }, []);
 

--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -37,7 +37,7 @@ export default function AppShell() {
   useKeyboardOffset();
 
   useEffect(() => {
-    const off = bus.on('nav:view', ({ id, params }: { id: ViewId; params?: Record<string, string> }) => open(id, params));
+    const off = bus.on('nav:view', ({ id, params }) => open(id as ViewId, params));
     return off;
   }, [open]);
 

--- a/src/state/chat.tsx
+++ b/src/state/chat.tsx
@@ -4,6 +4,7 @@ import type { ChatMessage } from "@/types/chat";
 import { useAvatarStore } from "@/state/avatar";
 import { useTextToSpeech } from "@/voice/useTextToSpeech";
 import { useVoiceStore } from "@/state/voice";
+import { bus } from "@/utils/bus";
 import {
   memoryStore,
   retrieveRelevantMemories,
@@ -33,7 +34,11 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     const history: ChatMessage[] = messages.map(m => ({ role: m.role, content: m.content }));
     const userMsg: ChatEntry = { id: crypto.randomUUID(), role: "user", content: text };
     setMessages(prev => [...prev, userMsg]);
-    window.dispatchEvent(new CustomEvent('voice-processing', { detail: true }));
+    bus.emit('chat/send', { id: userMsg.id, content: text });
+    const replyId = crypto.randomUUID();
+    bus.emit('chat/stream:start', { id: replyId });
+    bus.emit('voice/state:set', { state: 'thinking' });
+    bus.emit('sphere/state:set', { state: 'thinking' });
     useVoiceStore.getState().setThinking(true);
     setSending(true);
     void (async () => {
@@ -71,8 +76,9 @@ export function ChatProvider({ children }: { children: ReactNode }) {
           confidence,
         });
         useAvatarStore.getState().setSentiment(sentiment);
+        bus.emit('chat/stream:chunk', { id: replyId, content: replyText });
         const reply: ChatEntry = {
-          id: crypto.randomUUID(),
+          id: replyId,
           role: "assistant",
           content: replyText,
         };
@@ -80,16 +86,19 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         void speak(replyText);
         memoryStore.add("episodic", "assistant", replyText).catch(() => {});
         saveMemory(replyText, { role: "assistant" }).catch(() => {});
-      } catch {
+        bus.emit('chat/stream:end', { id: replyId });
+      } catch (e) {
         const err: ChatEntry = {
-          id: crypto.randomUUID(),
+          id: replyId,
           role: "assistant",
           content: "Sorry, I couldn't respond.",
         };
         setMessages(prev => [...prev, err]);
+        bus.emit('chat/stream:error', { id: replyId, error: e });
       } finally {
         setSending(false);
-        window.dispatchEvent(new CustomEvent('voice-processing', { detail: false }));
+        bus.emit('voice/state:set', { state: 'speaking' });
+        bus.emit('sphere/state:set', { state: 'speaking' });
         useVoiceStore.getState().setThinking(false);
       }
     })();

--- a/src/state/types/chatEvents.ts
+++ b/src/state/types/chatEvents.ts
@@ -1,0 +1,9 @@
+export type ChatEvents = {
+  'chat/send': { id: string; content: string };
+  'chat/stream:start': { id: string };
+  'chat/stream:chunk': { id: string; content: string };
+  'chat/stream:end': { id: string };
+  'chat/stream:error': { id: string; error: unknown };
+  'sphere/state:set': { state: 'thinking' | 'speaking' };
+  'voice/state:set': { state: 'thinking' | 'speaking' };
+};

--- a/src/utils/bus.ts
+++ b/src/utils/bus.ts
@@ -1,6 +1,8 @@
+import type { ChatEvents } from '@/state/types/chatEvents';
+
 export type EventMap = {
   'nav:view': { id: string; params?: Record<string, string> };
-};
+} & ChatEvents;
 
 const listeners: { [K in keyof EventMap]?: ((p: EventMap[K]) => void)[] } = {};
 

--- a/src/voice/useTextToSpeech.ts
+++ b/src/voice/useTextToSpeech.ts
@@ -5,12 +5,18 @@ import { ttsFallbackToast } from "@/voice/ttsFallbackToast";
 import { ttsAutoplayToast } from "@/voice/ttsAutoplayToast";
 import { useSubscription } from "@/modules/payments/hooks/useSubscription";
 import { guardPremiumAction } from "@/modules/payments/guard";
+import { bus } from "@/utils/bus";
 
-function fire(type: string, detail: boolean) {
-  window.dispatchEvent(new CustomEvent(type, { detail }));
-  const store = useVoiceStore.getState();
-  if (type === "voice-listening") store.setListening(detail);
-  if (type === "voice-processing") store.setThinking(detail);
+function fire(type: 'voice-listening' | 'voice-processing', detail: boolean) {
+  if (type === 'voice-processing') {
+    const state = detail ? 'thinking' : 'speaking';
+    bus.emit('voice/state:set', { state });
+    bus.emit('sphere/state:set', { state });
+    useVoiceStore.getState().setThinking(detail);
+  } else {
+    window.dispatchEvent(new CustomEvent(type, { detail }));
+    useVoiceStore.getState().setListening(detail);
+  }
 }
 
 const ELEVENLABS_DEFAULT_VOICE_ID =

--- a/src/voice/useVoiceInput.ts
+++ b/src/voice/useVoiceInput.ts
@@ -1,11 +1,17 @@
 import { useState, useRef, useCallback } from 'react'
 import { useVoiceStore } from '@/state/voice'
+import { bus } from '@/utils/bus'
 
-function fire(type: string, detail: boolean) {
-  window.dispatchEvent(new CustomEvent(type, { detail }))
-  const store = useVoiceStore.getState()
-  if (type === 'voice-listening') store.setListening(detail)
-  if (type === 'voice-processing') store.setThinking(detail)
+function fire(type: 'voice-listening' | 'voice-processing', detail: boolean) {
+  if (type === 'voice-processing') {
+    const state = detail ? 'thinking' : 'speaking'
+    bus.emit('voice/state:set', { state })
+    bus.emit('sphere/state:set', { state })
+    useVoiceStore.getState().setThinking(detail)
+  } else {
+    window.dispatchEvent(new CustomEvent(type, { detail }))
+    useVoiceStore.getState().setListening(detail)
+  }
 }
 
 export function useVoiceInput() {

--- a/src/voice/voiceio.ts
+++ b/src/voice/voiceio.ts
@@ -3,12 +3,18 @@ import { supabase } from "@/integrations/supabase/client";
 import { useAvatarStore } from "@/state/avatar";
 import { playClonedVoice } from "./voiceClone";
 import { ttsFallbackToast } from "@/voice/ttsFallbackToast";
+import { bus } from "@/utils/bus";
 
-function fire(type: string, detail: boolean) {
-  window.dispatchEvent(new CustomEvent(type, { detail }));
-  const store = useVoiceStore.getState();
-  if (type === "voice-listening") store.setListening(detail);
-  if (type === "voice-processing") store.setThinking(detail);
+function fire(type: 'voice-listening' | 'voice-processing', detail: boolean) {
+  if (type === 'voice-processing') {
+    const state = detail ? 'thinking' : 'speaking';
+    bus.emit('voice/state:set', { state });
+    bus.emit('sphere/state:set', { state });
+    useVoiceStore.getState().setThinking(detail);
+  } else {
+    window.dispatchEvent(new CustomEvent(type, { detail }));
+    useVoiceStore.getState().setListening(detail);
+  }
 }
 
 export type VoiceCallbacks = {


### PR DESCRIPTION
## Summary
- add `ChatEvents` type for chat and state events
- extend global event bus with typed chat and voice events
- emit and consume bus events across chat and voice modules

## Testing
- `npm test`
- `npm run lint` *(fails: 223 problems)*

------
https://chatgpt.com/codex/tasks/task_e_689e5296dcf4832686d886acab350a22