### PR TITLE
feat: add safe area layout

### DIFF
--- a/src/components/chat/AnchoredChatBar.tsx
+++ b/src/components/chat/AnchoredChatBar.tsx
@@ -138,7 +138,7 @@ export function AnchoredChatBar() {
     <div
       className="fixed inset-x-0 pointer-events-none"
       style={{
-        bottom: "calc(var(--kb-offset) + var(--safe-area-bottom))",
+        bottom: "var(--kb-offset)",
         zIndex: 70,
       }}
     >
@@ -150,7 +150,7 @@ export function AnchoredChatBar() {
       >
         {lastAssistant?.content}
       </div>
-      <div ref={ref} className="pointer-events-auto relative mx-3">
+      <div ref={ref} className="pointer-events-auto relative mx-3 pb-safe-bottom">
       <div className="glass-panel rounded-2xl p-2 elev flex items-center gap-2">
 
         <Button

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -1,5 +1,5 @@
 import { Link, useNavigate } from "react-router-dom";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { SoundControl } from "@/components/sounds/SoundControl";
 import { AuthMenu } from "@/components/auth/AuthMenu";
@@ -9,6 +9,7 @@ export default function AppHeader() {
   const { user, initializing } = useSupabaseAuth();
   const navigate = useNavigate();
   const [online, setOnline] = useState(true);
+  const headerRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
     const update = () => setOnline(typeof navigator !== "undefined" ? navigator.onLine : true);
@@ -21,8 +22,19 @@ export default function AppHeader() {
     };
   }, []);
 
+  useEffect(() => {
+    const el = headerRef.current;
+    if (!el) return;
+    const set = () =>
+      document.documentElement.style.setProperty("--header-h", `${el.offsetHeight}px`);
+    set();
+    const ro = new ResizeObserver(set);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
   return (
-    <header className="fixed top-0 inset-x-0 z-30">
+    <header ref={headerRef} className="fixed top-0 inset-x-0 z-30 pt-safe-top">
       <div className="px-4 sm:px-6">
         <div className="mt-3 glass-panel rounded-full px-3 py-2 elev flex items-center justify-between gap-3 animate-fade-in smooth">
           {/* Brand */}

--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -120,7 +120,7 @@ export default function AppShell() {
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -8 }}
             transition={{ duration: 0.18 }}
-            className="aurora-app pb-[calc(var(--dock-h)+var(--hud-gap)+var(--chatbar-h)+var(--kb-offset)+var(--safe-area-bottom))]"
+            className="aurora-app overflow-y-auto pt-[calc(var(--header-h)+var(--hud-gap))] pb-[calc(var(--dock-h)+var(--hud-gap)+var(--chatbar-h)+var(--kb-offset))]"
           >
             <Suspense fallback={<div className="p-6 opacity-70">Loading…</div>}>
               <Outlet />


### PR DESCRIPTION
## Summary
- ensure header sets safe-area height and top inset
- anchor chat bar with safe-area padding
- make app body scrollable with safe-area aware padding

## Testing
- `npm test`
- `npm run lint` *(fails: 217 errors, 21 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a1080a89708326ac192e428af23c1a