### PR TITLE
refactor: remove hud vars

### DIFF
--- a/src/components/chat/AnchoredChatBar.tsx
+++ b/src/components/chat/AnchoredChatBar.tsx
@@ -4,7 +4,6 @@ import { Input } from "@/components/ui/input";
 import { Mic, Send, Volume2 } from "lucide-react";
 import { useChatStore } from "@/state/chat";
 import { useTextToSpeech } from "@/voice/useTextToSpeech";
-import { AuroraSphere } from "@/components/avatar/AuroraSphere";
 import { setChatInputRef } from "@/hooks/useChatInputFocus";
 import { useVoiceStore } from "@/state/voice";
 import {
@@ -136,7 +135,7 @@ export function AnchoredChatBar() {
       <div
         className="fixed left-3 right-3 relative"
         style={{
-          bottom: `calc(var(--hud-h) + var(--dock-h) + var(--hud-gap) + var(--kb-offset) + var(--safe-area-bottom))`,
+          bottom: `calc(var(--dock-h) + var(--gap-h) + var(--kb-offset) + var(--safe-area-bottom))`,
           zIndex: "var(--z-hud)",
         }}
       >
@@ -179,7 +178,6 @@ export function AnchoredChatBar() {
         >
           <Send className="w-4 h-4" />
         </Button>
-        <AuroraSphere size={24} className="ml-1" />
         {blocked ? (
           <button
             type="button"

--- a/src/index.css
+++ b/src/index.css
@@ -77,10 +77,8 @@ All colors MUST be HSL.
     --z-modal: 60;
     --z-toast: 100;
 
-    /* HUD */
-    --hud-h: 128px;            /* desktop HUD height */
-    --hud-h-mobile: 164px;     /* mobile/two-line HUD height */
-    --hud-gap: 12px;           /* gap above HUD (the “white line” gutter) */
+    /* Layout gap */
+    --gap-h: 12px;           /* gap above dock/chat bar */
   }
 
   .light {
@@ -446,9 +444,9 @@ All colors MUST be HSL.
 }
 
 /* responsive tokens */
-@media (max-width: 768px){
-  :root { --hud-h: var(--hud-h-mobile); }
-}
+  @media (max-width: 768px){
+    /* no HUD height adjustments needed */
+  }
 
 /* Quick slot glyphs */
 .hud-glyph { width: 22px; height: 22px; display: block; filter: drop-shadow(0 1px 0 hsl(var(--background) / 0.3)); }

--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -35,9 +35,6 @@ export default function AppShell() {
   useWeeklyBrainBackup();
   useKeyboardOffset();
 
-  useEffect(() => {
-    document.documentElement.style.setProperty("--hud-h", "0px");
-  }, []);
 
   useEffect(() => {
     const off = bus.on('nav:view', ({ id, params }) => open(id as ViewId, params));
@@ -116,7 +113,7 @@ export default function AppShell() {
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -8 }}
             transition={{ duration: 0.18 }}
-            className="pb-[calc(var(--hud-h)+var(--dock-h)+var(--hud-gap)+var(--chatbar-h)+var(--kb-offset)+var(--safe-area-bottom))]"
+            className="aurora-app pb-[calc(var(--dock-h)+var(--chatbar-h)+var(--gap-h)+var(--kb-offset)+var(--safe-area-bottom))]"
           >
             <Suspense fallback={<div className="p-6 opacity-70">Loading…</div>}>
               <Outlet />

--- a/src/styles/vars.css
+++ b/src/styles/vars.css
@@ -36,8 +36,9 @@
   --dock-h: 56px; /* bottom dock */
   --fab-size: 56px;    /* new task */
   --gap: var(--space-md);
+  --gap-h: var(--gap);
   --kb-offset: 0px; /* keyboard height offset */
-  --compass-bottom: calc(var(--hud-h) + var(--dock-h) + var(--hud-gap) + var(--chatbar-h) + var(--gap));
+  --compass-bottom: calc(var(--dock-h) + var(--chatbar-h) + var(--gap-h) + var(--safe-area-bottom));
 }
 
 /* Ethereal dimension */


### PR DESCRIPTION
## Summary
- refactor layout variables: remove HUD metrics, add generic gap height
- adjust app shell padding and chat bar offset to use new vars
- decouple AuroraSphere from anchored chat bar

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npx eslint src/routes/AppShell.tsx src/components/chat/AnchoredChatBar.tsx src/styles/vars.css src/index.css`

------
https://chatgpt.com/codex/tasks/task_e_68a0d498152c83269d49c8f8bb33b7b7