### PR TITLE
refactor: centralize AppHeader

### DIFF
--- a/src/pages/AccountPlan.tsx
+++ b/src/pages/AccountPlan.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import AppHeader from '@/components/layout/AppHeader';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { PRICING_TIERS } from '@/modules/payments/components/PricingPage';
@@ -25,7 +24,6 @@ export default function AccountPlan() {
   return (
     <div className="relative min-h-svh">
       <div className="os-bg" />
-      <AppHeader />
       <main className="pt-24 pb-16 px-4 sm:px-6 max-w-5xl mx-auto space-y-8">
         <section>
           <h1 className="text-2xl font-semibold mb-4">Account Plan</h1>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -10,7 +10,6 @@ import {
 } from 'lucide-react';
 import GameHome from '@/game/path/GameHome';
 import ArchivePanel from '@/components/archive/ArchivePanel';
-import AppHeader from '@/components/layout/AppHeader';
 import { PanelHeaderUnified } from '@/components/layout/PanelHeaderUnified';
 import DailyKickoff from '@/components/live/DailyKickoff';
 import { useSupabaseAuth } from '@/hooks/useSupabaseAuth';
@@ -563,7 +562,6 @@ const Index = () => {
       onPointerUp={onPointerUp}
     >
       <div className="os-bg" />
-      <AppHeader />
 
       <div className="absolute inset-0 smooth" style={{ transform: translate }}>
         {/* 3x3 grid canvas sized by viewport */}

--- a/src/pages/Stack.tsx
+++ b/src/pages/Stack.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo } from "react";
-import AppHeader from "@/components/layout/AppHeader";
 import { Capacitor } from "@capacitor/core";
 import { supabase } from "@/integrations/supabase/client";
 import { useAvatarStore } from "@/state/avatar";
@@ -69,7 +68,6 @@ export default function StackPage() {
   return (
     <div className="relative min-h-svh">
       <div className="os-bg" />
-      <AppHeader />
       <main className="pt-24 pb-16 px-4 sm:px-6 max-w-5xl mx-auto">
         <article className="space-y-8">
           <header>

--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -14,6 +14,7 @@ import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
 import useDailyCheckIn from "@/hooks/useDailyCheckIn";
 import useWeeklyBrainBackup from "@/hooks/useWeeklyBrainBackup";
 import { useKeyboardOffset } from "@/hooks/useKeyboardOffset";
+import AppHeader from "@/components/layout/AppHeader";
 
 export default function AppShell() {
   const { user, initializing } = useSupabaseAuth();
@@ -111,6 +112,7 @@ export default function AppShell() {
   return (
     <div className={`relative min-h-svh room-${currentRoom}`} {...swipe}>
         <div className="os-bg" />
+        <AppHeader />
         <AnimatePresence mode="wait">
           <motion.div
             key={loc.pathname + loc.search}


### PR DESCRIPTION
## Summary
- render global header in AppShell so all routes share AppHeader
- remove redundant AppHeader imports from page components

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any / Empty block statement errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fa6e471c8326aec8337a4fdc225d