### PR TITLE
Prevent chat input focus from scrolling

### DIFF
--- a/src/hooks/useChatInputFocus.test.ts
+++ b/src/hooks/useChatInputFocus.test.ts
@@ -1,0 +1,34 @@
+/** @jest-environment jsdom */
+import { renderHook, act } from "@testing-library/react";
+import { setChatInputRef, useChatInputFocus } from "./useChatInputFocus";
+
+describe("useChatInputFocus", () => {
+  it("focuses the input immediately", () => {
+    const focus = jest.fn();
+    const input = { focus } as unknown as HTMLInputElement;
+    setChatInputRef(input);
+    const { result } = renderHook(() => useChatInputFocus());
+    act(() => {
+      result.current();
+    });
+    expect(focus).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not scroll the viewport when focusing", () => {
+    const scrollTo = jest.spyOn(window, "scrollTo");
+    const focus = jest.fn((options?: FocusOptions) => {
+      if (!options?.preventScroll) {
+        window.scrollTo(0, 100);
+      }
+    });
+    const input = { focus } as unknown as HTMLInputElement;
+    setChatInputRef(input);
+    const { result } = renderHook(() => useChatInputFocus());
+    act(() => {
+      result.current();
+    });
+    expect(focus).toHaveBeenCalledWith({ preventScroll: true });
+    expect(scrollTo).not.toHaveBeenCalled();
+    scrollTo.mockRestore();
+  });
+});

--- a/src/hooks/useChatInputFocus.ts
+++ b/src/hooks/useChatInputFocus.ts
@@ -4,7 +4,7 @@ let focusChatInput = () => {};
 
 export function setChatInputRef(ref: HTMLInputElement | null) {
   focusChatInput = () => {
-    ref?.focus();
+    ref?.focus({ preventScroll: true });
   };
 }
 


### PR DESCRIPTION
## Summary
- prevent chat input focus from causing scroll
- verify useChatInputFocus returns a callback that focuses without scrolling

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, empty block statement, no-require-imports, etc.)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_689e5f500db083268f74033f770f550a