### PR TITLE
Handle blocked TTS playback with resume option

### DIFF
--- a/src/pages/OnboardingFlow.tsx
+++ b/src/pages/OnboardingFlow.tsx
@@ -15,6 +15,7 @@ import {
   saveProfile,
 } from "@/data/profile";
 import { setEncryptionKey } from "@/state/encryption";
+import { Volume2 } from "lucide-react";
 
 
 type Msg = { role: "assistant" | "user"; content: string };
@@ -111,7 +112,7 @@ export default function OnboardingFlow() {
   const navigate = useNavigate();
 
   // SINGLE instance
-  const { speak, cancel, isSpeaking } = useTextToSpeech();
+  const { speak, cancel, isSpeaking, blocked, resume } = useTextToSpeech();
 
   const getInitialState = () => {
     if (typeof window === "undefined") return {};
@@ -404,6 +405,16 @@ export default function OnboardingFlow() {
       <div className="relative z-10 flex h-full flex-col">
         <div className="flex-shrink-0 flex flex-col items-center gap-4 p-4">
           <EvolvingSphere size={220} speaking={isSpeaking} />
+          {blocked && (
+            <button
+              type="button"
+              onClick={resume}
+              className="px-3 py-1 rounded-full bg-secondary text-secondary-foreground text-xs flex items-center gap-1"
+            >
+              <Volume2 className="w-3 h-3" />
+              Tap to play
+            </button>
+          )}
           <div className="relative w-full">
             <Progress value={progressPercent} />
             <div className="pointer-events-none absolute inset-0 grid place-items-center">

--- a/src/voice/voiceService.ts
+++ b/src/voice/voiceService.ts
@@ -122,9 +122,13 @@ class VoiceService {
     if (!this.enabled) {
       ttsAutoplayToast();
       const resume = () => {
+        window.removeEventListener('pointerdown', resume);
+        window.removeEventListener('keydown', resume);
         this.enable();
         void this.speak(text);
       };
+      this.blocked = resume;
+      bus.emit('voice/playback:blocked', { callback: this.blocked });
       window.addEventListener('pointerdown', resume, { once: true });
       window.addEventListener('keydown', resume, { once: true });
       return;


### PR DESCRIPTION
## Summary
- Detect TTS autoplay blocks in `voiceService.speak` and store a resume callback while showing a toast
- Surface a `blocked` flag to UI via `useTextToSpeech` and display a "Tap to play" pill in onboarding

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, Empty block statement, A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689ed0aafe648326b896fd554e576b77