### PR TITLE
feat: add configurable voice listen mode

### DIFF
--- a/src/components/chat/AnchoredChatBar.tsx
+++ b/src/components/chat/AnchoredChatBar.tsx
@@ -7,13 +7,19 @@ import { useTextToSpeech } from "@/voice/useTextToSpeech";
 import { ReactiveSphere } from "@/components/avatar/ReactiveSphere";
 import { setChatInputRef } from "@/hooks/useChatInputFocus";
 import { bus } from "@/utils/bus";
+import { useVoiceStore } from "@/state/voice";
+import {
+  startListening as startBusListening,
+  stopListening as stopBusListening,
+} from "@/voice/listenHelpers";
 
 export function AnchoredChatBar() {
   const { send, sending, messages, recall } = useChatStore();
   const { speak, blocked, resume } = useTextToSpeech();
 
   const [input, setInput] = useState("");
-  const [listening, setListening] = useState(false);
+  const listening = useVoiceStore((s) => s.isListening);
+  const listenMode = useVoiceStore((s) => s.listenMode);
   const [suggestion, setSuggestion] = useState<string | null>(null);
   const recognitionRef = useRef<SpeechRecognition | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -28,6 +34,7 @@ export function AnchoredChatBar() {
 
   useEffect(() => {
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     bus.emit('sphere/state:set', { state: 'idle' } as any);
 
   }, []);
@@ -46,7 +53,7 @@ export function AnchoredChatBar() {
         setSuggestion(transcript);
       }
     };
-    rec.onend = () => setListening(false);
+    rec.onend = () => stopBusListening();
     recognitionRef.current = rec;
     return () => {
       rec.stop();
@@ -57,11 +64,9 @@ export function AnchoredChatBar() {
   const startListening = () => {
     const rec = recognitionRef.current;
     if (!rec || listening) return;
-    setListening(true);
-    bus.emit('voice/listen:start', {});
-
+    startBusListening();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     bus.emit('sphere/state:set', { state: 'listening' } as any);
-
     rec.start();
   };
 
@@ -69,25 +74,18 @@ export function AnchoredChatBar() {
     const rec = recognitionRef.current;
     if (!rec) return;
     rec.stop();
-    bus.emit('voice/listen:stop', {});
-
+    stopBusListening();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     bus.emit('sphere/state:set', { state: 'thinking' } as any);
-
-    setListening(false);
-  };
-
-  const toggleListening = () => {
-    if (listening) stopListening();
-    else startListening();
   };
 
   const handlePressStart = () => {
     pressStartRef.current = Date.now();
-    startListening();
+    if (listenMode === 'push-to-talk') startListening();
   };
 
   const handlePressEnd = () => {
-    stopListening();
+    if (listenMode === 'push-to-talk') stopListening();
   };
 
   const handleMicClick = () => {
@@ -96,7 +94,10 @@ export function AnchoredChatBar() {
       pressStartRef.current = null;
       if (duration > 300) return;
     }
-    toggleListening();
+    if (listenMode === 'toggle') {
+      if (listening) stopListening();
+      else startListening();
+    }
   };
 
   const handleSend = (override?: string) => {

--- a/src/state/voice.ts
+++ b/src/state/voice.ts
@@ -8,6 +8,7 @@ const VOICE_EXPR_KEY = 'aurora.voiceExpression';
 const VOICE_EMOTION_KEY = 'aurora.voiceEmotion';
 const VOICE_MODE_KEY = 'aurora.voiceMode';
 const VOICE_LOCALE_KEY = 'aurora.voiceLocale';
+const VOICE_LISTEN_MODE_KEY = 'aurora.voiceListenMode';
 
 type VoiceMode =
   | 'cloned'
@@ -15,6 +16,8 @@ type VoiceMode =
   | 'browser-tts'
   | 'local-tts'
   | 'off';
+
+type ListenMode = 'push-to-talk' | 'toggle';
 
 type VoiceState = {
   isListening: boolean;
@@ -27,6 +30,7 @@ type VoiceState = {
   pitch: number;
   expression: number;
   emotion: string;
+  listenMode: ListenMode;
   setListening: (v: boolean) => void;
   setThinking: (v: boolean) => void;
   setSpeaking: (v: boolean) => void;
@@ -37,6 +41,7 @@ type VoiceState = {
   setPitch: (v: number) => void;
   setExpression: (v: number) => void;
   setEmotion: (v: string) => void;
+  setListenMode: (m: ListenMode) => void;
 };
 
 export const useVoiceStore = create<VoiceState>((set) => {
@@ -45,6 +50,13 @@ export const useVoiceStore = create<VoiceState>((set) => {
       isThinking: state === 'thinking',
       isSpeaking: state === 'speaking',
     });
+  });
+
+  bus.on('voice/listen:start', () => {
+    set({ isListening: true });
+  });
+  bus.on('voice/listen:stop', () => {
+    set({ isListening: false });
   });
 
   const hasWindow = typeof window !== 'undefined';
@@ -68,6 +80,9 @@ export const useVoiceStore = create<VoiceState>((set) => {
     emotion: hasWindow
       ? ls!.getItem(VOICE_EMOTION_KEY) || 'neutral'
       : 'neutral',
+    listenMode: hasWindow
+      ? ((ls!.getItem(VOICE_LISTEN_MODE_KEY) as ListenMode) || 'push-to-talk')
+      : 'push-to-talk',
 
     setListening: (v) => set({ isListening: v }),
     setThinking: (v) => set({ isThinking: v }),
@@ -77,7 +92,9 @@ export const useVoiceStore = create<VoiceState>((set) => {
       try {
         if (id) ls?.setItem(VOICE_ID_KEY, id);
         else ls?.removeItem(VOICE_ID_KEY);
-      } catch {}
+      } catch {
+        /* empty */
+      }
       set({ voiceId: id });
     },
 
@@ -85,7 +102,9 @@ export const useVoiceStore = create<VoiceState>((set) => {
       if (persist) {
         try {
           ls?.setItem(VOICE_MODE_KEY, mode);
-        } catch {}
+        } catch {
+          /* empty */
+        }
       }
       set({ mode });
     },
@@ -93,36 +112,55 @@ export const useVoiceStore = create<VoiceState>((set) => {
     setLocale: (locale) => {
       try {
         ls?.setItem(VOICE_LOCALE_KEY, locale);
-      } catch {}
+      } catch {
+        /* empty */
+      }
       set({ locale });
     },
 
     setSpeed: (speed) => {
       try {
         ls?.setItem(VOICE_SPEED_KEY, String(speed));
-      } catch {}
+      } catch {
+        /* empty */
+      }
       set({ speed });
     },
 
     setPitch: (pitch) => {
       try {
         ls?.setItem(VOICE_PITCH_KEY, String(pitch));
-      } catch {}
+      } catch {
+        /* empty */
+      }
       set({ pitch });
     },
 
     setExpression: (expression) => {
       try {
         ls?.setItem(VOICE_EXPR_KEY, String(expression));
-      } catch {}
+      } catch {
+        /* empty */
+      }
       set({ expression });
     },
 
     setEmotion: (emotion) => {
       try {
         ls?.setItem(VOICE_EMOTION_KEY, emotion);
-      } catch {}
+      } catch {
+        /* empty */
+      }
       set({ emotion });
+    },
+
+    setListenMode: (listenMode) => {
+      try {
+        ls?.setItem(VOICE_LISTEN_MODE_KEY, listenMode);
+      } catch {
+        /* empty */
+      }
+      set({ listenMode });
     }, // <- no extra comma after the last property
   };
 });

--- a/src/voice/listenHelpers.ts
+++ b/src/voice/listenHelpers.ts
@@ -1,0 +1,34 @@
+import { bus } from '@/utils/bus';
+import { useVoiceStore } from '@/state/voice';
+
+export const startListening = () => {
+  bus.emit('voice/listen:start', {});
+};
+
+export const stopListening = () => {
+  bus.emit('voice/listen:stop', {});
+};
+
+export const toggleListening = () => {
+  const { isListening } = useVoiceStore.getState();
+  if (isListening) stopListening();
+  else startListening();
+};
+
+export const handleListenPressStart = () => {
+  if (useVoiceStore.getState().listenMode === 'push-to-talk') {
+    startListening();
+  }
+};
+
+export const handleListenPressEnd = () => {
+  if (useVoiceStore.getState().listenMode === 'push-to-talk') {
+    stopListening();
+  }
+};
+
+export const handleListenClick = () => {
+  if (useVoiceStore.getState().listenMode === 'toggle') {
+    toggleListening();
+  }
+};

--- a/voice/README.md
+++ b/voice/README.md
@@ -4,6 +4,16 @@ This package provides speech-to-text (STT) and text-to-speech (TTS) utilities
 for the Aurora project.  By default it uses [Whisper](https://github.com/openai/whisper)
 for transcription and streams results to the client over WebRTC.
 
+## Listening modes
+
+The frontend supports two listening modes for voice input:
+
+- `push-to-talk` – hold the microphone button to listen (default).
+- `toggle` – tap the microphone button to start or stop listening.
+
+The selected mode is persisted in `localStorage` under `aurora.voiceListenMode`
+so existing behaviour remains `push-to-talk` unless changed by the user.
+
 ## Configuring Whisper Model Size
 
 The STT pipeline loads a Whisper model at import time.  You can adjust the


### PR DESCRIPTION
## Summary
- add listenMode with persistence and bus-driven state updates
- create voice listening helpers for push-to-talk and toggle modes
- document listening mode defaults

## Testing
- `npm run lint` *(fails: Unexpected any, Empty block statement, etc.)*
- `npx eslint src/state/voice.ts src/components/chat/AnchoredChatBar.tsx src/voice/listenHelpers.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e95c4bd2c8326b19f043aacef7956