### PR TITLE
Refactor voice input to use centralized voice service

### DIFF
--- a/src/state/types/chatEvents.ts
+++ b/src/state/types/chatEvents.ts
@@ -15,5 +15,6 @@ export type ChatEvents = {
   'voice/state:set': { state: 'thinking' | 'speaking' };
   'voice/listen:start': {};
   'voice/listen:stop': {};
+  'voice/listen:transcript': { text: string };
 };
 

--- a/src/state/voice.ts
+++ b/src/state/voice.ts
@@ -8,6 +8,7 @@ const VOICE_EXPR_KEY = 'aurora.voiceExpression';
 const VOICE_EMOTION_KEY = 'aurora.voiceEmotion';
 const VOICE_MODE_KEY = 'aurora.voiceMode';
 const VOICE_LOCALE_KEY = 'aurora.voiceLocale';
+const VOICE_INPUT_MODE_KEY = 'aurora.voiceInputMode';
 
 type VoiceMode =
   | 'cloned'
@@ -27,6 +28,7 @@ type VoiceState = {
   pitch: number;
   expression: number;
   emotion: string;
+  inputMode: 'push-to-talk' | 'toggle';
   setListening: (v: boolean) => void;
   setThinking: (v: boolean) => void;
   setSpeaking: (v: boolean) => void;
@@ -37,6 +39,7 @@ type VoiceState = {
   setPitch: (v: number) => void;
   setExpression: (v: number) => void;
   setEmotion: (v: string) => void;
+  setInputMode: (m: 'push-to-talk' | 'toggle') => void;
 };
 
 export const useVoiceStore = create<VoiceState>((set) => {
@@ -68,6 +71,10 @@ export const useVoiceStore = create<VoiceState>((set) => {
     emotion: hasWindow
       ? ls!.getItem(VOICE_EMOTION_KEY) || 'neutral'
       : 'neutral',
+    inputMode: hasWindow
+      ? (ls!.getItem(VOICE_INPUT_MODE_KEY) as 'push-to-talk' | 'toggle') ||
+        'push-to-talk'
+      : 'push-to-talk',
 
     setListening: (v) => set({ isListening: v }),
     setThinking: (v) => set({ isThinking: v }),
@@ -123,6 +130,13 @@ export const useVoiceStore = create<VoiceState>((set) => {
         ls?.setItem(VOICE_EMOTION_KEY, emotion);
       } catch {}
       set({ emotion });
-    }, // <- no extra comma after the last property
+    },
+
+    setInputMode: (inputMode) => {
+      try {
+        ls?.setItem(VOICE_INPUT_MODE_KEY, inputMode);
+      } catch {}
+      set({ inputMode });
+    } // <- no extra comma after the last property
   };
 });

--- a/src/voice/useVoiceInput.ts
+++ b/src/voice/useVoiceInput.ts
@@ -1,72 +1,51 @@
-import { useState, useRef, useCallback } from 'react'
-import { useVoiceStore } from '@/state/voice'
-import { bus } from '@/utils/bus'
+import { useState, useEffect, useCallback } from 'react';
+import { useVoiceStore } from '@/state/voice';
+import { bus } from '@/utils/bus';
+import { voiceService } from '@/voice/voiceService';
 
 export function useVoiceInput() {
-  const [isRecording, setIsRecording] = useState(false)
-  const [transcript, setTranscript] = useState('')
-  const pcRef = useRef<RTCPeerConnection | null>(null)
-  const channelRef = useRef<RTCDataChannel | null>(null)
-  const audioRef = useRef<HTMLAudioElement | null>(null)
+  const mode = useVoiceStore((s) => s.inputMode);
+  const isListening = useVoiceStore((s) => s.isListening);
+  const [transcript, setTranscript] = useState('');
 
-  const start = useCallback(async () => {
-    if (isRecording) return
-    const pc = new RTCPeerConnection()
-    pcRef.current = pc
+  useEffect(() => {
+    const handler = ({ text }: { text: string }) => setTranscript(text);
+    const off = bus.on('voice/listen:transcript', handler);
+    return () => {
+      off();
+      voiceService.stopListening();
+      voiceService.cancel();
+    };
+  }, []);
 
-    pc.ondatachannel = e => {
-      channelRef.current = e.channel
-      e.channel.onmessage = ev => {
-        try {
-          const msg = JSON.parse(ev.data)
-            if (msg.transcript) {
-              setTranscript(msg.transcript)
-              useVoiceStore.getState().setThinking(false)
-            }
-          if (msg.audio) {
-            const audio = new Audio('data:audio/wav;base64,' + msg.audio)
-            audio.play()
-            audioRef.current = audio
-          }
-        } catch { /* ignore */ }
-      }
-    }
-
-    pc.ontrack = ev => {
-      const audio = new Audio()
-      audio.srcObject = ev.streams[0]
-      audio.play()
-      audioRef.current = audio
-    }
-
-    const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
-    stream.getTracks().forEach(t => pc.addTrack(t, stream))
-
-    const offer = await pc.createOffer()
-    await pc.setLocalDescription(offer)
-    const res = await fetch('/voice', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ sdp: offer.sdp, type: offer.type })
-    })
-    const answer = await res.json()
-    await pc.setRemoteDescription(answer)
-      setIsRecording(true)
-      useVoiceStore.getState().setListening(true)
-      useVoiceStore.getState().setThinking(false)
-  }, [isRecording])
+  const start = useCallback(() => {
+    void voiceService.startListening();
+  }, []);
 
   const stop = useCallback(() => {
-      channelRef.current?.close()
-      pcRef.current?.getSenders().forEach(s => s.track?.stop())
-      pcRef.current?.close()
-      pcRef.current = null
-      setIsRecording(false)
-      useVoiceStore.getState().setListening(false)
-      useVoiceStore.getState().setThinking(true)
-      bus.emit('sphere/state:set', { state: 'thinking' })
-      bus.emit('voice/state:set', { state: 'thinking' })
-  }, [])
+    voiceService.stopListening();
+  }, []);
 
-  return { startRecording: start, stopRecording: stop, transcript, setTranscript, isRecording, audioRef }
+  const toggle = useCallback(() => {
+    if (useVoiceStore.getState().isListening) voiceService.stopListening();
+    else void voiceService.startListening();
+  }, []);
+
+  const handlePress = useCallback(() => {
+    if (mode === 'push-to-talk') start();
+    else toggle();
+  }, [mode, start, toggle]);
+
+  const handleRelease = useCallback(() => {
+    if (mode === 'push-to-talk') stop();
+  }, [mode, stop]);
+
+  return {
+    transcript,
+    isListening,
+    startListening: handlePress,
+    stopListening: handleRelease,
+    cleanup: stop,
+  } as const;
 }
+

--- a/src/voice/voiceService.ts
+++ b/src/voice/voiceService.ts
@@ -52,6 +52,7 @@ class VoiceService {
           const msg = JSON.parse(ev.data);
           if (msg.transcript) {
             useVoiceStore.getState().setThinking(false);
+            bus.emit('voice/listen:transcript', { text: msg.transcript });
           }
           if (msg.audio) {
             const audio = new Audio('data:audio/wav;base64,' + msg.audio);


### PR DESCRIPTION
## Summary
- Emit transcripts from `voiceService` through the event bus
- Track microphone control mode in `useVoiceStore`
- Replace WebRTC code with service calls in `useVoiceInput`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e95cdf9cc8326a755b2102c0e5ecd