### PR TITLE
feat: make dock collapsible and move chat

### DIFF
--- a/src/components/chat/AnchoredChatBar.tsx
+++ b/src/components/chat/AnchoredChatBar.tsx
@@ -22,7 +22,7 @@ export function AnchoredChatBar() {
   const recognitionRef = useRef<SpeechRecognition | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const pressStartRef = useRef<number | null>(null);
-  const barRef = useRef<HTMLDivElement | null>(null);
+  const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const ref = inputRef.current;
@@ -36,23 +36,14 @@ export function AnchoredChatBar() {
   }, []);
 
   useEffect(() => {
-    if (typeof ResizeObserver === "undefined") return;
-    const bar = barRef.current;
-    if (!bar) return;
-
-    const setHeight = (h: number) => {
-      document.documentElement.style.setProperty("--chatbar-h", `${h}px`);
-    };
-
-    setHeight(bar.getBoundingClientRect().height);
-
-    const observer = new ResizeObserver((entries) => {
-      for (const entry of entries) {
-        setHeight(entry.contentRect.height);
-      }
-    });
-    observer.observe(bar);
-    return () => observer.disconnect();
+    const el = ref.current;
+    if (!el) return;
+    const set = () =>
+      document.documentElement.style.setProperty("--chatbar-h", `${el.offsetHeight}px`);
+    set();
+    const ro = new ResizeObserver(set);
+    ro.observe(el);
+    return () => ro.disconnect();
   }, []);
 
   useEffect(() => {
@@ -147,8 +138,8 @@ export function AnchoredChatBar() {
     <div
       className="fixed inset-x-0 pointer-events-none"
       style={{
-        bottom: `calc(var(--dock-h) + var(--hud-gap) + var(--kb-offset) + var(--safe-area-bottom))`,
-        zIndex: "var(--z-hud)",
+        bottom: "calc(var(--kb-offset) + var(--safe-area-bottom))",
+        zIndex: 70,
       }}
     >
       {/* Visually hidden live region for screen reader announcements */}
@@ -159,7 +150,7 @@ export function AnchoredChatBar() {
       >
         {lastAssistant?.content}
       </div>
-      <div ref={barRef} className="pointer-events-auto relative mx-3">
+      <div ref={ref} className="pointer-events-auto relative mx-3">
       <div className="glass-panel rounded-2xl p-2 elev flex items-center gap-2">
 
         <Button

--- a/src/components/navigation/BottomDock.tsx
+++ b/src/components/navigation/BottomDock.tsx
@@ -1,134 +1,179 @@
-import {
-  Brain,
-  BookOpen,
-  Radio,
-  Home,
-  Settings,
-} from "lucide-react";
-import { useEffect, useRef } from "react";
-import { NavLink, useLocation } from "react-router-dom";
-import { QuickActionBar } from "./QuickActionBar";
+import { useEffect, useRef, useState, useMemo } from "react";
+import { NavLink } from "react-router-dom";
+import { Home, Brain, BookOpen, Radio, Settings } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useGameStore } from "@/game/store";
 import { useAvatarStore } from "@/state/avatar";
 import { AuroraSphere } from "@/components/avatar/AuroraSphere";
+import { QuickActionBar } from "./QuickActionBar";
+import { useKeyboardOffset } from "@/hooks/useKeyboardOffset";
 
-interface NavItem {
-  to: string;
-  label: string;
-  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
-}
-
-const items: NavItem[] = [
-  { to: "/app", label: "Home", icon: Home },
-  { to: "/app/brain", label: "Brain", icon: Brain },
-  { to: "/app/journal", label: "Journal", icon: BookOpen },
-  { to: "/app/live", label: "Live", icon: Radio },
-  { to: "/app/settings", label: "Settings", icon: Settings },
-];
+const DOCK_COLLAPSE_KEY = "ui:dock:collapsed";
 
 export default function BottomDock() {
   const stats = useGameStore((s) => s.stats);
   const avatarEnabled = useAvatarStore((s) => s.enabled);
   const ref = useRef<HTMLDivElement>(null);
+  useKeyboardOffset();
 
+  // collapsed state persisted in localStorage
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    return localStorage.getItem(DOCK_COLLAPSE_KEY) === "1";
+  });
+  useEffect(() => {
+    localStorage.setItem(DOCK_COLLAPSE_KEY, collapsed ? "1" : "0");
+  }, [collapsed]);
+
+  // measure height -> --dock-h
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
-
-    const setHeight = () => {
-      document.documentElement.style.setProperty(
-        "--dock-h",
-        `${el.offsetHeight}px`
-      );
+    const set = () => {
+      const h = el.offsetHeight || 0;
+      document.documentElement.style.setProperty("--dock-h", `${h}px`);
     };
-
-    const observer = new ResizeObserver(setHeight);
-    setHeight();
-    observer.observe(el);
-
-    return () => {
-      observer.disconnect();
-    };
+    set();
+    const ro = new ResizeObserver(set);
+    ro.observe(el);
+    return () => ro.disconnect();
   }, []);
 
-  const { pathname } = useLocation();
-  const onHome = pathname === "/app";
+  const items = useMemo(
+    () => [
+      { to: "/app", label: "Home", icon: Home },
+      { to: "/app/brain", label: "Brain", icon: Brain },
+      { to: "/app/journal", label: "Journal", icon: BookOpen },
+      { to: "/app/live", label: "Live", icon: Radio },
+      { to: "/app/settings", label: "Settings", icon: Settings },
+    ],
+    []
+  );
+
+  const onEdgeClick = () => setCollapsed((c) => !c);
 
   return (
     <div
-      className="fixed inset-x-0 pointer-events-none"
+      ref={ref}
+      className={cn(
+        "fixed left-0 right-0 mx-3 select-none",
+        "transition-[transform,opacity] duration-200",
+        collapsed ? "pb-2" : "pb-3"
+      )}
       style={{
-        bottom: `calc(var(--kb-offset) + var(--safe-area-bottom))`,
-        zIndex: "var(--z-hud)",
+        bottom: `calc(var(--kb-offset) + var(--safe-area-bottom) + var(--chatbar-h) + var(--hud-gap))`,
+        zIndex: 80,
+        pointerEvents: "auto",
       }}
     >
-      <div ref={ref} className="w-full pointer-events-auto">
-        <div className="mx-3 hud-panel hud-maple rounded-2xl px-4 py-3 flex flex-col gap-2 select-none">
-          <div className="flex items-center gap-3 min-w-0">
-            {avatarEnabled && <AuroraSphere size={44} />}
-            <div className="min-w-0">
-            <div className="text-[13px] opacity-90 truncate">
-              Lv. {stats.level} • Streak {stats.streak}
-            </div>
-            <div className="text-[15px] font-semibold truncate">Dean</div>
+      <button
+        aria-label={collapsed ? "Expand dock" : "Collapse dock"}
+        onClick={onEdgeClick}
+        className="absolute -top-2 left-0 right-0 h-3 rounded-t-2xl opacity-30 hover:opacity-60 focus:opacity-80 outline-none"
+        style={{ WebkitTapHighlightColor: "transparent" }}
+      />
+
+      <div
+        className={cn(
+          "hud-panel hud-maple rounded-2xl px-4",
+          collapsed ? "py-2" : "py-3",
+          "backdrop-blur-md"
+        )}
+      >
+        {collapsed ? (
+          <div className="flex items-center justify-between gap-3">
+            <QuickActionBar iconsOnly />
+            <nav aria-label="Main navigation">
+              <ul className="flex gap-5">
+                {items.map(({ to, label, icon: Icon }) => (
+                  <li key={label}>
+                    <NavLink
+                      to={to}
+                      end={to === "/app"}
+                      className={({ isActive }) =>
+                        cn(
+                          "flex flex-col items-center text-[11px] gap-1",
+                          isActive ? "text-primary" : "text-muted-foreground"
+                        )
+                      }
+                    >
+                      <Icon className="w-5 h-5" />
+                      <span className="sr-only">{label}</span>
+                    </NavLink>
+                  </li>
+                ))}
+              </ul>
+            </nav>
           </div>
-        </div>
-        <div className="flex md:flex-row flex-col gap-2 md:items-center">
-          <div className="maple-gauge">
-            <div className="maple-gauge__top">
-              <span className="maple-gauge__label">HP</span>
-              <span className="maple-gauge__val">{Math.floor(stats.hp)}%</span>
+        ) : (
+          <>
+            <div className="flex items-center gap-3 min-w-0 mb-2">
+              {avatarEnabled && <AuroraSphere size={44} />}
+              <div className="min-w-0">
+                <div className="text-[13px] opacity-90 truncate">
+                  Lv. {stats.level} • Streak {stats.streak}
+                </div>
+                <div className="text-[15px] font-semibold truncate">Dean</div>
+              </div>
             </div>
-            <div className="maple-gauge__bar hp">
-              <span style={{ width: `${stats.hp}%` }} />
+
+            <div className="flex md:flex-row flex-col gap-2 md:items-center mb-1">
+              <div className="maple-gauge">
+                <div className="maple-gauge__top">
+                  <span className="maple-gauge__label">HP</span>
+                  <span className="maple-gauge__val">{Math.floor(stats.hp)}%</span>
+                </div>
+                <div className="maple-gauge__bar hp">
+                  <span style={{ width: `${stats.hp}%` }} />
+                </div>
+              </div>
+              <div className="maple-gauge">
+                <div className="maple-gauge__top">
+                  <span className="maple-gauge__label">MP</span>
+                  <span className="maple-gauge__val">{Math.floor(stats.mp)}%</span>
+                </div>
+                <div className="maple-gauge__bar mp">
+                  <span style={{ width: `${stats.mp}%` }} />
+                </div>
+              </div>
+              <div className="maple-gauge">
+                <div className="maple-gauge__top">
+                  <span className="maple-gauge__label">XP</span>
+                  <span className="maple-gauge__val">{Math.floor(stats.xp)}%</span>
+                </div>
+                <div className="maple-gauge__bar xp">
+                  <span style={{ width: `${stats.xp}%` }} />
+                </div>
+              </div>
             </div>
-          </div>
-          <div className="maple-gauge">
-            <div className="maple-gauge__top">
-              <span className="maple-gauge__label">MP</span>
-              <span className="maple-gauge__val">{Math.floor(stats.mp)}%</span>
+
+            <div className="flex items-center justify-between gap-3">
+              <QuickActionBar />
+              <nav aria-label="Main navigation">
+                <ul className="flex gap-5">
+                  {items.map(({ to, label, icon: Icon }) => (
+                    <li key={label}>
+                      <NavLink
+                        to={to}
+                        end={to === "/app"}
+                        className={({ isActive }) =>
+                          cn(
+                            "flex flex-col items-center text-xs gap-1",
+                            isActive ? "text-primary" : "text-muted-foreground"
+                          )
+                        }
+                      >
+                        <Icon className="w-5 h-5" />
+                        <span>{label}</span>
+                      </NavLink>
+                    </li>
+                  ))}
+                </ul>
+              </nav>
             </div>
-            <div className="maple-gauge__bar mp">
-              <span style={{ width: `${stats.mp}%` }} />
-            </div>
-          </div>
-          <div className="maple-gauge">
-            <div className="maple-gauge__top">
-              <span className="maple-gauge__label">XP</span>
-              <span className="maple-gauge__val">{Math.floor(stats.xp)}%</span>
-            </div>
-            <div className="maple-gauge__bar xp">
-              <span style={{ width: `${stats.xp}%` }} />
-            </div>
-          </div>
-        </div>
-        <div className="flex items-center">
-          {!onHome ? <QuickActionBar /> : <span aria-hidden="true" />}
-          <nav aria-label="Main navigation" className="flex-1">
-            <ul className="flex justify-around items-center">
-              {items.map(({ to, label, icon: Icon }) => (
-                <li key={to}>
-                  <NavLink
-                    to={to}
-                    className={({ isActive }) =>
-                      cn(
-                        "flex flex-col items-center text-xs gap-1",
-                        isActive ? "text-primary" : "text-muted-foreground"
-                      )
-                    }
-                    aria-label={label}
-                  >
-                    <Icon className="w-5 h-5" />
-                    <span>{label}</span>
-                  </NavLink>
-                </li>
-              ))}
-            </ul>
-          </nav>
-        </div>
+          </>
+        )}
       </div>
     </div>
-  </div>
   );
 }
