### PR TITLE
fix: remove stray tokens in ReactiveSphere

### DIFF
--- a/src/components/avatar/ReactiveSphere.tsx
+++ b/src/components/avatar/ReactiveSphere.tsx
@@ -11,8 +11,6 @@ interface Props {
   size?: number;
   className?: string;
 }
-
-ain
 export function ReactiveSphere({ size = 48, className }: Props) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const analyserRef = useRef<AnalyserNode | null>(null);
@@ -83,7 +81,6 @@ export function ReactiveSphere({ size = 48, className }: Props) {
 
     return () => {
       cancelAnimationFrame(frameRef.current);
-n
       renderer.dispose();
     };
   }, [size, state]);


### PR DESCRIPTION
## Summary
- remove stray tokens from ReactiveSphere component that caused runtime ReferenceError

## Testing
- `npm test --silent`
- `npm run lint` *(fails: Unexpected any, prefer-const, no-empty, no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_689e69dc23708326ac0002670c464adb