### PR TITLE
Add accessibility labels to bottom dock navigation

### DIFF
--- a/src/components/navigation/BottomDock.tsx
+++ b/src/components/navigation/BottomDock.tsx
@@ -87,11 +87,15 @@ export default function BottomDock() {
             </div>
           </div>
         </div>
-        <nav>
+        <div
+          role="region"
+          aria-label="Quick actions"
+          className="flex justify-around items-center"
+        >
+          <QuickActionBar />
+        </div>
+        <nav aria-label="Main navigation">
           <ul className="flex justify-around items-center">
-            <li>
-              <QuickActionBar />
-            </li>
             {items.map(({ to, label, icon: Icon }) => (
               <li key={label}>
                 <NavLink


### PR DESCRIPTION
## Summary
- add descriptive `aria-label` for bottom dock's main navigation
- expose quick action bar as separate labeled region for clarity

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e8852450832684e6d031e77e1931