### PR TITLE
Add animated stat bars and mock progress events

### DIFF
--- a/src/game/hud/StatBars.tsx
+++ b/src/game/hud/StatBars.tsx
@@ -1,21 +1,27 @@
-import { useGameStore } from '@/game/store'
+import { motion } from 'framer-motion'
+import { useProgressStore } from '@/state/progress'
 
 const Bar = ({label,hue,value}:{label:string; hue:string; value:number}) => (
   <div className="w-full">
     <div className="text-[10px] uppercase tracking-wide opacity-70">{label}</div>
     <div className="h-3 rounded-full bg-white/6 overflow-hidden hud-bar">
-      <div className="h-full rounded-full" style={{ width: `${value}%`, background: `linear-gradient(90deg, hsl(${hue} / .9), hsl(${hue}))` }} />
+      <motion.div
+        className="h-full rounded-full"
+        style={{ background: `linear-gradient(90deg, hsl(${hue} / .9), hsl(${hue}))` }}
+        animate={{ width: `${value}%` }}
+        transition={{ type: 'spring', stiffness: 160, damping: 20 }}
+      />
     </div>
   </div>
 )
 
 export default function StatBars() {
-  const stats = useGameStore(s => s.stats)
+  const { hp, mp, xp } = useProgressStore(s => ({ hp: s.hp, mp: s.mp, xp: s.xp % 100 }))
   return (
     <div className="space-y-2 min-w-[260px] w-[min(480px,50vw)]">
-      <Bar label="HP" hue="0 80% 60%" value={stats.hp}/>
-      <Bar label="MP" hue="210 90% 65%" value={stats.mp}/>
-      <Bar label="XP" hue="200 90% 55%" value={stats.xp}/>
+      <Bar label="HP" hue="0 80% 60%" value={hp}/>
+      <Bar label="MP" hue="210 90% 65%" value={mp}/>
+      <Bar label="XP" hue="200 90% 55%" value={xp}/>
     </div>
   )
 }

--- a/src/pages/HomeSnapshot.tsx
+++ b/src/pages/HomeSnapshot.tsx
@@ -1,16 +1,33 @@
+import { useEffect } from "react";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { useGameStore, selectMission, selectSetMissionTitle, selectSetMissionDescription, selectToday } from "@/game/store";
 import { QuickPodsRow } from "@/components/quick/QuickPodsRow";
+import StatBars from "@/game/hud/StatBars";
+import { useProgressStore } from "@/state/progress";
 
 export default function HomeSnapshot() {
   const mission = useGameStore(selectMission);
   const setMissionTitle = useGameStore(selectSetMissionTitle);
   const setMissionDescription = useGameStore(selectSetMissionDescription);
   const { nextCommitment } = useGameStore(selectToday);
+  const addNote = useProgressStore((s) => s.addNote);
+  const confidenceRep = useProgressStore((s) => s.confidenceRep);
+  const completeTask = useProgressStore((s) => s.complete);
+
+  useEffect(() => {
+    const t = setInterval(() => {
+      const r = Math.random();
+      if (r < 0.33) addNote({ text: "mock", ts: Date.now() });
+      else if (r < 0.66) confidenceRep();
+      else completeTask(`mock-${Date.now()}`);
+    }, 4000);
+    return () => clearInterval(t);
+  }, [addNote, confidenceRep, completeTask]);
 
   return (
     <div className="min-h-svh bg-background text-foreground p-4 space-y-6">
+      <StatBars />
       <div className="glass-panel rounded-xl p-6 space-y-4">
         <Input
           value={mission.title}

--- a/src/state/progress.ts
+++ b/src/state/progress.ts
@@ -1,9 +1,19 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
+const clamp = (v: number, min = 0, max = 100) => Math.max(min, Math.min(max, v));
+
+const calcXP = (cur: number, amount: number) => {
+  const total = cur + Math.max(0, amount);
+  const level = 1 + Math.floor(total / 100);
+  return { xp: total, level };
+};
+
 type Note = { text: string; ts: number; mood?: string };
 
 type ProgressState = {
+  hp: number;
+  mp: number;
   xp: number;
   level: number;
   streak: number;
@@ -14,23 +24,36 @@ type ProgressState = {
   complete: (id: string) => void;
   unlock: (id: string) => void;
   addNote: (note: Note) => void;
+  confidenceRep: () => void;
 };
 
 export const useProgressStore = create<ProgressState>()(
   persist(
     (set, get) => ({
+      hp: 100,
+      mp: 100,
       xp: 0,
       level: 1,
       streak: 0,
       unlocked: new Set<string>(["hypno-calm-60", "focus-25", "browser-notion"]),
       completed: {},
       notes: [],
-      awardXP: (amount) => set((s) => {
-        const total = s.xp + Math.max(0, amount);
-        const level = 1 + Math.floor(total / 100);
-        return { xp: total, level };
-      }),
-      complete: (id) => set((s) => ({ completed: { ...s.completed, [id]: true } })),
+      awardXP: (amount) =>
+        set((s) => {
+          const { xp, level } = calcXP(s.xp, amount);
+          return { xp, level };
+        }),
+      complete: (id) =>
+        set((s) => {
+          const { xp, level } = calcXP(s.xp, 10);
+          return {
+            completed: { ...s.completed, [id]: true },
+            xp,
+            level,
+            hp: clamp(s.hp + 2),
+            mp: clamp(s.mp + 2),
+          };
+        }),
       unlock: (id) => set((s) => ({ unlocked: new Set<string>([...s.unlocked, id]) })),
       addNote: (note) =>
         set((s) => {
@@ -39,17 +62,37 @@ export const useProgressStore = create<ProgressState>()(
           const lastDay = last ? new Date(last.ts).toDateString() : null;
           const today = new Date().toDateString();
           if (lastDay !== today) streak += 1;
-          return { notes: [...s.notes, note], streak };
+          const { xp, level } = calcXP(s.xp, 5);
+          return {
+            notes: [...s.notes, note],
+            streak,
+            xp,
+            level,
+            hp: clamp(s.hp + 1),
+            mp: clamp(s.mp + 2),
+          };
+        }),
+      confidenceRep: () =>
+        set((s) => {
+          const { xp, level } = calcXP(s.xp, 3);
+          return {
+            xp,
+            level,
+            hp: clamp(s.hp + 1),
+            mp: clamp(s.mp + 3),
+          };
         }),
     }),
     {
       name: "aurora-progress",
-      partialize: (s) => ({ xp: s.xp, level: s.level, streak: s.streak, completed: s.completed, notes: s.notes, unlocked: Array.from(s.unlocked) }),
+      partialize: (s) => ({ hp: s.hp, mp: s.mp, xp: s.xp, level: s.level, streak: s.streak, completed: s.completed, notes: s.notes, unlocked: Array.from(s.unlocked) }),
       version: 1,
       migrate: (p: any) => {
         if (!p?.state) return p;
         const st = p.state;
         st.unlocked = new Set<string>(st.unlocked || []);
+        if (typeof st.hp !== "number") st.hp = 100;
+        if (typeof st.mp !== "number") st.mp = 100;
         return p;
       },
     }


### PR DESCRIPTION
## Summary
- Track hp, mp, and xp in the progress store with gains from notes, confidence reps, and task completions
- Animate StatBars via Framer Motion and subscribe to progress store
- Fire mock progress events on HomeSnapshot to demo stat changes

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, Empty block statement)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bb044fa0832684ae27a74872d52e