### PR TITLE
feat: add spacing and safe-area tokens for layout

### DIFF
--- a/src/components/chat/AnchoredChatBar.tsx
+++ b/src/components/chat/AnchoredChatBar.tsx
@@ -136,7 +136,7 @@ export function AnchoredChatBar() {
       <div
         className="fixed left-3 right-3 relative"
         style={{
-          bottom: `calc(var(--hud-h) + var(--dock-h) + var(--hud-gap) + var(--kb-offset) + env(safe-area-inset-bottom))`,
+          bottom: `calc(var(--hud-h) + var(--dock-h) + var(--hud-gap) + var(--kb-offset) + var(--safe-area-bottom))`,
           zIndex: "var(--z-hud)",
         }}
       >

--- a/src/components/game/GameHUD.tsx
+++ b/src/components/game/GameHUD.tsx
@@ -30,7 +30,7 @@ export function GameHUD() {
       <div
         className="fixed left-3 right-3"
         style={{
-          top: 'max(12px, env(safe-area-inset-top))',
+          top: 'max(var(--space-md), var(--safe-area-top))',
           zIndex: 'var(--z-hud)',
           pointerEvents: 'auto',
         }}

--- a/src/components/live/ActionDock.tsx
+++ b/src/components/live/ActionDock.tsx
@@ -10,7 +10,7 @@ export default function ActionDock({
   onVoice?: () => void;
 }) {
   return (
-    <div className="fixed inset-x-0" style={{ bottom: `calc(env(safe-area-inset-bottom) + 12px)` }}>
+    <div className="fixed inset-x-0" style={{ bottom: `calc(var(--safe-area-bottom) + var(--space-md))` }}>
       <div className="mx-auto max-w-3xl px-4 pointer-events-none">
         <div className="pointer-events-auto glass-panel rounded-2xl p-2 elev flex flex-wrap gap-2 justify-center">
           <Button className="h-12 rounded-xl px-5" onClick={onStart}>Start Hypnosis Session</Button>

--- a/src/components/live/QuickActionsBar.tsx
+++ b/src/components/live/QuickActionsBar.tsx
@@ -190,7 +190,7 @@ export function QuickActionsBar({ currentTask }: { currentTask: Task | null }) {
   return (
     <div
       className="glass-panel rounded-xl p-3 elev flex flex-wrap items-center gap-2 sm:gap-3 pb-safe"
-      style={{ height: `calc(100% + env(safe-area-inset-bottom))` }}
+      style={{ height: `calc(100% + var(--safe-area-bottom))` }}
     >
       {/* Hypnosis quick-play */}
       <Button size="sm" onClick={() => setPreOpen(true)}>Start Hypnosis</Button>

--- a/src/components/mindworld/ActionButton.tsx
+++ b/src/components/mindworld/ActionButton.tsx
@@ -1,6 +1,6 @@
 export default function ActionButton({ label = "Action", onPress }: { label?: string; onPress: () => void }) {
   return (
-    <div className="fixed right-4 controls-safe" style={{ bottom: `calc(env(safe-area-inset-bottom) + 16px)` }}>
+    <div className="fixed right-4 controls-safe" style={{ bottom: `calc(var(--safe-area-bottom) + var(--space-lg))` }}>
       <button
         aria-label={label}
         onClick={onPress}

--- a/src/components/mindworld/VirtualJoystick.tsx
+++ b/src/components/mindworld/VirtualJoystick.tsx
@@ -78,7 +78,7 @@ export default function VirtualJoystick({
 
   return (
     <div
-      className="fixed left-4" style={{ bottom: `calc(env(safe-area-inset-bottom) + 16px)` }}
+      className="fixed left-4" style={{ bottom: `calc(var(--safe-area-bottom) + var(--space-lg))` }}
     >
       <div
         ref={baseRef}

--- a/src/components/navigation/BottomDock.tsx
+++ b/src/components/navigation/BottomDock.tsx
@@ -21,7 +21,7 @@ export default function BottomDock() {
     <nav
       className="fixed left-0 right-0"
       style={{
-        bottom: `calc(var(--hud-h) + var(--kb-offset) + env(safe-area-inset-bottom))`,
+        bottom: `calc(var(--hud-h) + var(--kb-offset) + var(--safe-area-bottom))`,
         zIndex: "var(--z-hud)",
         height: "var(--dock-h)",
       }}

--- a/src/components/tasks/QuickAddTaskFAB.tsx
+++ b/src/components/tasks/QuickAddTaskFAB.tsx
@@ -93,7 +93,7 @@ export default function QuickAddTaskFAB({ roadmapId, onCreated }: Props) {
         className="fixed right-4 rounded-full glass-panel elev smooth hover-scale focus:outline-none focus:ring-2 focus:ring-ring"
         style={{
           zIndex: 'var(--z-modal)',
-          bottom: `calc(env(safe-area-inset-bottom) + var(--compass-bottom, 12px) + var(--compass-size, 72px) + var(--gap, 12px))`,
+          bottom: `calc(var(--safe-area-bottom) + var(--compass-bottom, var(--space-md)) + var(--compass-size, 72px) + var(--gap, var(--space-md)))`,
           width: 56,
           height: 56,
         }}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -45,7 +45,7 @@ const DialogContent = React.forwardRef<
         "fixed left-[50%] top-[50%] grid w-full max-w-screen h-dvh translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:max-w-lg sm:h-auto sm:rounded-lg",
         className
       )}
-      style={{ zIndex: 'var(--z-modal)', paddingBottom: 'env(safe-area-inset-bottom)' }}
+      style={{ zIndex: 'var(--z-modal)', paddingBottom: 'var(--safe-area-bottom)' }}
       {...props}
     >
       {children}

--- a/src/game/path/BottomGameNav.tsx
+++ b/src/game/path/BottomGameNav.tsx
@@ -10,7 +10,7 @@ export default function BottomGameNav({ onSelect }: { onSelect?: (key: 'home' | 
   return (
     <nav
       className="fixed left-1/2 -translate-x-1/2 z-20 rounded-2xl bg-white/5 backdrop-blur-sm border border-white/10 shadow-[0_10px_30px_rgba(0,0,0,.5)]"
-      style={{ bottom: `calc(env(safe-area-inset-bottom) + 8px)` }}
+      style={{ bottom: `calc(var(--safe-area-bottom) + var(--space-sm))` }}
       role="tablist"
       aria-label="Game navigation"
     >

--- a/src/index.css
+++ b/src/index.css
@@ -272,9 +272,9 @@ All colors MUST be HSL.
 @keyframes liquid-move { 0% { background-position: 0% 50% } 100% { background-position: 200% 50% } }
 
 /* Safe area helper */
-.dock-safe { padding-bottom: calc(env(safe-area-inset-bottom) + 12px); }
-.pb-safe { padding-bottom: calc(env(safe-area-inset-bottom) + 12px); }
-.pt-safe { padding-top: calc(env(safe-area-inset-top) + 12px); }
+.dock-safe { padding-bottom: var(--edge-bottom); }
+.pb-safe { padding-bottom: var(--edge-bottom); }
+.pt-safe { padding-top: var(--edge-top); }
 
 /* Idle float for avatar */
 .idle-float { animation: idle-float 4s ease-in-out infinite; }
@@ -341,7 +341,7 @@ All colors MUST be HSL.
 .hint { position: absolute; bottom: calc(12% + 150px); left:50%; transform: translateX(-50%); font-size: 12px; color: hsl(var(--foreground)); background: hsl(var(--background) / 0.7); padding: 6px 10px; border-radius: 10px; border: 1px solid hsl(var(--border)); white-space: nowrap; }
 .player { position: absolute; bottom: calc(12% + 70px); width: 80px; height: 80px; }
 .parallax-foreground { position:absolute; inset:0; pointer-events:none; background-image: radial-gradient(6px 6px at 10% 90%, hsl(var(--accent) / 0.15), transparent 60%), radial-gradient(6px 6px at 90% 88%, hsl(var(--primary) / 0.15), transparent 60%); background-size: 200px 200px; opacity: 0.4; }
-.controls-safe { padding-bottom: calc(env(safe-area-inset-bottom) + 16px); }
+.controls-safe { padding-bottom: calc(var(--safe-area-bottom) + var(--space-lg)); }
 
 /* HUD styles */
 .hud-shell {
@@ -458,7 +458,7 @@ All colors MUST be HSL.
 .hud-glyph.portal { background: conic-gradient(from 0deg, hsl(var(--accent)) 0 25%, transparent 25% 50%, hsl(var(--accent)) 50% 75%, transparent 75% 100%); border-radius: 50%; }
 
 /* Safe area helper for HUD */
-.pb-safe { padding-bottom: calc(env(safe-area-inset-bottom) + 12px); }
+.pb-safe { padding-bottom: var(--edge-bottom); }
 
 /* ===== EvolvingSphere (gooey liquid orb) ===== */
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -354,9 +354,9 @@ function CompassIndicator({
       style={{
         width: 72,
         height: 72,
-        right: `calc(env(safe-area-inset-right) + 12px)`,
+        right: `calc(var(--safe-area-right) + var(--space-md))`,
         bottom:
-          `calc(env(safe-area-inset-bottom) + var(--compass-bottom, 12px))` as unknown as number,
+          `calc(var(--safe-area-bottom) + var(--compass-bottom, var(--space-md)))` as unknown as number,
       }}
     >
       {/* center */}

--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -112,7 +112,7 @@ export default function AppShell() {
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -8 }}
             transition={{ duration: 0.18 }}
-            className="pb-[calc(var(--hud-h)+var(--dock-h)+var(--hud-gap)+var(--chatbar-h)+var(--kb-offset)+env(safe-area-inset-bottom))]"
+            className="pb-[calc(var(--hud-h)+var(--dock-h)+var(--hud-gap)+var(--chatbar-h)+var(--kb-offset)+var(--safe-area-bottom))]"
           >
             <Suspense fallback={<div className="p-6 opacity-70">Loading…</div>}>
               <Outlet />

--- a/src/styles/hud-fixes.css
+++ b/src/styles/hud-fixes.css
@@ -2,9 +2,9 @@
 
 /* Clamp HUD within safe bottom rail and margins (overrides utility left/right) */
 .hud-readable {
-  left: clamp(12px, 2vw, 24px);
-  right: clamp(12px, 2vw, 24px);
-  bottom: max(env(safe-area-inset-bottom), 12px);
+  left: clamp(var(--space-md), 2vw, var(--space-xl));
+  right: clamp(var(--space-md), 2vw, var(--space-xl));
+  bottom: max(var(--safe-area-bottom), var(--space-md));
   z-index: 50;
 }
 

--- a/src/styles/vars.css
+++ b/src/styles/vars.css
@@ -1,10 +1,30 @@
 /* Floating metrics for the app: right-side stack */
 :root {
+  /* Spacing scale */
+  --space-xs: 4px;
+  --space-sm: 8px;
+  --space-md: 12px;
+  --space-lg: 16px;
+  --space-xl: 24px;
+  --space-2xl: 32px;
+
+  /* Safe area insets */
+  --safe-area-top: env(safe-area-inset-top);
+  --safe-area-right: env(safe-area-inset-right);
+  --safe-area-bottom: env(safe-area-inset-bottom);
+  --safe-area-left: env(safe-area-inset-left);
+
+  /* Safe area offsets */
+  --edge-top: calc(var(--safe-area-top) + var(--space-md));
+  --edge-right: calc(var(--safe-area-right) + var(--space-md));
+  --edge-bottom: calc(var(--safe-area-bottom) + var(--space-md));
+  --edge-left: calc(var(--safe-area-left) + var(--space-md));
+
   --compass-size: 72px;
   --chatbar-h: 64px; /* chat bar */
   --dock-h: 56px; /* bottom dock */
   --fab-size: 56px;    /* new task */
-  --gap: 12px;
+  --gap: var(--space-md);
   --kb-offset: 0px; /* keyboard height offset */
   --compass-bottom: calc(var(--hud-h) + var(--dock-h) + var(--hud-gap) + var(--chatbar-h) + var(--gap));
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,14 +10,30 @@ export default {
 	],
 	prefix: "",
 	theme: {
-		container: {
-			center: true,
-			padding: '2rem',
-			screens: {
-				'2xl': '1400px'
-			}
-		},
-		extend: {
+                container: {
+                        center: true,
+                        padding: 'var(--space-2xl)',
+                        screens: {
+                                '2xl': '1400px'
+                        }
+                },
+                extend: {
+                        spacing: {
+                                xs: 'var(--space-xs)',
+                                sm: 'var(--space-sm)',
+                                md: 'var(--space-md)',
+                                lg: 'var(--space-lg)',
+                                xl: 'var(--space-xl)',
+                                '2xl': 'var(--space-2xl)',
+                                'safe-top': 'var(--safe-area-top)',
+                                'safe-right': 'var(--safe-area-right)',
+                                'safe-bottom': 'var(--safe-area-bottom)',
+                                'safe-left': 'var(--safe-area-left)',
+                                'edge-top': 'var(--edge-top)',
+                                'edge-right': 'var(--edge-right)',
+                                'edge-bottom': 'var(--edge-bottom)',
+                                'edge-left': 'var(--edge-left)',
+                        },
 			colors: {
 				border: 'hsl(var(--border))',
 				input: 'hsl(var(--input))',


### PR DESCRIPTION
## Summary
- define CSS spacing scale and safe-area variables
- expose spacing tokens in Tailwind and use them for container padding
- update components and utilities to compute edge padding from safe-area tokens

## Testing
- `npm run lint` *(fails: Unexpected any and other errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a03b0057cc832689aed60d672d9a41