### PR TITLE
feat: improve modal accessibility with titles and descriptions

### DIFF
--- a/src/components/hypno/HypnoPanel.tsx
+++ b/src/components/hypno/HypnoPanel.tsx
@@ -5,6 +5,7 @@ import { useGameStore } from "@/game/store";
 import { REWARDS } from "@/game/QuestEngine";
 import { supabase } from "@/integrations/supabase/client";
 import { logEvent } from "@/integrations/supabase/gameSync";
+import { DialogTitle } from "@/components/ui/dialog";
 
 type Props = {
   onClose?: () => void;
@@ -52,7 +53,7 @@ export default function HypnoPanel({ onClose }: Props) {
     <div className="fixed inset-x-0 bottom-0" style={{ zIndex: "var(--z-modal)" }}>
       <div className="glass-panel rounded-t-2xl p-4 elev">
         <div className="flex items-center justify-between">
-          <h3 className="text-base font-semibold">Hypno Temple</h3>
+          <DialogTitle className="text-base font-semibold">Hypno Temple</DialogTitle>
           <button className="rounded-full px-3 py-1 bg-secondary" onClick={handleClose}>Close</button>
         </div>
         <div className="mt-3">

--- a/src/components/live/LiveFocusView.tsx
+++ b/src/components/live/LiveFocusView.tsx
@@ -6,6 +6,11 @@ import { Button } from '@/components/ui/button';
 import { useCurrentTask, type Task } from '@/state/task';
 import { FocusTimer } from './FocusTimer';
 import { useViewNav } from '@/state/view';
+import {
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 
 type Roadmap = {
   id: string;
@@ -174,9 +179,12 @@ export default function LiveFocusView() {
       <Button variant="ghost" className="self-start" onClick={() => open('home')}>
         Back
       </Button>
-      <h2 className="text-xl font-semibold">
-        {task ? task.title : 'No task selected'}
-      </h2>
+      <DialogHeader className="text-center">
+        <DialogTitle>{task ? task.title : 'No task selected'}</DialogTitle>
+        <DialogDescription>
+          Stay focused on your current task.
+        </DialogDescription>
+      </DialogHeader>
       <FocusTimer />
     </section>
   );

--- a/src/components/modals/ModalHost.tsx
+++ b/src/components/modals/ModalHost.tsx
@@ -4,7 +4,13 @@ import LiveFocusView from "@/components/live/LiveFocusView";
 import FocusView from "@/views/FocusView";
 import HypnoPanel from "@/components/hypno/HypnoPanel";
 import VoiceView from "@/views/VoiceView";
-import { Dialog, DialogContent } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
 import { useChatInputFocus } from "@/hooks/useChatInputFocus";
 import { useUIStore } from "@/state/ui";
 import { useEffect, type ReactNode } from "react";
@@ -72,7 +78,16 @@ export default function ModalHost() {
       className = "p-0 sm:max-w-lg";
       break;
     case "more":
-      content = <div>More</div>;
+      content = (
+        <>
+          <DialogHeader>
+            <DialogTitle>More</DialogTitle>
+            <DialogDescription>Additional options</DialogDescription>
+          </DialogHeader>
+          <div>More</div>
+        </>
+      );
+      className = "sm:max-w-md";
       break;
     case "inventory":
       content = <InventoryModal />;

--- a/src/views/BrainView.tsx
+++ b/src/views/BrainView.tsx
@@ -9,6 +9,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog';
 import { useChatInputFocus } from '@/hooks/useChatInputFocus';
@@ -199,7 +200,12 @@ export default function BrainView() {
 
   return (
     <div className="container mx-auto px-4 py-6 space-y-6">
-      <h1 className="text-2xl font-semibold">Brain</h1>
+      <DialogHeader>
+        <DialogTitle>Brain</DialogTitle>
+        <DialogDescription>
+          Search and manage stored memories.
+        </DialogDescription>
+      </DialogHeader>
       <div className="flex flex-wrap gap-2 items-center">
         <Input
           placeholder="Search memories"

--- a/src/views/JournalView.tsx
+++ b/src/views/JournalView.tsx
@@ -3,6 +3,11 @@ import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
+import {
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Flame, Mic, MicOff } from "lucide-react";
 import { toast } from "@/hooks/use-toast";
 import { VoiceIO } from "@/voice/voiceio";
@@ -109,13 +114,18 @@ export default function JournalView() {
 
   return (
     <div className="container mx-auto px-4 py-6 space-y-4">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold">Journal</h1>
-        <div className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-secondary text-secondary-foreground text-sm">
-          <Flame className="w-4 h-4 text-destructive" />
-          <span className="font-medium tabular-nums">{streak}</span>
+      <DialogHeader>
+        <div className="flex items-center justify-between">
+          <DialogTitle>Journal</DialogTitle>
+          <div className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-secondary text-secondary-foreground text-sm">
+            <Flame className="w-4 h-4 text-destructive" />
+            <span className="font-medium tabular-nums">{streak}</span>
+          </div>
         </div>
-      </div>
+        <DialogDescription>
+          Record your thoughts and feelings.
+        </DialogDescription>
+      </DialogHeader>
 
       <Card>
         <CardContent className="space-y-2 pt-4">

--- a/src/views/VoiceView.tsx
+++ b/src/views/VoiceView.tsx
@@ -1,6 +1,11 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { toast } from "@/components/ui/use-toast";
 import { Mic, MicOff, Save, Sparkles, Send } from "lucide-react";
 import { useViewNav } from "@/state/view";
@@ -64,8 +69,12 @@ export default function VoiceView() {
 
   return (
     <div className="container mx-auto px-4 py-6">
-      <h1 className="text-2xl font-semibold mb-2">Voice</h1>
-      <p className="opacity-70 mb-4">Press to talk. I’ll transcribe as you speak.</p>
+      <DialogHeader>
+        <DialogTitle>Voice</DialogTitle>
+        <DialogDescription>
+          Press to talk. I’ll transcribe as you speak.
+        </DialogDescription>
+      </DialogHeader>
 
       <div className="grid gap-4 md:grid-cols-3">
         <Card className="md:col-span-2">


### PR DESCRIPTION
## Summary
- ensure ModalHost "more" variant includes dialog title and description
- add DialogTitle and DialogDescription to Brain, Journal, Voice, LiveFocus, and Hypno views

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68a10ba8d2d083269ebbe3352fd257df