+

--- a/src/components/navigation/QuickActionBar.tsx
+++ b/src/components/navigation/QuickActionBar.tsx
@@ -10,20 +10,23 @@ const actions = [
   },
 ];
 
-export function QuickActionBar() {
+export function QuickActionBar({ iconsOnly = false }: { iconsOnly?: boolean }) {
   if (!actions.length) return null;
   return (
-    <div className="flex items-center gap-2">
+    <ul className="flex items-center gap-3">
       {actions.map(({ id, label, icon: Icon, onClick }) => (
-        <button
-          key={id}
-          onClick={onClick}
-          className="p-2 rounded-md hover:bg-accent"
-          aria-label={label}
-        >
-          <Icon className="w-5 h-5" />
-        </button>
+        <li key={id}>
+          <button
+            onClick={onClick}
+            className="flex flex-col items-center gap-1 px-2 py-1 rounded-lg hover:opacity-90 focus:outline-none focus:ring-2"
+            aria-label={label}
+            title={label}
+          >
+            <Icon className="w-5 h-5" />
+            {!iconsOnly && <span className="text-xs">{label}</span>}
+          </button>
+        </li>
       ))}
-    </div>
+    </ul>
   );
 }

--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -120,7 +120,7 @@ export default function AppShell() {
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -8 }}
             transition={{ duration: 0.18 }}
-            className="aurora-app pb-[calc(var(--dock-h)+var(--chatbar-h)+var(--hud-gap)+var(--kb-offset)+var(--safe-area-bottom))]"
+            className="aurora-app pb-[calc(var(--dock-h)+var(--hud-gap)+var(--chatbar-h)+var(--kb-offset)+var(--safe-area-bottom))]"
           >
             <Suspense fallback={<div className="p-6 opacity-70">Loading…</div>}>
               <Outlet />


### PR DESCRIPTION
## Summary
- move anchored chat bar to the screen bottom and expose its height via `--chatbar-h`
- add collapsible bottom dock with persistent state and quick-action icon row
- allow QuickActionBar to hide labels when showing icons only

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in voice files)*

------
https://chatgpt.com/codex/tasks/task_e_68a1062279208326bcfbda4383be3266