### PR TITLE
feat: add motion tokens and reduced-motion support

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -66,7 +66,9 @@ All colors MUST be HSL.
     --gradient-surface: linear-gradient(180deg, hsl(240 3.7% 15.9% / 0.70), hsl(240 10% 3.9% / 0.50));
 
     /* Motion */
-    --transition-smooth: all 300ms cubic-bezier(0.22, 1, 0.36, 1);
+    --ease-standard: cubic-bezier(0.22, 1, 0.36, 1);
+    --duration-fast: 150ms;
+    --duration-slow: 300ms;
 
     /* Layering */
     --z-bg: 0;
@@ -117,6 +119,13 @@ All colors MUST be HSL.
     --sidebar-border: 220 13% 91%;
     --sidebar-ring: 240 5% 64.9%;
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    :root {
+      --duration-fast: 0ms;
+      --duration-slow: 0ms;
+    }
+  }
 }
 
 @layer base {
@@ -151,7 +160,7 @@ All colors MUST be HSL.
   }
 
   .smooth {
-    transition: var(--transition-smooth);
+    transition: all var(--duration-slow) var(--ease-standard);
   }
 }
 
@@ -285,7 +294,7 @@ All colors MUST be HSL.
 @media (prefers-reduced-motion: reduce) { .idle-float { animation: none; } }
 
 /* Hub scene backgrounds */
-.hub-scene { position: relative; overflow: hidden; background: var(--gradient-surface); transition: var(--transition-smooth); }
+.hub-scene { position: relative; overflow: hidden; background: var(--gradient-surface); transition: all var(--duration-slow) var(--ease-standard); }
 .hub-scene .world-sky {
   background-image:
     radial-gradient(1400px 700px at 20% -10%, hsl(var(--primary) / 0.25), transparent 55%),

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,8 +17,8 @@ export default {
 				'2xl': '1400px'
 			}
 		},
-		extend: {
-			colors: {
+                extend: {
+                        colors: {
 				border: 'hsl(var(--border))',
 				input: 'hsl(var(--input))',
 				ring: 'hsl(var(--ring))',
@@ -68,12 +68,19 @@ export default {
                                 md: 'var(--radius-md)',
                                 sm: 'var(--radius-sm)'
                         },
-			keyframes: {
-				'accordion-down': {
-					from: { height: '0', opacity: '0' },
-					to: { height: 'var(--radix-accordion-content-height)', opacity: '1' }
-				},
-				'accordion-up': {
+                        transitionTimingFunction: {
+                                standard: 'var(--ease-standard)'
+                        },
+                        transitionDuration: {
+                                fast: 'var(--duration-fast)',
+                                slow: 'var(--duration-slow)'
+                        },
+                        keyframes: {
+                                'accordion-down': {
+                                        from: { height: '0', opacity: '0' },
+                                        to: { height: 'var(--radix-accordion-content-height)', opacity: '1' }
+                                },
+                                'accordion-up': {
 					from: { height: 'var(--radix-accordion-content-height)', opacity: '1' },
 					to: { height: '0', opacity: '0' }
 				},
@@ -102,20 +109,20 @@ export default {
 					'100%': { transform: 'translateX(100%)' }
 				}
 			},
-			animation: {
-				'accordion-down': 'accordion-down 0.2s ease-out',
-				'accordion-up': 'accordion-up 0.2s ease-out',
-				'fade-in': 'fade-in 0.3s ease-out',
-				'fade-out': 'fade-out 0.3s ease-out',
-				'scale-in': 'scale-in 0.2s ease-out',
-				'scale-out': 'scale-out 0.2s ease-out',
-				'slide-in-right': 'slide-in-right 0.3s ease-out',
-				'slide-out-right': 'slide-out-right 0.3s ease-out',
-				// Combined
-				'enter': 'fade-in 0.3s ease-out, scale-in 0.2s ease-out',
-				'exit': 'fade-out 0.3s ease-out, scale-out 0.2s ease-out'
-			}
-		}
-	},
-	plugins: [require("tailwindcss-animate")],
+                        animation: {
+                                'accordion-down': 'accordion-down var(--duration-fast) var(--ease-standard)',
+                                'accordion-up': 'accordion-up var(--duration-fast) var(--ease-standard)',
+                                'fade-in': 'fade-in var(--duration-slow) var(--ease-standard)',
+                                'fade-out': 'fade-out var(--duration-slow) var(--ease-standard)',
+                                'scale-in': 'scale-in var(--duration-fast) var(--ease-standard)',
+                                'scale-out': 'scale-out var(--duration-fast) var(--ease-standard)',
+                                'slide-in-right': 'slide-in-right var(--duration-slow) var(--ease-standard)',
+                                'slide-out-right': 'slide-out-right var(--duration-slow) var(--ease-standard)',
+                                // Combined
+                                'enter': 'fade-in var(--duration-slow) var(--ease-standard), scale-in var(--duration-fast) var(--ease-standard)',
+                                'exit': 'fade-out var(--duration-slow) var(--ease-standard), scale-out var(--duration-fast) var(--ease-standard)'
+                        }
+                }
+        },
+        plugins: [require("tailwindcss-animate")],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- introduce motion variables for easing and duration, replacing old transition tokens
- wire Tailwind animations and transitions to new motion tokens
- respect prefers-reduced-motion by zeroing motion durations

## Testing
- `npm test`
- `npm run build` (fails: Cannot find name 'SpeechRecognition' and other TS errors)
- `npx tailwindcss -i src/index.css -o /tmp/tailwind.css`
- `npm run lint` (fails: @typescript-eslint/no-explicit-any and other lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68a03b01e16c832690a822c33ff37b5b