### PR TITLE
refactor: separate chat bar and dock

### DIFF
--- a/src/components/chat/AnchoredChatBar.tsx
+++ b/src/components/chat/AnchoredChatBar.tsx
@@ -144,7 +144,13 @@ export function AnchoredChatBar() {
   };
 
   return (
-    <>
+    <div
+      className="fixed inset-x-0 pointer-events-none"
+      style={{
+        bottom: `calc(var(--dock-h) + var(--hud-gap) + var(--kb-offset) + var(--safe-area-bottom))`,
+        zIndex: "var(--z-hud)",
+      }}
+    >
       {/* Visually hidden live region for screen reader announcements */}
       <div
         className="sr-only"
@@ -153,7 +159,7 @@ export function AnchoredChatBar() {
       >
         {lastAssistant?.content}
       </div>
-      <div ref={barRef} className="pointer-events-auto relative mx-3 mb-[var(--hud-gap)]">
+      <div ref={barRef} className="pointer-events-auto relative mx-3">
       <div className="glass-panel rounded-2xl p-2 elev flex items-center gap-2">
 
         <Button
@@ -254,6 +260,6 @@ export function AnchoredChatBar() {
         </button>
       </div>
     </div>
-    </>
+  </div>
   );
 }

--- a/src/components/navigation/BottomDock.tsx
+++ b/src/components/navigation/BottomDock.tsx
@@ -57,11 +57,18 @@ export default function BottomDock() {
   }, []);
 
   return (
-    <div ref={ref} className="w-full pointer-events-auto">
-      <div className="mx-3 hud-panel hud-maple rounded-2xl px-4 py-3 flex flex-col gap-2 select-none">
-        <div className="flex items-center gap-3 min-w-0">
-          {avatarEnabled && <AuroraSphere size={44} />}
-          <div className="min-w-0">
+    <div
+      className="fixed inset-x-0 pointer-events-none"
+      style={{
+        bottom: `calc(var(--kb-offset) + var(--safe-area-bottom))`,
+        zIndex: "var(--z-hud)",
+      }}
+    >
+      <div ref={ref} className="w-full pointer-events-auto">
+        <div className="mx-3 hud-panel hud-maple rounded-2xl px-4 py-3 flex flex-col gap-2 select-none">
+          <div className="flex items-center gap-3 min-w-0">
+            {avatarEnabled && <AuroraSphere size={44} />}
+            <div className="min-w-0">
             <div className="text-[13px] opacity-90 truncate">
               Lv. {stats.level} • Streak {stats.streak}
             </div>
@@ -156,5 +163,6 @@ export default function BottomDock() {
         </div>
       </div>
     </div>
+  </div>
   );
 }

--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -127,16 +127,8 @@ export default function AppShell() {
         </AnimatePresence>
 
         <ModalHost />
-        <div
-          className="fixed inset-x-0 pointer-events-none"
-          style={{
-            bottom: `calc(var(--kb-offset) + var(--safe-area-bottom))`,
-            zIndex: "var(--z-hud)",
-          }}
-        >
-          <AnchoredChatBar />
-          <BottomDock />
-        </div>
+        <AnchoredChatBar />
+        <BottomDock />
         <TimerHudChip />
       </div>
   );


### PR DESCRIPTION
## Summary
- render AnchoredChatBar and BottomDock separately in AppShell
- give AnchoredChatBar its own fixed positioning
- give BottomDock its own fixed positioning

## Testing
- `npx jest`
- `npm run lint` *(fails: unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f778e38883269f6ec9d2aafeeacf