### PR TITLE
chore: document chat live region for screen readers

### DIFF
--- a/src/components/chat/AnchoredChatBar.tsx
+++ b/src/components/chat/AnchoredChatBar.tsx
@@ -120,6 +120,7 @@ export function AnchoredChatBar() {
 
   return (
     <>
+      {/* Visually hidden live region for screen reader announcements */}
       <div
         className="sr-only"
         aria-live="polite"


### PR DESCRIPTION
## Summary
- document visually hidden live region announcing the latest assistant reply

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e60d642148326bf4306415d82d8d6