### PR TITLE
Handle missing usedTimes in subscription usage

### DIFF
--- a/src/modules/payments/__tests__/subscriptionManager.test.tsx
+++ b/src/modules/payments/__tests__/subscriptionManager.test.tsx
@@ -1,0 +1,72 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { jest } from '@jest/globals';
+import { SubscriptionManager } from '../components/SubscriptionManager';
+import { useSubscription } from '../hooks/useSubscription';
+
+jest.mock('../hooks/useSubscription');
+const mockUseSubscription = useSubscription as jest.Mock;
+
+const baseSubscription = {
+  id: 'sub_123',
+  userId: 'user_1',
+  planId: 'pro',
+  status: 'active',
+  currentPeriodStart: new Date().toISOString(),
+  currentPeriodEnd: new Date().toISOString(),
+  cancelAtPeriodEnd: false,
+  stripeCustomerId: 'cust_123',
+  stripeSubscriptionId: 'stripe_sub_123',
+  billingCycle: 'monthly' as const,
+};
+
+describe('SubscriptionManager refresh', () => {
+  beforeEach(() => {
+    mockUseSubscription.mockReset();
+  });
+
+  it('handles missing usage object', async () => {
+    const refetch = jest.fn();
+    mockUseSubscription.mockReturnValue({
+      subscription: baseSubscription,
+      usage: null,
+      isLoading: false,
+      error: null,
+      isOnTrial: false,
+      trialDaysLeft: 0,
+      canAccessFeature: jest.fn(),
+      cancelSubscription: jest.fn(),
+      updateSubscription: jest.fn(),
+      refetch,
+    });
+
+    const user = userEvent.setup();
+    render(<SubscriptionManager />);
+    await user.click(screen.getByRole('button', { name: /refresh/i }));
+    expect(refetch).toHaveBeenCalled();
+  });
+
+  it('handles missing usedTimes property', async () => {
+    const refetch = jest.fn();
+    mockUseSubscription.mockReturnValue({
+      subscription: baseSubscription,
+      usage: { aiMessagesUsed: 1, widgetsActive: 0, teamSeatsUsed: 0 },
+      isLoading: false,
+      error: null,
+      isOnTrial: false,
+      trialDaysLeft: 0,
+      canAccessFeature: jest.fn(),
+      cancelSubscription: jest.fn(),
+      updateSubscription: jest.fn(),
+      refetch,
+    });
+
+    const user = userEvent.setup();
+    render(<SubscriptionManager />);
+    await user.click(screen.getByRole('button', { name: /refresh/i }));
+    expect(refetch).toHaveBeenCalled();
+  });
+});

--- a/src/modules/payments/components/SubscriptionManager.tsx
+++ b/src/modules/payments/components/SubscriptionManager.tsx
@@ -56,6 +56,11 @@ function SubscriptionManagerUI() {
     }
   };
 
+  const handleRefresh = () => {
+    const usedTimes = usage?.usedTimes ?? 0;
+    refetch();
+  };
+
   if (isLoading) {
     return (
       <div className="max-w-4xl mx-auto p-6">
@@ -99,7 +104,7 @@ function SubscriptionManagerUI() {
     <div className="max-w-4xl mx-auto p-6 space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Subscription Management</h1>
-        <Button variant="outline" onClick={refetch}>
+        <Button variant="outline" onClick={handleRefresh}>
           <Settings className="w-4 h-4 mr-2" />
           Refresh
         </Button>

--- a/src/modules/payments/types/subscription.ts
+++ b/src/modules/payments/types/subscription.ts
@@ -41,4 +41,5 @@ export interface UsageStats {
   aiMessagesUsed: number;
   widgetsActive: number;
   teamSeatsUsed: number;
+  usedTimes?: number;
 }


### PR DESCRIPTION
## Summary
- default to 0 when usage.usedTimes is missing and refresh subscription
- allow UsageStats to omit usedTimes
- test refresh handling without usage data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a10b9663448326941d0793be3536ad