### PR TITLE
Add quick action buttons to bottom dock

### DIFF
--- a/src/components/modals/ModalHost.tsx
+++ b/src/components/modals/ModalHost.tsx
@@ -1,6 +1,9 @@
 import BrainView from "@/views/BrainView";
 import JournalView from "@/views/JournalView";
 import LiveFocusView from "@/components/live/LiveFocusView";
+import FocusView from "@/views/FocusView";
+import HypnoView from "@/views/HypnoView";
+import VoiceView from "@/views/VoiceView";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { useChatInputFocus } from "@/hooks/useChatInputFocus";
 import { useUIStore } from "@/state/ui";
@@ -27,6 +30,18 @@ export default function ModalHost() {
       break;
     case "journal":
       content = <JournalView />;
+      break;
+    case "focus":
+      content = <FocusView />;
+      break;
+    case "hypno":
+      content = <HypnoView />;
+      break;
+    case "notes":
+      content = <JournalView />;
+      break;
+    case "voice":
+      content = <VoiceView />;
       break;
     case "live":
       content = <LiveFocusView />;

--- a/src/components/navigation/BottomDock.tsx
+++ b/src/components/navigation/BottomDock.tsx
@@ -1,11 +1,21 @@
 import { NavLink } from "react-router-dom";
-import { Brain, BookOpen, Home, MoreHorizontal, Radio } from "lucide-react";
+import {
+  Brain,
+  BookOpen,
+  Home,
+  MoreHorizontal,
+  Radio,
+  Target,
+  Sparkles,
+  NotebookPen,
+  Mic,
+} from "lucide-react";
 import { useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 import { useGameStore } from "@/game/store";
 import { useAvatarStore } from "@/state/avatar";
+import { useUIStore } from "@/state/ui";
 import { AuroraSphere } from "@/components/avatar/AuroraSphere";
-import { QuickActionBar } from "./QuickActionBar";
 
 interface DockItem {
   to: string;
@@ -87,34 +97,63 @@ export default function BottomDock() {
             </div>
           </div>
         </div>
-        <div
-          role="region"
-          aria-label="Quick actions"
-          className="flex justify-around items-center"
-        >
-          <QuickActionBar />
+        <div className="flex items-center">
+          <div
+            role="region"
+            aria-label="Quick actions"
+            className="flex items-center gap-2"
+          >
+            <button
+              onClick={() => useUIStore.getState().openModal("focus")}
+              aria-label="Focus"
+              className="p-2 rounded-md hover:bg-accent"
+            >
+              <Target className="w-5 h-5" />
+            </button>
+            <button
+              onClick={() => useUIStore.getState().openModal("hypno")}
+              aria-label="Hypno"
+              className="p-2 rounded-md hover:bg-accent"
+            >
+              <Sparkles className="w-5 h-5" />
+            </button>
+            <button
+              onClick={() => useUIStore.getState().openModal("notes")}
+              aria-label="Notes"
+              className="p-2 rounded-md hover:bg-accent"
+            >
+              <NotebookPen className="w-5 h-5" />
+            </button>
+            <button
+              onClick={() => useUIStore.getState().openModal("voice")}
+              aria-label="Voice"
+              className="p-2 rounded-md hover:bg-accent"
+            >
+              <Mic className="w-5 h-5" />
+            </button>
+          </div>
+          <nav aria-label="Main navigation" className="flex-1">
+            <ul className="flex justify-around items-center">
+              {items.map(({ to, label, icon: Icon }) => (
+                <li key={label}>
+                  <NavLink
+                    to={to}
+                    end={to === "/app"}
+                    className={({ isActive }) =>
+                      cn(
+                        "flex flex-col items-center text-xs gap-1",
+                        isActive ? "text-primary" : "text-muted-foreground"
+                      )
+                    }
+                  >
+                    <Icon className="w-5 h-5" />
+                    <span>{label}</span>
+                  </NavLink>
+                </li>
+              ))}
+            </ul>
+          </nav>
         </div>
-        <nav aria-label="Main navigation">
-          <ul className="flex justify-around items-center">
-            {items.map(({ to, label, icon: Icon }) => (
-              <li key={label}>
-                <NavLink
-                  to={to}
-                  end={to === "/app"}
-                  className={({ isActive }) =>
-                    cn(
-                      "flex flex-col items-center text-xs gap-1",
-                      isActive ? "text-primary" : "text-muted-foreground"
-                    )
-                  }
-                >
-                  <Icon className="w-5 h-5" />
-                  <span>{label}</span>
-                </NavLink>
-              </li>
-            ))}
-          </ul>
-        </nav>
       </div>
     </div>
   );

--- a/src/state/ui.ts
+++ b/src/state/ui.ts
@@ -10,7 +10,11 @@ export type ModalId =
   | "tasks"
   | "goals"
   | "settings"
-  | "more";
+  | "more"
+  | "focus"
+  | "hypno"
+  | "notes"
+  | "voice";
 
 type UIState = {
   activeModal: ModalId | null;


### PR DESCRIPTION
## Summary
- replace dynamic QuickActionBar with Focus, Hypno, Notes, and Voice buttons that open modals
- expand UI modal types and host to support new panels

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0eb7064b48326a3d86f60b6201676