### PR TITLE
refactor: remove HUD and modal components from Index page

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -16,9 +16,6 @@ import DailyKickoff from '@/components/live/DailyKickoff';
 import { useSupabaseAuth } from '@/hooks/useSupabaseAuth';
 import LandingPage from './LandingPage';
 import { type PathNode } from '@/game/path/path.data';
-import HUDBar from '@/game/hud/HUDBar';
-import { QuickActionsBar } from '@/components/live/QuickActionsBar';
-import ModalHost from '@/components/modals/ModalHost';
 import FastTravel from '@/components/overlays/FastTravel';
 import HypnoPanel from '@/components/hypno/HypnoPanel';
 import { useGameStore } from '@/game/store';
@@ -622,14 +619,9 @@ const Index = () => {
       {/* Daily Kickoff overlay */}
       <DailyKickoff visible={showKickoff} onComplete={handleKickoffComplete} />
 
-      {/* Unified HUD */}
-      <HUDBar />
-      <QuickActionsBar currentTask={null} />
-
       {/* Overlays */}
       <FastTravel />
       <HypnoPanel />
-      <ModalHost />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- remove HUDBar, QuickActionsBar, and ModalHost from the Index page
- leave overlays managed by FastTravel and HypnoPanel only

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any & other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ea4143048326b2f4638cca097939