### PR TITLE
refactor: centralize motion tokens

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -9,7 +9,7 @@
   height: 6em;
   padding: 1.5em;
   will-change: filter;
-  transition: filter 300ms;
+  transition: filter var(--duration-slow) var(--ease-standard);
 }
 .logo:hover {
   filter: drop-shadow(0 0 2em #646cffaa);

--- a/src/index.css
+++ b/src/index.css
@@ -66,7 +66,9 @@ All colors MUST be HSL.
     --gradient-surface: linear-gradient(180deg, hsl(240 3.7% 15.9% / 0.70), hsl(240 10% 3.9% / 0.50));
 
     /* Motion */
-    --transition-smooth: all 300ms cubic-bezier(0.22, 1, 0.36, 1);
+    --ease-standard: cubic-bezier(0.22, 1, 0.36, 1);
+    --duration-fast: 200ms;
+    --duration-slow: 300ms;
 
     /* Layering */
     --z-bg: 0;
@@ -151,7 +153,7 @@ All colors MUST be HSL.
   }
 
   .smooth {
-    transition: var(--transition-smooth);
+    transition: all var(--duration-fast) var(--ease-standard);
   }
 }
 
@@ -165,7 +167,10 @@ All colors MUST be HSL.
 
 @layer utilities {
   .hover-scale {
-    @apply transition-transform duration-200 hover:scale-105;
+    transition: transform var(--duration-fast) var(--ease-standard);
+  }
+  .hover-scale:hover {
+    transform: scale(1.05);
   }
 
   .story-link {
@@ -182,7 +187,7 @@ All colors MUST be HSL.
     background: hsl(var(--primary));
     transform: scaleX(0);
     transform-origin: bottom right;
-    transition: transform 300ms ease;
+    transition: transform var(--duration-slow) var(--ease-standard);
   }
   .story-link:hover::after {
     transform: scaleX(1);
@@ -210,7 +215,7 @@ All colors MUST be HSL.
   border-radius: 1rem;
   pointer-events: none;
   box-shadow: 0 0 0 0 hsl(var(--accent) / 0.0), 0 0 40px 0 hsl(var(--accent) / 0.35);
-  animation: focus-glow-pulse 2.4s ease-in-out infinite;
+  animation: focus-glow-pulse 2.4s var(--ease-standard) infinite;
 }
 @keyframes focus-glow-pulse {
   0%, 100% { box-shadow: 0 0 0 0 hsl(var(--accent) / 0.0), 0 0 30px 0 hsl(var(--accent) / 0.28); }
@@ -229,7 +234,7 @@ All colors MUST be HSL.
   width: 12px; height: 12px;
   background: radial-gradient(circle at 50% 50%, hsl(var(--accent)) 0, transparent 60%);
   filter: blur(0.3px);
-  animation: sparkle-pop 900ms ease-out forwards;
+  animation: sparkle-pop 900ms var(--ease-standard) forwards;
 }
 @keyframes sparkle-pop {
   0% { transform: scale(0.2); opacity: 0; }
@@ -243,7 +248,7 @@ All colors MUST be HSL.
     radial-gradient(1200px 600px at 20% 0%, hsl(var(--primary) / 0.25), transparent 50%),
     radial-gradient(1000px 500px at 80% 20%, hsl(var(--accent) / 0.20), transparent 50%),
     var(--gradient-surface);
-  animation: ambient-shift 12s ease-in-out infinite alternate;
+  animation: ambient-shift 12s var(--ease-standard) infinite alternate;
 }
 @keyframes ambient-shift {
   0% { background-position: 0% 0%, 100% 0%, 0 0; }
@@ -255,7 +260,7 @@ All colors MUST be HSL.
 .hero-ambient.focused { --primary: 203 89% 53%; --accent: 203 89% 53%; }
 
 /* Flame flicker */
-.flame-flicker { animation: flame-flicker 1.2s ease-in-out infinite; transform-origin: center; }
+.flame-flicker { animation: flame-flicker 1.2s var(--ease-standard) infinite; transform-origin: center; }
 @keyframes flame-flicker {
   0%, 100% { transform: scale(1); filter: drop-shadow(0 0 6px hsl(var(--destructive) / 0.6)); }
   50% { transform: scale(1.05); filter: drop-shadow(0 0 10px hsl(var(--destructive) / 0.8)); }
@@ -277,7 +282,7 @@ All colors MUST be HSL.
 .pt-safe { padding-top: var(--edge-top); }
 
 /* Idle float for avatar */
-.idle-float { animation: idle-float 4s ease-in-out infinite; }
+.idle-float { animation: idle-float 4s var(--ease-standard) infinite; }
 @keyframes idle-float {
   0%, 100% { transform: translateY(0); }
   50% { transform: translateY(-6px); }
@@ -285,7 +290,7 @@ All colors MUST be HSL.
 @media (prefers-reduced-motion: reduce) { .idle-float { animation: none; } }
 
 /* Hub scene backgrounds */
-.hub-scene { position: relative; overflow: hidden; background: var(--gradient-surface); transition: var(--transition-smooth); }
+.hub-scene { position: relative; overflow: hidden; background: var(--gradient-surface); transition: all var(--duration-fast) var(--ease-standard); }
 .hub-scene .world-sky {
   background-image:
     radial-gradient(1400px 700px at 20% -10%, hsl(var(--primary) / 0.25), transparent 55%),
@@ -489,7 +494,7 @@ All colors MUST be HSL.
   background:
     radial-gradient(60% 60% at 35% 35%, hsla(var(--es-hue), var(--es-sat), 92%, .9), transparent 55%),
     radial-gradient(90% 90% at 50% 50%, hsla(var(--es-hue), var(--es-sat), var(--es-light), 1), hsla(var(--es-hue), var(--es-sat), calc(var(--es-light) - 10%), 1));
-  animation: es-breathe calc(var(--es-speed) / var(--es-intensity, 1)) ease-in-out infinite;
+  animation: es-breathe calc(var(--es-speed) / var(--es-intensity, 1)) var(--ease-standard) infinite;
 }
 @keyframes es-breathe {
   0%   { transform: scale(1); }
@@ -522,7 +527,7 @@ All colors MUST be HSL.
     radial-gradient(90% 90% at 50% 50%, hsla(var(--es-hue), var(--es-sat), calc(var(--es-light) + 6%), 1), hsla(var(--es-hue), var(--es-sat), calc(var(--es-light) - 6%), 1));
   animation:
     es-orbit calc(var(--es-speed) / var(--es-intensity, 1)) linear infinite,
-    es-jelly calc((var(--es-speed) * .6) / var(--es-intensity, 1)) ease-in-out infinite;
+    es-jelly calc((var(--es-speed) * .6) / var(--es-intensity, 1)) var(--ease-standard) infinite;
   transform-origin: calc(var(--r)) 0;
 }
 @keyframes es-orbit {

--- a/src/styles/hud-maple.css
+++ b/src/styles/hud-maple.css
@@ -23,7 +23,7 @@
 
 .maple-gauge__bar { height: 14px; border-radius: 9px; position: relative; background: linear-gradient(180deg, hsl(0 0% 100% / 0.08), hsl(0 0% 100% / 0.04)); box-shadow: inset 0 -2px 0 hsl(0 0% 0% / 0.35), inset 0 2px 0 hsl(0 0% 100% / 0.08); overflow: hidden; }
 .maple-gauge__bar::before { content:""; position:absolute; inset:1px; border-radius: 8px; pointer-events:none; background: linear-gradient(180deg, hsl(0 0% 100% / 0.20), hsl(0 0% 100% / 0.06)); mix-blend-mode: overlay; opacity:.65; }
-.maple-gauge__bar > span { display:block; height: 100%; border-radius: inherit; box-shadow: inset 0 -2px 0 hsl(0 0% 0% / 0.25), inset 0 2px 0 hsl(0 0% 100% / 0.18); transition: width .25s ease; }
+.maple-gauge__bar > span { display:block; height: 100%; border-radius: inherit; box-shadow: inset 0 -2px 0 hsl(0 0% 0% / 0.25), inset 0 2px 0 hsl(0 0% 100% / 0.18); transition: width var(--duration-slow) var(--ease-standard); }
 
 /* Fill colors use semantic tokens */
 .maple-gauge__bar.hp > span { background: linear-gradient(90deg, hsl(var(--hp) / 1), hsl(var(--hp) / 0.92)); }

--- a/src/styles/path.css
+++ b/src/styles/path.css
@@ -33,7 +33,7 @@
   50% { transform: scale(1.04); }
   100% { transform: scale(1); }
 }
-.node-pulse { animation: nodePulse 2.4s ease-in-out infinite; }
+.node-pulse { animation: nodePulse 2.4s var(--ease-standard) infinite; }
 
 /* tiny stars */
 .tiny-star {


### PR DESCRIPTION
## Summary
- define `--ease-standard`, `--duration-fast`, and `--duration-slow` tokens in `:root`
- replace `--transition-smooth` usages and adopt tokens for transitions and animations
- update additional styles to use motion tokens

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68a0474ef9608326b74acc37b9dab5a3