### PR TITLE
Refactor TTS to use voice service

### DIFF
--- a/src/pages/OnboardingFlow.tsx
+++ b/src/pages/OnboardingFlow.tsx
@@ -111,7 +111,7 @@ export default function OnboardingFlow() {
   const navigate = useNavigate();
 
   // SINGLE instance
-  const { speak, cancel, isSpeaking, enabled, enable } = useTextToSpeech();
+  const { speak, cancel, isSpeaking } = useTextToSpeech();
 
   const getInitialState = () => {
     if (typeof window === "undefined") return {};
@@ -198,9 +198,9 @@ export default function OnboardingFlow() {
   // Speak assistant messages as they appear
   useEffect(() => {
     const last = messages[messages.length - 1];
-    if (enabled && last?.role === "assistant") speak(last.content);
+    if (last?.role === "assistant") speak(last.content);
     return cancel;
-  }, [messages, enabled, speak, cancel]);
+  }, [messages, speak, cancel]);
 
   // Scroll to latest message
   useEffect(() => {
@@ -444,14 +444,14 @@ export default function OnboardingFlow() {
               placeholder="Your answer..."
               className="resize-none"
               onFocus={() => {
-                if (!enabled) enable();
+                /* voice enabled via service */
               }}
             />
             <Button
               type="submit"
               className="self-end"
               onClick={() => {
-                if (!enabled) enable();
+                /* voice enabled via service */
               }}
             >
               Continue

--- a/src/state/chat.ts
+++ b/src/state/chat.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import { auroraChatStream } from "@/utils/auroraChat";
 import type { ChatMessage } from "@/types/chat";
 import { useAvatarStore } from "@/state/avatar";
-import { VoiceIO } from "@/voice/voiceio";
+import { voiceService } from "@/voice/voiceService";
 import {
   memoryStore,
   retrieveRelevantMemories,
@@ -20,7 +20,7 @@ type ChatState = {
   send: (content: string) => Promise<void>;
 };
 
-const voice = typeof window !== "undefined" ? new VoiceIO() : null;
+// VoiceService handles TTS internally
 
 export const useChatStore = create<ChatState>((set, get) => ({
   messages: [],
@@ -85,7 +85,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       useAvatarStore.getState().setSentiment(sentiment);
       bus.emit('chat/stream:end', { id: responseId });
       set({ sending: false });
-      voice?.speak(fullText);
+      void voiceService.speak(fullText);
       memoryStore.add("episodic", "assistant", fullText).catch(() => {});
       saveMemory(fullText, { role: "assistant" }).catch(() => {});
     } catch (error) {

--- a/src/state/types/chatEvents.ts
+++ b/src/state/types/chatEvents.ts
@@ -16,5 +16,6 @@ export type ChatEvents = {
   'voice/listen:start': {};
   'voice/listen:stop': {};
   'voice/transcript': { text: string };
+  'voice/playback:blocked': { callback: (() => void) | null };
 };
 

--- a/src/voice/useTextToSpeech.ts
+++ b/src/voice/useTextToSpeech.ts
@@ -1,275 +1,31 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { useVoiceStore } from "@/state/voice";
-import { playClonedVoice } from "./voiceClone";
-import { ttsFallbackToast } from "@/voice/ttsFallbackToast";
-import { ttsAutoplayToast } from "@/voice/ttsAutoplayToast";
-import { useSubscription } from "@/modules/payments/hooks/useSubscription";
-import { guardPremiumAction } from "@/modules/payments/guard";
-import { bus } from "@/utils/bus";
-
-const ELEVENLABS_DEFAULT_VOICE_ID =
-  import.meta.env.VITE_ELEVENLABS_DEFAULT_VOICE_ID ||
-  "21m00Tcm4TlvDq8ikWAM"; // Rachel (stock voice)
+import { useCallback, useEffect, useState } from 'react';
+import { useVoiceStore } from '@/state/voice';
+import { voiceService } from '@/voice/voiceService';
+import { bus } from '@/utils/bus';
 
 export function useTextToSpeech() {
-  const [isSpeaking, setIsSpeaking] = useState(false);
-  const [enabled, setEnabled] = useState<boolean>(() => {
-    return localStorage.getItem("aurora_voice_enabled") === "1";
-  });
-  const utterRef = useRef<SpeechSynthesisUtterance | null>(null);
-  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const isSpeaking = useVoiceStore((s) => s.isSpeaking);
   const [blocked, setBlocked] = useState<(() => void) | null>(null);
-  const { voiceId, speed, pitch, expression, emotion, mode, setMode } =
 
-    useVoiceStore((s) => ({
-      voiceId: s.voiceId,
-      speed: s.speed,
-      pitch: s.pitch,
-      expression: s.expression,
-      emotion: s.emotion,
-      mode: s.mode,
-      setMode: s.setMode,
-
-    }));
-  const { canAccessFeature } = useSubscription();
-
-  // Allow enabling via first user gesture (click/keydown) OR explicit call
   useEffect(() => {
-    if (enabled) return;
-    const prime = () => {
-      setEnabled(true);
-      localStorage.setItem("aurora_voice_enabled", "1");
-      try {
-        window.speechSynthesis.getVoices();
-        window.speechSynthesis.resume();
-      } catch {
-        /* ignore */
-      }
-    };
-    window.addEventListener("pointerdown", prime, { once: true });
-    window.addEventListener("keydown", prime, { once: true });
-    return () => {
-      window.removeEventListener("pointerdown", prime);
-      window.removeEventListener("keydown", prime);
-    };
-  }, [enabled]);
-
-  const enable = useCallback(() => {
-    setEnabled(true);
-    localStorage.setItem("aurora_voice_enabled", "1");
-    try {
-      window.speechSynthesis.getVoices();
-      window.speechSynthesis.resume();
-    } catch {
-      /* ignore */
-    }
+    setBlocked(voiceService.getBlockedCallback());
+    const off = bus.on('voice/playback:blocked', ({ callback }) => {
+      setBlocked(callback);
+    });
+    return () => off();
   }, []);
 
-  const speak = useCallback(
-    async (text: string) => {
-      if (!text?.trim()) return;
-      setBlocked(null);
-      if (!enabled) {
-        ttsAutoplayToast();
-        const resume = () => {
-          enable();
-          void speak(text);
-        };
-        window.addEventListener("pointerdown", resume, { once: true });
-        window.addEventListener("keydown", resume, { once: true });
-        return;
-      }
-      bus.emit('sphere/state:set', { state: 'thinking' });
-      bus.emit('voice/state:set', { state: 'thinking' });
-
-      let current = mode;
-      const locale = navigator.language;
-
-      while (current && current !== "off") {
-        if (current === "cloned") {
-          const result = await guardPremiumAction(
-            canAccessFeature,
-            "voice_features",
-            "voice_clone",
-            "use the default voice instead",
-          );
-          if (result === null) {
-            bus.emit('sphere/state:set', { state: 'thinking' });
-            bus.emit('voice/state:set', { state: 'thinking' });
-            return;
-          }
-          if (result === 'free') {
-            current = "eleven-default";
-            setMode("eleven-default", false);
-            continue;
-          }
-          if (!voiceId) {
-            current = "eleven-default";
-            setMode("eleven-default", false);
-            continue;
-          }
-            const { audio, error } = await playClonedVoice(text, voiceId, {
-              emotion,
-              speed,
-              pitch,
-              expression,
-              onStart: () => {
-                bus.emit('sphere/state:set', { state: 'speaking' });
-                bus.emit('voice/state:set', { state: 'speaking' });
-                setIsSpeaking(true);
-              },
-              onEnd: () => {
-                bus.emit('sphere/state:set', { state: 'thinking' });
-                bus.emit('voice/state:set', { state: 'thinking' });
-                setIsSpeaking(false);
-              },
-            });
-          if (audio) {
-            audioRef.current = audio;
-            if ((error as { name?: string } | undefined)?.name === "NotAllowedError") {
-              bus.emit('sphere/state:set', { state: 'thinking' });
-              bus.emit('voice/state:set', { state: 'thinking' });
-              ttsAutoplayToast();
-              setBlocked(() => () => {
-                audio.play().catch(() => {});
-              });
-            }
-            return;
-          }
-          const status = (error as { status?: number } | undefined)?.status;
-          if (status === 401 || status === 429) ttsFallbackToast();
-          current = "eleven-default";
-          setMode("eleven-default", false);
-          continue;
-        }
-        if (current === "eleven-default") {
-          const { audio, error } = await playClonedVoice(
-            text,
-            ELEVENLABS_DEFAULT_VOICE_ID,
-            {
-              emotion,
-              speed,
-              pitch,
-              expression,
-              onStart: () => {
-                bus.emit('sphere/state:set', { state: 'speaking' });
-                bus.emit('voice/state:set', { state: 'speaking' });
-                setIsSpeaking(true);
-              },
-              onEnd: () => {
-                bus.emit('sphere/state:set', { state: 'thinking' });
-                bus.emit('voice/state:set', { state: 'thinking' });
-                setIsSpeaking(false);
-              },
-            },
-          );
-          if (audio) {
-            audioRef.current = audio;
-            if ((error as { name?: string } | undefined)?.name === "NotAllowedError") {
-              bus.emit('sphere/state:set', { state: 'thinking' });
-              bus.emit('voice/state:set', { state: 'thinking' });
-              ttsAutoplayToast();
-              setBlocked(() => () => {
-                audio.play().catch(() => {});
-              });
-            }
-            return;
-          }
-          current = "browser-tts";
-          setMode("browser-tts", false);
-          ttsFallbackToast();
-          continue;
-        }
-        if (current === "browser-tts") {
-          try {
-            window.speechSynthesis.cancel();
-            let voices = window.speechSynthesis.getVoices();
-            if (!voices.length) {
-              await new Promise((r) => setTimeout(r, 250));
-              voices = window.speechSynthesis.getVoices();
-            }
-            const v = voices.find(
-              (vo) =>
-                vo.lang === locale ||
-                vo.lang.startsWith(locale.split("-")[0]),
-            );
-            if (!v) {
-              current = "off";
-              setMode("off", false);
-              continue;
-            }
-            const u = new SpeechSynthesisUtterance(text);
-            utterRef.current = u;
-            u.voice = v;
-            u.rate = speed;
-            u.pitch = pitch;
-            u.onstart = () => {
-              bus.emit('sphere/state:set', { state: 'speaking' });
-              bus.emit('voice/state:set', { state: 'speaking' });
-              setIsSpeaking(true);
-            };
-            u.onend = () => {
-              bus.emit('sphere/state:set', { state: 'thinking' });
-              bus.emit('voice/state:set', { state: 'thinking' });
-              setIsSpeaking(false);
-            };
-            u.onerror = () => {
-              bus.emit('sphere/state:set', { state: 'thinking' });
-              bus.emit('voice/state:set', { state: 'thinking' });
-              setIsSpeaking(false);
-            };
-            try {
-              window.speechSynthesis.speak(u);
-            } catch (err) {
-              bus.emit('sphere/state:set', { state: 'thinking' });
-              bus.emit('voice/state:set', { state: 'thinking' });
-              if ((err as { name?: string } | undefined)?.name === "NotAllowedError") {
-                ttsAutoplayToast();
-                setBlocked(() => () => {
-                  window.speechSynthesis.speak(u);
-                });
-              }
-              return;
-            }
-            return;
-          } catch {
-            current = "off";
-            setMode("off", false);
-            continue;
-          }
-        }
-        if (current === "local-tts") {
-          current = "off";
-          setMode("off", false);
-          continue;
-        }
-      }
-      bus.emit('sphere/state:set', { state: 'thinking' });
-      bus.emit('voice/state:set', { state: 'thinking' });
-    },
-    [enabled, mode, voiceId, emotion, speed, pitch, expression, setMode, enable, canAccessFeature],
-
-  );
+  const speak = useCallback((text: string) => {
+    void voiceService.speak(text);
+  }, []);
 
   const cancel = useCallback(() => {
-    try { audioRef.current?.pause(); } catch { /* ignore */ }
-    audioRef.current = null;
-    try {
-      window.speechSynthesis.cancel();
-    } catch {
-      /* ignore */
-    }
-    setBlocked(null);
-    setIsSpeaking(false);
+    voiceService.cancel();
   }, []);
 
   const resume = useCallback(() => {
-    if (blocked) {
-      blocked();
-      setBlocked(null);
-    }
-  }, [blocked]);
+    voiceService.resume();
+  }, []);
 
-  return { speak, cancel, isSpeaking, enabled, enable, blocked: !!blocked, resume };
+  return { speak, cancel, isSpeaking, blocked: !!blocked, resume };
 }
-

--- a/src/voice/voiceService.ts
+++ b/src/voice/voiceService.ts
@@ -22,21 +22,25 @@ class VoiceService {
   constructor() {
     if (typeof window !== 'undefined') {
       this.enabled = localStorage.getItem('aurora_voice_enabled') === '1';
-      const enable = () => {
-        this.enabled = true;
-        localStorage.setItem('aurora_voice_enabled', '1');
-        try {
-          window.speechSynthesis.getVoices();
-          window.speechSynthesis.resume();
-        } catch {
-          /* ignore */
-        }
-      };
+      const enable = () => this.enable();
       if (!this.enabled) {
         window.addEventListener('pointerdown', enable, { once: true });
         window.addEventListener('keydown', enable, { once: true });
       }
       window.addEventListener('beforeunload', () => this.cancel());
+    }
+  }
+
+  enable() {
+    this.enabled = true;
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('aurora_voice_enabled', '1');
+      try {
+        window.speechSynthesis.getVoices();
+        window.speechSynthesis.resume();
+      } catch {
+        /* ignore */
+      }
     }
   }
 
@@ -63,6 +67,7 @@ class VoiceService {
                 this.blocked = () => {
                   audio.play().catch(() => {});
                 };
+                bus.emit('voice/playback:blocked', { callback: this.blocked });
               }
             });
           }
@@ -113,11 +118,11 @@ class VoiceService {
   async speak(text: string) {
     if (!text?.trim()) return;
     this.blocked = null;
+    bus.emit('voice/playback:blocked', { callback: null });
     if (!this.enabled) {
       ttsAutoplayToast();
       const resume = () => {
-        this.enabled = true;
-        localStorage.setItem('aurora_voice_enabled', '1');
+        this.enable();
         void this.speak(text);
       };
       window.addEventListener('pointerdown', resume, { once: true });
@@ -185,6 +190,7 @@ class VoiceService {
             this.blocked = () => {
               audio.play().catch(() => {});
             };
+            bus.emit('voice/playback:blocked', { callback: this.blocked });
           }
           return;
         }
@@ -222,6 +228,7 @@ class VoiceService {
             this.blocked = () => {
               audio.play().catch(() => {});
             };
+            bus.emit('voice/playback:blocked', { callback: this.blocked });
           }
           return;
         }
@@ -259,7 +266,18 @@ class VoiceService {
             bus.emit('voice/state:set', { state: 'thinking' });
           };
           this.utter = utter;
-          window.speechSynthesis.speak(utter);
+          try {
+            window.speechSynthesis.speak(utter);
+          } catch (err) {
+            if ((err as { name?: string } | undefined)?.name === 'NotAllowedError') {
+              ttsAutoplayToast();
+              this.blocked = () => {
+                window.speechSynthesis.speak(utter);
+              };
+              bus.emit('voice/playback:blocked', { callback: this.blocked });
+            }
+            return;
+          }
           return;
         } catch {
           current = 'off';
@@ -294,8 +312,18 @@ class VoiceService {
       this.utter = null;
     }
     this.blocked = null;
+    bus.emit('voice/playback:blocked', { callback: null });
     useVoiceStore.getState().setListening(false);
     useVoiceStore.getState().setSpeaking(false);
+  }
+
+  resume() {
+    if (this.blocked) {
+      const cb = this.blocked;
+      this.blocked = null;
+      bus.emit('voice/playback:blocked', { callback: null });
+      cb();
+    }
   }
 
   getBlockedCallback() {

--- a/src/voice/voiceio.ts
+++ b/src/voice/voiceio.ts
@@ -1,9 +1,6 @@
-import { useVoiceStore } from "@/state/voice";
-import { supabase } from "@/integrations/supabase/client";
-import { useAvatarStore } from "@/state/avatar";
-import { playClonedVoice } from "./voiceClone";
-import { ttsFallbackToast } from "@/voice/ttsFallbackToast";
-import { bus } from "@/utils/bus";
+import { useVoiceStore } from '@/state/voice';
+import { voiceService } from '@/voice/voiceService';
+import { bus } from '@/utils/bus';
 
 export type VoiceCallbacks = {
   onPartial?: (text: string) => void;
@@ -14,12 +11,13 @@ export type VoiceCallbacks = {
 
 export class VoiceIO {
   private recognition: SpeechRecognition | null = null;
-  private utter: SpeechSynthesisUtterance | null = null;
-  private audio: HTMLAudioElement | null = null;
   private callbacks: VoiceCallbacks;
 
   constructor(callbacks: VoiceCallbacks = {}) {
     this.callbacks = callbacks;
+    bus.on('voice/state:set', ({ state }) => {
+      this.callbacks.onSpeakingChange?.(state === 'speaking');
+    });
   }
 
   startPushToTalk() {
@@ -62,8 +60,8 @@ export class VoiceIO {
       this.recognition.start();
       useVoiceStore.getState().setListening(true);
       useVoiceStore.getState().setThinking(false);
-    } catch (e) {
-      // starting while already started throws
+    } catch {
+      // ignore
     }
   }
 
@@ -74,126 +72,10 @@ export class VoiceIO {
   }
 
   async speak(text: string) {
-    const state = useVoiceStore.getState();
-    let { voiceId, mode, locale, speed, pitch, expression, emotion } = state;
-    let success = false;
-
-    const onStart = () => {
-      bus.emit('sphere/state:set', { state: 'speaking' });
-      bus.emit('voice/state:set', { state: 'speaking' });
-      useVoiceStore.getState().setSpeaking(true);
-      this.callbacks.onSpeakingChange?.(true);
-    };
-    const onEnd = () => {
-      bus.emit('sphere/state:set', { state: 'thinking' });
-      bus.emit('voice/state:set', { state: 'thinking' });
-      useVoiceStore.getState().setSpeaking(false);
-      this.callbacks.onSpeakingChange?.(false);
-      useAvatarStore.getState().setAudio(null);
-      useAvatarStore.getState().setSentiment(0);
-    };
-
-    const tryCloned = async () => {
-      if (!voiceId) return false;
-      const audio = await playClonedVoice(text, voiceId, {
-        emotion,
-        speed,
-        pitch,
-        expression,
-        onStart,
-        onEnd,
-      });
-      if (audio) {
-        this.audio = audio;
-        useAvatarStore.getState().setAudio(audio);
-        return true;
-      }
-      return false;
-    };
-
-    const tryEleven = async () => {
-      try {
-        const { data, error } = await supabase.functions.invoke("tts-generate", {
-          body: { text, emotion, speed, pitch, expression },
-        });
-        if (!error && data?.audioBase64) {
-          const src = `data:${data.contentType};base64,${data.audioBase64}`;
-          const audio = new Audio(src);
-          this.audio = audio;
-          useAvatarStore.getState().setAudio(audio);
-          audio.onplay = onStart;
-          const end = () => {
-            onEnd();
-          };
-          audio.onended = end;
-          audio.onerror = (e) => {
-            end();
-            this.callbacks.onError?.(e);
-          };
-          await audio.play();
-          return true;
-        }
-      } catch (e) {
-        this.callbacks.onError?.(e);
-      }
-      return false;
-    };
-
-    const tryBrowser = () => {
-      if (!("speechSynthesis" in window)) return false;
-      const u = new SpeechSynthesisUtterance(text);
-      u.lang = locale;
-      u.rate = speed;
-      u.pitch = pitch;
-      u.onstart = onStart;
-      const end = () => {
-        onEnd();
-      };
-      u.onend = end;
-      u.onerror = (e) => {
-        end();
-        this.callbacks.onError?.(e);
-      };
-      speechSynthesis.speak(u);
-      this.utter = u;
-      return true;
-    };
-
-    let currentMode = mode;
-
-    if (currentMode === "cloned") {
-      success = await tryCloned();
-      if (!success) {
-        useVoiceStore.getState().setMode("eleven-default");
-        currentMode = "eleven-default";
-        if (voiceId) ttsFallbackToast();
-      }
-    }
-
-    if (!success && currentMode === "eleven-default") {
-      success = await tryEleven();
-      if (!success) {
-        useVoiceStore.getState().setMode("browser-tts");
-        currentMode = "browser-tts";
-        ttsFallbackToast();
-      }
-    }
-
-    if (!success) {
-      tryBrowser();
-    }
+    await voiceService.speak(text);
   }
 
   stopSpeaking() {
-    try { this.audio?.pause(); } catch {}
-    this.audio = null;
-    useAvatarStore.getState().setAudio(null);
-    useAvatarStore.getState().setSentiment(0);
-    try { window.speechSynthesis.cancel(); } catch {}
-    bus.emit('sphere/state:set', { state: 'thinking' });
-    bus.emit('voice/state:set', { state: 'thinking' });
-    useVoiceStore.getState().setSpeaking(false);
-    this.callbacks.onSpeakingChange?.(false);
-    this.utter = null;
+    voiceService.cancel();
   }
 }


### PR DESCRIPTION
## Summary
- Replace custom text-to-speech hook with voiceService.speak/cancel and new resume support
- Emit playback blocked events from voiceService to drive autoplay toast and tap-to-play pill
- Update chat and onboarding flows to use the unified voiceService API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e781eeed88326bcb4ea53057f96b8