### PR TITLE
feat: monitor chat bar height

### DIFF
--- a/src/components/chat/AnchoredChatBar.tsx
+++ b/src/components/chat/AnchoredChatBar.tsx
@@ -22,6 +22,7 @@ export function AnchoredChatBar() {
   const recognitionRef = useRef<SpeechRecognition | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const pressStartRef = useRef<number | null>(null);
+  const barRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     const ref = inputRef.current;
@@ -32,6 +33,26 @@ export function AnchoredChatBar() {
 
   useEffect(() => {
     // placeholder for any init logic
+  }, []);
+
+  useEffect(() => {
+    if (typeof ResizeObserver === "undefined") return;
+    const bar = barRef.current;
+    if (!bar) return;
+
+    const setHeight = (h: number) => {
+      document.documentElement.style.setProperty("--chatbar-h", `${h}px`);
+    };
+
+    setHeight(bar.getBoundingClientRect().height);
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setHeight(entry.contentRect.height);
+      }
+    });
+    observer.observe(bar);
+    return () => observer.disconnect();
   }, []);
 
   useEffect(() => {
@@ -132,7 +153,7 @@ export function AnchoredChatBar() {
       >
         {lastAssistant?.content}
       </div>
-      <div className="pointer-events-auto relative mx-3 mb-[var(--gap-h)]">
+      <div ref={barRef} className="pointer-events-auto relative mx-3 mb-[var(--hud-gap)]">
       <div className="glass-panel rounded-2xl p-2 elev flex items-center gap-2">
 
         <Button
@@ -149,6 +170,7 @@ export function AnchoredChatBar() {
           <Mic className="w-4 h-4" />
         </Button>
         <Input
+          id="anchored-chat-input"
           value={input}
           ref={inputRef}
           onChange={(e) => {


### PR DESCRIPTION
## Summary
- give chat bar input unique id for anchoring
- update --chatbar-h CSS variable using ResizeObserver
- switch chat bar bottom margin to --hud-gap variable

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any ... in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f54a1edc8326ae2dcaad7f18acf6