### PR TITLE
feat: add radius design tokens

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -44,7 +44,9 @@ All colors MUST be HSL.
     --input: 240 3.7% 15.9%;
     --ring: 203 89% 53%;
 
-    --radius: 1.25rem;
+    --radius-sm: 0.5rem;
+    --radius-md: 1rem;
+    --radius-lg: 1.5rem;
 
     /* Sidebar tokens */
     --sidebar-background: 240 5.9% 10%;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -63,11 +63,11 @@ export default {
 					ring: 'hsl(var(--sidebar-ring))'
 				}
 			},
-			borderRadius: {
-				lg: 'var(--radius)',
-				md: 'calc(var(--radius) - 2px)',
-				sm: 'calc(var(--radius) - 4px)'
-			},
+                        borderRadius: {
+                                lg: 'var(--radius-lg)',
+                                md: 'var(--radius-md)',
+                                sm: 'var(--radius-sm)'
+                        },
 			keyframes: {
 				'accordion-down': {
 					from: { height: '0', opacity: '0' },


### PR DESCRIPTION
## Summary
- add small, medium, and large radius CSS variables
- map Tailwind border radius utilities to new tokens

## Testing
- `npx tailwindcss -c tailwind.config.ts -i src/index.css -o /tmp/tailwind.css`
- `npm test`
- `npm run lint` *(fails: Unexpected any, empty block statements, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a0386d78848326aa82fe77e7bbd0a5