### PR TITLE
feat: announce latest assistant message in chat bar

### DIFF
--- a/src/components/chat/AnchoredChatBar.tsx
+++ b/src/components/chat/AnchoredChatBar.tsx
@@ -111,13 +111,21 @@ export function AnchoredChatBar() {
   };
 
   return (
-    <div
-      className="fixed left-3 right-3 relative"
-      style={{
-        bottom: `calc(var(--hud-h) + var(--dock-h) + var(--hud-gap) + var(--kb-offset) + env(safe-area-inset-bottom))`,
-        zIndex: "var(--z-hud)",
-      }}
-    >
+    <>
+      <div
+        className="sr-only"
+        aria-live="polite"
+        key={lastAssistant?.id ?? messages.length}
+      >
+        {lastAssistant?.content}
+      </div>
+      <div
+        className="fixed left-3 right-3 relative"
+        style={{
+          bottom: `calc(var(--hud-h) + var(--dock-h) + var(--hud-gap) + var(--kb-offset) + env(safe-area-inset-bottom))`,
+          zIndex: "var(--z-hud)",
+        }}
+      >
       <div className="pointer-events-auto glass-panel rounded-2xl p-2 elev flex items-center gap-2">
         <Button
           size="icon"
@@ -217,5 +225,6 @@ export function AnchoredChatBar() {
         </button>
       </div>
     </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- announce latest assistant message to screen readers via hidden aria-live region keyed to the message id
- wrap chat bar output in a fragment to accommodate the new live region

## Testing
- `npm test`
- `npm run lint` *(fails: 205 errors, 22 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689e5f5e23e08326b7cb4e3b7c640f49