### PR TITLE
Add HUD modal controls and accessibility

### DIFF
--- a/src/components/modals/ControlsModal.tsx
+++ b/src/components/modals/ControlsModal.tsx
@@ -1,0 +1,12 @@
+import { DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+export default function ControlsModal() {
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Controls</DialogTitle>
+      </DialogHeader>
+      <div className="text-sm text-muted-foreground">Coming soon.</div>
+    </>
+  );
+}

--- a/src/components/modals/InventoryModal.tsx
+++ b/src/components/modals/InventoryModal.tsx
@@ -1,0 +1,12 @@
+import { DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+export default function InventoryModal() {
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Inventory</DialogTitle>
+      </DialogHeader>
+      <div className="text-sm text-muted-foreground">Coming soon.</div>
+    </>
+  );
+}

--- a/src/components/modals/MapModal.tsx
+++ b/src/components/modals/MapModal.tsx
@@ -1,0 +1,12 @@
+import { DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+export default function MapModal() {
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Map</DialogTitle>
+      </DialogHeader>
+      <div className="text-sm text-muted-foreground">Coming soon.</div>
+    </>
+  );
+}

--- a/src/components/modals/ModalHost.tsx
+++ b/src/components/modals/ModalHost.tsx
@@ -12,6 +12,9 @@ import AnalyticsModal from "@/components/modals/AnalyticsModal";
 import GoalsModal from "@/components/modals/GoalsModal";
 import SettingsModal from "@/components/modals/SettingsModal";
 import TasksModal from "@/components/modals/TasksModal";
+import InventoryModal from "@/components/modals/InventoryModal";
+import MapModal from "@/components/modals/MapModal";
+import ControlsModal from "@/components/modals/ControlsModal";
 
 export default function ModalHost() {
   const { activeModal, closeModal } = useUIStore();
@@ -70,6 +73,18 @@ export default function ModalHost() {
       break;
     case "more":
       content = <div>More</div>;
+      break;
+    case "inventory":
+      content = <InventoryModal />;
+      className = "sm:max-w-md";
+      break;
+    case "map":
+      content = <MapModal />;
+      className = "sm:max-w-md";
+      break;
+    case "controls":
+      content = <ControlsModal />;
+      className = "sm:max-w-md";
       break;
     default:
       content = null;

--- a/src/game/hud/HUDBar.tsx
+++ b/src/game/hud/HUDBar.tsx
@@ -4,9 +4,11 @@ import QuickSlot from './QuickSlot'
 import { quickSlots } from './hud.data'
 import { useHUDActions } from './useHUDActions'
 import { useEffect } from 'react'
+import { useUIStore } from '@/state/ui'
 
 export default function HUDBar() {
   const { run } = useHUDActions()
+  const openModal = useUIStore.getState().openModal
 
   // Desktop hotkeys 1..6
   useEffect(() => {
@@ -14,7 +16,7 @@ export default function HUDBar() {
       const target = e.target as HTMLElement | null
       if (target && (target.closest('input, textarea, [contenteditable="true"]'))) return
       const n = Number(e.key)
-      if (n >= 1 && n <= quickSlots.length) run(quickSlots[n-1].action as any)
+      if (n >= 1 && n <= quickSlots.length) run(quickSlots[n-1].action)
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
@@ -36,17 +38,49 @@ export default function HUDBar() {
               <div className="grow min-w-[260px]"><StatBars/></div>
 
               {/* Right: System icons always at far right */}
-              <div className="ml-auto flex items-center gap-2 order-3 sm:order-none">
-                <button className="hud-icon settings hover-scale smooth hover:brightness-110 active:scale-95" aria-label="Settings"/>
-                <button className="hud-icon bag hover-scale smooth hover:brightness-110 active:scale-95" aria-label="Bag"/>
-                <button className="hud-icon map hover-scale smooth hover:brightness-110 active:scale-95" aria-label="Map" onClick={()=>run('openMap' as any)}/>
-                <button className="hud-icon stick hover-scale smooth hover:brightness-110 active:scale-95" aria-label="Joystick" onClick={() => window.dispatchEvent(new CustomEvent('mos', { detail: { type: 'toggleJoystick' } }))}/>
+              <div className="ml-auto flex items-center gap-2 sm:gap-3 order-3 sm:order-none">
+                <button
+                  type="button"
+                  className="hud-icon settings hover-scale smooth hover:brightness-110 active:scale-95"
+                  aria-label="Settings"
+                  title="Settings"
+                  onClick={() => openModal('settings')}
+                >
+                  <span className="sr-only">Settings</span>
+                </button>
+                <button
+                  type="button"
+                  className="hud-icon bag hover-scale smooth hover:brightness-110 active:scale-95"
+                  aria-label="Inventory"
+                  title="Inventory"
+                  onClick={() => openModal('inventory')}
+                >
+                  <span className="sr-only">Inventory</span>
+                </button>
+                <button
+                  type="button"
+                  className="hud-icon map hover-scale smooth hover:brightness-110 active:scale-95"
+                  aria-label="Map"
+                  title="Map"
+                  onClick={() => openModal('map')}
+                >
+                  <span className="sr-only">Map</span>
+                </button>
+                <button
+                  type="button"
+                  className="hud-icon stick hover-scale smooth hover:brightness-110 active:scale-95"
+                  aria-label="Controls"
+                  title="Controls"
+                  onClick={() => openModal('controls')}
+                >
+                  <span className="sr-only">Controls</span>
+                </button>
               </div>
 
               {/* Quick Slots: full width on small (second line), inline on large */}
               <div className="flex items-center gap-3 basis-full sm:basis-auto order-4 sm:order-none">
                 {quickSlots.map(s => (
-                  <QuickSlot key={s.id} hotkey={s.key} label={s.label} icon={s.icon} onClick={() => run(s.action as any)} />
+                  <QuickSlot key={s.id} hotkey={s.key} label={s.label} icon={s.icon} onClick={() => run(s.action)} />
                 ))}
               </div>
             </div>

--- a/src/state/ui.ts
+++ b/src/state/ui.ts
@@ -15,7 +15,10 @@ export type ModalId =
   | "focus"
   | "hypno"
   | "notes"
-  | "voice";
+  | "voice"
+  | "inventory"
+  | "map"
+  | "controls";
 
 type UIState = {
   activeModal: ModalId | null;


### PR DESCRIPTION
## Summary
- add tooltips and modal handlers for HUD bar icon buttons
- extend UI store and ModalHost with inventory, map, and controls modals
- include placeholder modal components for inventory, map, and controls

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any / Empty block statement in existing files)*


------
https://chatgpt.com/codex/tasks/task_e_68a0fb6784d08326829b1fe9a0350fef