### PR TITLE
feat: add home snapshot page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import HypnoShell from "@/routes/hypno/HypnoShell";
 import ExtensionPage from "@/pages/Extension";
 import StackPage from "./pages/Stack";
 import AccountPlanPage from "./pages/AccountPlan";
+import HomeSnapshot from "./pages/HomeSnapshot";
 import AppShell from "@/routes/AppShell";
 import HomeView from "@/views/HomeView";
 import { views } from "@/views/registry";
@@ -38,6 +39,7 @@ function AppRoutesWithShell() {
         <Route path="/extension" element={<ExtensionPage />} />
         <Route path="/stack" element={<StackPage />} />
         <Route path="/plan" element={<AccountPlanPage />} />
+        <Route path="/home" element={<HomeSnapshot />} />
         {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
         <Route path="*" element={<NotFound />} />
       </Route>
@@ -64,6 +66,7 @@ function LegacyRoutes() {
       <Route path="/extension" element={<ExtensionPage />} />
       <Route path="/stack" element={<StackPage />} />
       <Route path="/plan" element={<AccountPlanPage />} />
+      <Route path="/home" element={<HomeSnapshot />} />
       {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
       <Route path="*" element={<NotFound />} />
     </Routes>

--- a/src/components/quick/QuickPodsRow.tsx
+++ b/src/components/quick/QuickPodsRow.tsx
@@ -1,0 +1,30 @@
+import { Target, Waves, StickyNote, Mic, type LucideIcon } from "lucide-react";
+import { useHUDActions } from "@/game/hud/useHUDActions";
+import type { QuickActionKey } from "@/game/hud/hud.data";
+
+const pods: { action: QuickActionKey; label: string; icon: LucideIcon }[] = [
+  { action: "startFocus", label: "Focus", icon: Target },
+  { action: "startHypnosis", label: "Hypno", icon: Waves },
+  { action: "addNote", label: "Notes", icon: StickyNote },
+  { action: "voiceNote", label: "Voice", icon: Mic },
+];
+
+export function QuickPodsRow() {
+  const { run } = useHUDActions();
+  return (
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+      {pods.map((p) => (
+        <button
+          key={p.action}
+          onClick={() => run(p.action)}
+          className="glass-panel rounded-xl p-4 flex flex-col items-center gap-2 hover-scale"
+        >
+          <p.icon className="w-6 h-6" />
+          <span className="text-sm font-medium">{p.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default QuickPodsRow;

--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -10,6 +10,7 @@ export type GameState = {
   mood: "Calm" | "Focused" | "Confident" | "Stressed" | "Tired";
   quests: Record<string, boolean>;
   mission: { title: string; description: string };
+  today: { nextCommitment: string };
   setPos: (x: number, y: number) => void;
   setMood: (m: GameState["mood"]) => void;
   awardXP: (amount: number) => void;
@@ -19,6 +20,7 @@ export type GameState = {
   setStats: (s: Partial<Stats>) => void;
   setMissionTitle: (title: string) => void;
   setMissionDescription: (description: string) => void;
+  setToday: (t: GameState["today"]) => void;
   fetchStats: () => Promise<void>;
 };
 
@@ -28,6 +30,7 @@ const defaults: GameState = {
   mood: "Focused",
   quests: {},
   mission: { title: "", description: "" },
+  today: { nextCommitment: "Focus session at 2 PM" },
   setPos() {},
   setMood() {},
   awardXP() {},
@@ -37,6 +40,7 @@ const defaults: GameState = {
   setStats() {},
   setMissionTitle() {},
   setMissionDescription() {},
+  setToday() {},
   fetchStats: async () => {},
 };
 
@@ -129,6 +133,7 @@ export const useGameStore = create<GameState>((set, get) => {
       const m = get().mission;
       persist({ mission: { ...m, description } });
     },
+    setToday: (t) => persist({ today: t }),
   };
 });
 

--- a/src/pages/HomeSnapshot.tsx
+++ b/src/pages/HomeSnapshot.tsx
@@ -1,0 +1,38 @@
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { useGameStore } from "@/game/store";
+import { QuickPodsRow } from "@/components/quick/QuickPodsRow";
+
+export default function HomeSnapshot() {
+  const mission = useGameStore((s) => s.mission);
+  const setMissionTitle = useGameStore((s) => s.setMissionTitle);
+  const setMissionDescription = useGameStore((s) => s.setMissionDescription);
+  const nextCommitment = useGameStore((s) => s.today.nextCommitment);
+
+  return (
+    <div className="min-h-svh bg-background text-foreground p-4 space-y-6">
+      <div className="glass-panel rounded-xl p-6 space-y-4">
+        <Input
+          value={mission.title}
+          onChange={(e) => setMissionTitle(e.target.value)}
+          placeholder="Mission title"
+        />
+        <Textarea
+          value={mission.description}
+          onChange={(e) => setMissionDescription(e.target.value)}
+          placeholder="Mission description"
+          rows={3}
+        />
+      </div>
+
+      <div className="glass-panel rounded-xl p-6 flex items-center gap-4">
+        <div className="flex-1">
+          <div className="text-sm opacity-80">Next:</div>
+          <div className="font-medium">{nextCommitment}</div>
+        </div>
+      </div>
+
+      <QuickPodsRow />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add QuickPodsRow component for quick actions
- create HomeSnapshot page with mission editing and schedule bar
- expose HomeSnapshot at /home via router and extend game store with today schedule

## Testing
- `npm test` (fails: voiceService tests)
- `npm run lint` (fails: eslint errors)


------
https://chatgpt.com/codex/tasks/task_e_689f0d3f212883269369cc70ad5861bf