### PR TITLE
feat: open quick actions in place

### DIFF
--- a/src/components/quick/QuickPodsRow.tsx
+++ b/src/components/quick/QuickPodsRow.tsx
@@ -1,28 +1,64 @@
 import { Target, Waves, StickyNote, Mic, type LucideIcon } from "lucide-react";
+import { useState } from "react";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import FocusRunner from "@/nodes/FocusRunner";
 import { useHUDActions } from "@/game/hud/useHUDActions";
-import type { QuickActionKey } from "@/game/hud/hud.data";
 
-const pods: { action: QuickActionKey; label: string; icon: LucideIcon }[] = [
-  { action: "startFocus", label: "Focus", icon: Target },
-  { action: "startHypnosis", label: "Hypno", icon: Waves },
-  { action: "addNote", label: "Notes", icon: StickyNote },
-  { action: "voiceNote", label: "Voice", icon: Mic },
+const pods: { key: string; label: string; icon: LucideIcon }[] = [
+  { key: "focus", label: "Focus", icon: Target },
+  { key: "hypno", label: "Hypno", icon: Waves },
+  { key: "notes", label: "Notes", icon: StickyNote },
+  { key: "voice", label: "Voice", icon: Mic },
 ];
 
 export function QuickPodsRow() {
   const { run } = useHUDActions();
+  const [focusOpen, setFocusOpen] = useState(false);
+
+  const handle = (key: string) => {
+    if (key === "focus") {
+      setFocusOpen(true);
+      return;
+    }
+    if (key === "hypno") {
+      window.dispatchEvent(new CustomEvent("open-hypno-panel"));
+      return;
+    }
+    if (key === "notes") {
+      run("addNote");
+      return;
+    }
+    if (key === "voice") {
+      run("voiceNote");
+      return;
+    }
+  };
+
   return (
-    <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-      {pods.map((p) => (
-        <button
-          key={p.action}
-          onClick={() => run(p.action)}
-          className="glass-panel rounded-xl p-4 flex flex-col items-center gap-2 hover-scale"
-        >
-          <p.icon className="w-6 h-6" />
-          <span className="text-sm font-medium">{p.label}</span>
-        </button>
-      ))}
+    <div>
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {pods.map((p) => (
+          <button
+            key={p.key}
+            onClick={() => handle(p.key)}
+            className="glass-panel rounded-xl p-4 flex flex-col items-center gap-2 hover-scale"
+          >
+            <p.icon className="w-6 h-6" />
+            <span className="text-sm font-medium">{p.label}</span>
+          </button>
+        ))}
+      </div>
+
+      <Dialog open={focusOpen} onOpenChange={setFocusOpen}>
+        <DialogContent className="sm:max-w-md p-0" onEscapeKeyDown={() => setFocusOpen(false)}>
+          {focusOpen && (
+            <FocusRunner
+              node={{ id: "quick-focus", label: "Focus Session", minutes: 25 }}
+              onExit={() => setFocusOpen(false)}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/views/HomeView.tsx
+++ b/src/views/HomeView.tsx
@@ -2,18 +2,10 @@ import React, { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import {
-  Target,
-  Waves,
-  StickyNote,
-  Mic,
-  Pencil,
-  type LucideIcon,
-} from "lucide-react";
+import { Pencil } from "lucide-react";
 import { AvatarSphere } from "@/components/avatar/AvatarSphere";
 import { useGameStore } from "@/game/store";
-import { useHUDActions } from "@/game/hud/useHUDActions";
-import type { QuickActionKey } from "@/game/hud/hud.data";
+import QuickPodsRow from "@/components/quick/QuickPodsRow";
 
 function ProgressRing({ value }: { value: number }) {
   return (
@@ -32,7 +24,6 @@ function ProgressRing({ value }: { value: number }) {
 }
 
 export default function HomeView() {
-  const { run } = useHUDActions();
   const progress = useGameStore((s) => s.stats.xp);
   const mission = useGameStore((s) => s.mission);
   const setMissionTitle = useGameStore((s) => s.setMissionTitle);
@@ -44,13 +35,6 @@ export default function HomeView() {
   const changes = [
     { id: 1, text: "Logged a voice note", time: "2h ago" },
     { id: 2, text: "Completed focus session", time: "Yesterday" },
-  ];
-
-  const pods: { action: QuickActionKey; label: string; icon: LucideIcon }[] = [
-    { action: "startFocus", label: "Focus", icon: Target },
-    { action: "startHypnosis", label: "Hypno", icon: Waves },
-    { action: "addNote", label: "Notes", icon: StickyNote },
-    { action: "voiceNote", label: "Voice", icon: Mic },
   ];
 
   const handleSave = () => {
@@ -124,22 +108,10 @@ export default function HomeView() {
             <div className="text-sm opacity-80">Next:</div>
             <div className="font-medium">{nextCommitment}</div>
           </div>
-          <Button onClick={() => run("startFocus")}>Start Focus</Button>
         </div>
 
         {/* Quick pods */}
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-          {pods.map((p) => (
-            <button
-              key={p.action}
-              onClick={() => run(p.action)}
-              className="glass-panel rounded-xl p-4 flex flex-col items-center gap-2 hover-scale"
-            >
-              <p.icon className="w-6 h-6" />
-              <span className="text-sm font-medium">{p.label}</span>
-            </button>
-          ))}
-        </div>
+        <QuickPodsRow />
 
         {/* Recent changes */}
         <div className="glass-panel rounded-xl p-6">


### PR DESCRIPTION
## Summary
- swap HomeView quick action buttons for QuickPodsRow with in-place modals
- trigger focus dialog or hypnosis panel directly from quick pods

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any / other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689fb78327148326a77e00cb6a3c3b05