### PR TITLE
Refactor voice input to use centralized voice service

### DIFF
--- a/src/state/types/chatEvents.ts
+++ b/src/state/types/chatEvents.ts
@@ -15,5 +15,6 @@ export type ChatEvents = {
   'voice/state:set': { state: 'thinking' | 'speaking' };
   'voice/listen:start': {};
   'voice/listen:stop': {};
+  'voice/transcript': { text: string };
 };
 

--- a/src/state/voice.ts
+++ b/src/state/voice.ts
@@ -8,6 +8,7 @@ const VOICE_EXPR_KEY = 'aurora.voiceExpression';
 const VOICE_EMOTION_KEY = 'aurora.voiceEmotion';
 const VOICE_MODE_KEY = 'aurora.voiceMode';
 const VOICE_LOCALE_KEY = 'aurora.voiceLocale';
+const VOICE_INPUT_MODE_KEY = 'aurora.voiceInputMode';
 
 type VoiceMode =
   | 'cloned'
@@ -16,12 +17,15 @@ type VoiceMode =
   | 'local-tts'
   | 'off';
 
+type VoiceInputMode = 'push-to-talk' | 'toggle';
+
 type VoiceState = {
   isListening: boolean;
   isThinking: boolean;
   isSpeaking: boolean;
   voiceId: string | null;
   mode: VoiceMode;
+  inputMode: VoiceInputMode;
   locale: string;
   speed: number;
   pitch: number;
@@ -32,6 +36,7 @@ type VoiceState = {
   setSpeaking: (v: boolean) => void;
   setVoiceId: (id: string | null) => void;
   setMode: (m: VoiceMode, persist?: boolean) => void; // <- align with impl
+  setInputMode: (m: VoiceInputMode) => void;
   setLocale: (l: string) => void;
   setSpeed: (v: number) => void;
   setPitch: (v: number) => void;
@@ -59,6 +64,9 @@ export const useVoiceStore = create<VoiceState>((set) => {
       ? (ls!.getItem(VOICE_MODE_KEY) as VoiceMode) ||
         (import.meta.env.VITE_ELEVEN_API_KEY ? 'eleven-default' : 'browser-tts')
       : 'browser-tts',
+    inputMode: hasWindow
+      ? ((ls!.getItem(VOICE_INPUT_MODE_KEY) as VoiceInputMode) || 'push-to-talk')
+      : 'push-to-talk',
     locale: hasWindow
       ? ls!.getItem(VOICE_LOCALE_KEY) || navigator.language || 'en-US'
       : 'en-US',
@@ -88,6 +96,13 @@ export const useVoiceStore = create<VoiceState>((set) => {
         } catch {}
       }
       set({ mode });
+    },
+
+    setInputMode: (inputMode) => {
+      try {
+        ls?.setItem(VOICE_INPUT_MODE_KEY, inputMode);
+      } catch {}
+      set({ inputMode });
     },
 
     setLocale: (locale) => {

--- a/src/voice/useVoiceInput.ts
+++ b/src/voice/useVoiceInput.ts
@@ -1,72 +1,39 @@
-import { useState, useRef, useCallback } from 'react'
-import { useVoiceStore } from '@/state/voice'
-import { bus } from '@/utils/bus'
+import { useState, useEffect, useCallback } from 'react';
+import { useVoiceStore } from '@/state/voice';
+import { voiceService } from '@/voice/voiceService';
+import { bus } from '@/utils/bus';
 
 export function useVoiceInput() {
-  const [isRecording, setIsRecording] = useState(false)
-  const [transcript, setTranscript] = useState('')
-  const pcRef = useRef<RTCPeerConnection | null>(null)
-  const channelRef = useRef<RTCDataChannel | null>(null)
-  const audioRef = useRef<HTMLAudioElement | null>(null)
+  const mode = useVoiceStore((s) => s.inputMode);
+  const isListening = useVoiceStore((s) => s.isListening);
+  const [transcript, setTranscript] = useState('');
 
-  const start = useCallback(async () => {
-    if (isRecording) return
-    const pc = new RTCPeerConnection()
-    pcRef.current = pc
+  useEffect(() => {
+    const off = bus.on('voice/transcript', ({ text }) => {
+      setTranscript(text);
+    });
+    return () => {
+      off();
+    };
+  }, []);
 
-    pc.ondatachannel = e => {
-      channelRef.current = e.channel
-      e.channel.onmessage = ev => {
-        try {
-          const msg = JSON.parse(ev.data)
-            if (msg.transcript) {
-              setTranscript(msg.transcript)
-              useVoiceStore.getState().setThinking(false)
-            }
-          if (msg.audio) {
-            const audio = new Audio('data:audio/wav;base64,' + msg.audio)
-            audio.play()
-            audioRef.current = audio
-          }
-        } catch { /* ignore */ }
-      }
-    }
+  const startListening = useCallback(() => {
+    void voiceService.startListening();
+  }, []);
 
-    pc.ontrack = ev => {
-      const audio = new Audio()
-      audio.srcObject = ev.streams[0]
-      audio.play()
-      audioRef.current = audio
-    }
+  const stopListening = useCallback(() => {
+    voiceService.stopListening();
+  }, []);
 
-    const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
-    stream.getTracks().forEach(t => pc.addTrack(t, stream))
+  useEffect(() => {
+    return () => {
+      voiceService.cancel();
+    };
+  }, []);
 
-    const offer = await pc.createOffer()
-    await pc.setLocalDescription(offer)
-    const res = await fetch('/voice', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ sdp: offer.sdp, type: offer.type })
-    })
-    const answer = await res.json()
-    await pc.setRemoteDescription(answer)
-      setIsRecording(true)
-      useVoiceStore.getState().setListening(true)
-      useVoiceStore.getState().setThinking(false)
-  }, [isRecording])
+  const cleanup = useCallback(() => {
+    voiceService.cancel();
+  }, []);
 
-  const stop = useCallback(() => {
-      channelRef.current?.close()
-      pcRef.current?.getSenders().forEach(s => s.track?.stop())
-      pcRef.current?.close()
-      pcRef.current = null
-      setIsRecording(false)
-      useVoiceStore.getState().setListening(false)
-      useVoiceStore.getState().setThinking(true)
-      bus.emit('sphere/state:set', { state: 'thinking' })
-      bus.emit('voice/state:set', { state: 'thinking' })
-  }, [])
-
-  return { startRecording: start, stopRecording: stop, transcript, setTranscript, isRecording, audioRef }
+  return { startListening, stopListening, transcript, isListening, mode, cleanup };
 }

--- a/src/voice/voiceService.ts
+++ b/src/voice/voiceService.ts
@@ -52,6 +52,7 @@ class VoiceService {
           const msg = JSON.parse(ev.data);
           if (msg.transcript) {
             useVoiceStore.getState().setThinking(false);
+            bus.emit('voice/transcript', { text: msg.transcript });
           }
           if (msg.audio) {
             const audio = new Audio('data:audio/wav;base64,' + msg.audio);


### PR DESCRIPTION
## Summary
- Replace custom WebRTC handling with `voiceService` in `useVoiceInput`
- Persist push-to-talk vs toggle preference in voice store
- Emit and consume transcript events for voice listening

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, empty block statements, and other pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e95bb63048326a382897291a9347c