### PR TITLE
Annotate memory context with relevance

### DIFF
--- a/src/agent/AuroraAgent.ts
+++ b/src/agent/AuroraAgent.ts
@@ -7,6 +7,7 @@ import {
   retrieveRelevantMemories,
 } from "@/memory/indexedDbMemory";
 import { saveMemory, queryMemory } from "@/memory/store";
+import { mergeAndExplainMemories, formatMemoryContext } from "@/memory/relevance";
 import brain from "@/brain/Brain";
 import { filterRegistry } from "@/brain/filters";
 import { scanResponse, explainIssues } from "@/agent/safety";
@@ -61,12 +62,10 @@ export class AuroraAgent {
       retrieveRelevantMemories(text),
       queryMemory(text, 5),
     ]);
-    const memoryContext = [
-      ...memories.map((m) => `${m.role}: ${m.content}`),
-      ...longTerm.map((m) => `${m.metadata?.role ?? 'memory'}: ${m.text}`),
-    ].join('\n');
+    const { annotated } = mergeAndExplainMemories(text, memories, longTerm);
+    const memoryContext = formatMemoryContext(annotated);
 
-    const confidence = memories.length + longTerm.length > 2 ? 0.9 : 0.5;
+    const confidence = annotated.length > 2 ? 0.9 : 0.5;
 
     const userSummary = this.history
       .filter((m) => m.role === 'user')

--- a/src/memory/relevance.ts
+++ b/src/memory/relevance.ts
@@ -1,0 +1,46 @@
+import type { MemoryEntry } from './indexedDbMemory';
+import type { MemoryRecord } from './store';
+
+export interface AnnotatedMemory {
+  role: string;
+  content: string;
+  score?: number;
+  why: string;
+}
+
+function explainRelevance(query: string, content: string): string {
+  const qWords = new Set(query.toLowerCase().split(/\W+/).filter(Boolean));
+  const words = content.toLowerCase().split(/\W+/).filter(Boolean);
+  const match = words.find(w => qWords.has(w));
+  return match ? `Mentions "${match}"` : 'Semantically related';
+}
+
+export function mergeAndExplainMemories(
+  query: string,
+  memories: MemoryEntry[],
+  longTerm: MemoryRecord[],
+  max = 5
+): { annotated: AnnotatedMemory[]; recall: string | null } {
+  const combined = [
+    ...memories.map(m => ({
+      role: m.role,
+      content: m.content,
+      score: (m as any).score ?? (m as any).confidence,
+    })),
+    ...longTerm.map(m => ({
+      role: m.metadata?.role ?? 'memory',
+      content: m.text,
+      score: (m as any).score ?? (m.metadata as any)?.score,
+    })),
+  ];
+  combined.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+  const top = combined.slice(0, max);
+  const annotated = top.map(m => ({ ...m, why: explainRelevance(query, m.content) }));
+  return { annotated, recall: annotated[0]?.why ?? null };
+}
+
+export function formatMemoryContext(list: AnnotatedMemory[]): string {
+  return list
+    .map(m => `${m.role}: ${m.content} (Why recalled: ${m.why})`)
+    .join('\n');
+}

--- a/src/state/chat.ts
+++ b/src/state/chat.ts
@@ -8,6 +8,7 @@ import {
   retrieveRelevantMemories,
 } from "@/memory/indexedDbMemory";
 import { saveMemory, queryMemory } from "@/memory/store";
+import { mergeAndExplainMemories, formatMemoryContext } from "@/memory/relevance";
 import { bus } from "@/utils/bus";
 
 export type ChatEntry = ChatMessage & { id: string };
@@ -48,22 +49,16 @@ export const useChatStore = create<ChatState>((set, get) => ({
         retrieveRelevantMemories(text),
         queryMemory(text, 5),
       ]);
-      const top = [
-        ...memories.map(m => m.content),
-        ...longTerm.map(m => m.text),
-      ];
+      const { annotated, recall } = mergeAndExplainMemories(text, memories, longTerm);
       if (import.meta.env.DEV) {
-        console.debug("Brain retrieval", top.slice(0, 5));
+        console.debug("Brain retrieval", annotated.slice(0, 5));
       }
-      set({ recall: top.length ? "Why I recalled this" : null });
-      if (top.length) {
+      set({ recall });
+      if (recall) {
         setTimeout(() => set({ recall: null }), 5000);
       }
-      const memoryContext = [
-        ...memories.map(m => `${m.role}: ${m.content}`),
-        ...longTerm.map(m => `${m.metadata?.role ?? 'memory'}: ${m.text}`),
-      ].join("\n");
-      const confidence = memories.length + longTerm.length > 2 ? 0.9 : 0.5;
+      const memoryContext = formatMemoryContext(annotated);
+      const confidence = annotated.length > 2 ? 0.9 : 0.5;
       const payload: ChatMessage[] = [
         ...history,
         ...(memoryContext


### PR DESCRIPTION
## Summary
- Merge long-term and episodic memories, rank and explain relevance, and format context strings
- Show first explanation as recall hint and include annotated memories in model payload
- Apply same memory-annotation logic to Aurora agent processing

## Testing
- `npm run lint` *(fails: 226 problems)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e5891235483268991d2f470557d3e