### PR TITLE
style: increase chat bar height

### DIFF
--- a/src/styles/vars.css
+++ b/src/styles/vars.css
@@ -1,7 +1,7 @@
 /* Floating metrics for the app: right-side stack */
 :root {
   --compass-size: 72px;
-  --chatbar-h: 56px; /* chat bar */
+  --chatbar-h: 64px; /* chat bar */
   --dock-h: 56px; /* bottom dock */
   --fab-size: 56px;    /* new task */
   --gap: 12px;


### PR DESCRIPTION
## Summary
- increase chat bar height variable from 56px to 64px so components using `--compass-bottom` account for the taller bar

## Testing
- `npm test`
- `npm run lint` *(fails: unexpected any, empty block statements, React hooks usage)*

------
https://chatgpt.com/codex/tasks/task_e_689e5f94cd888326a0f2908b896292fe