### PR TITLE
refactor: rename gap-h to hud-gap

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -78,7 +78,7 @@ All colors MUST be HSL.
     --z-toast: 100;
 
     /* Layout gap */
-    --gap-h: 12px;           /* gap above dock/chat bar */
+    --hud-gap: 12px;           /* gap above dock/chat bar */
   }
 
   .light {

--- a/src/styles/vars.css
+++ b/src/styles/vars.css
@@ -36,9 +36,9 @@
   --dock-h: 56px; /* bottom dock */
   --fab-size: 56px;    /* new task */
   --gap: var(--space-md);
-  --gap-h: var(--gap);
+  --hud-gap: var(--gap);
   --kb-offset: 0px; /* keyboard height offset */
-  --compass-bottom: calc(var(--dock-h) + var(--chatbar-h) + var(--gap-h) + var(--safe-area-bottom));
+  --compass-bottom: calc(var(--dock-h) + var(--chatbar-h) + var(--hud-gap) + var(--safe-area-bottom));
 }
 
 /* Ethereal dimension */


### PR DESCRIPTION
## Summary
- rename `--gap-h` to `--hud-gap` in global style variables
- update compass bottom calculation and default layout gap
- ensure HUD-related components reference `var(--hud-gap)`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0f778aef483268cc8b2978e4a4f46