### PR TITLE
fix: observe dock height changes

### DIFF
--- a/src/components/navigation/BottomDock.tsx
+++ b/src/components/navigation/BottomDock.tsx
@@ -27,8 +27,23 @@ export default function BottomDock() {
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const h = ref.current?.offsetHeight || 0;
-    document.documentElement.style.setProperty("--dock-h", `${h}px`);
+    const el = ref.current;
+    if (!el) return;
+
+    const setHeight = () => {
+      document.documentElement.style.setProperty(
+        "--dock-h",
+        `${el.offsetHeight}px`
+      );
+    };
+
+    const observer = new ResizeObserver(setHeight);
+    setHeight();
+    observer.observe(el);
+
+    return () => {
+      observer.disconnect();
+    };
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- track bottom dock height using ResizeObserver

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0e690a2948326907d16429b5227b9