### PR TITLE
feat: emit voice listening events from chat bar

### DIFF
--- a/src/components/chat/AnchoredChatBar.tsx
+++ b/src/components/chat/AnchoredChatBar.tsx
@@ -6,6 +6,7 @@ import { useChatStore } from "@/state/chat";
 import { useTextToSpeech } from "@/voice/useTextToSpeech";
 import { EvolvingSphere } from "@/components/effects/EvolvingSphere";
 import { setChatInputRef } from "@/hooks/useChatInputFocus";
+import { bus } from "@/utils/bus";
 
 export function AnchoredChatBar() {
   const { send, sending, messages, recall } = useChatStore();
@@ -52,6 +53,7 @@ export function AnchoredChatBar() {
     const rec = recognitionRef.current;
     if (!rec || listening) return;
     setListening(true);
+    bus.emit('voice/listen:start', {});
     rec.start();
   };
 
@@ -59,6 +61,7 @@ export function AnchoredChatBar() {
     const rec = recognitionRef.current;
     if (!rec) return;
     rec.stop();
+    bus.emit('voice/listen:stop', {});
     setListening(false);
   };
 

--- a/src/state/types/chatEvents.ts
+++ b/src/state/types/chatEvents.ts
@@ -6,5 +6,7 @@ export type ChatEvents = {
   'chat/stream:error': { id: string; error: unknown };
   'sphere/state:set': { state: 'thinking' | 'speaking' };
   'voice/state:set': { state: 'thinking' | 'speaking' };
+  'voice/listen:start': {};
+  'voice/listen:stop': {};
 };
 


### PR DESCRIPTION
## Summary
- emit bus events when voice listening starts or stops
- include voice listen events in ChatEvents type

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e5ef69ae48326991f4e66f9bb1686