### PR TITLE
feat: guard telemetry with env flag

### DIFF
--- a/docs/dev/analytics.md
+++ b/docs/dev/analytics.md
@@ -1,0 +1,20 @@
+# Analytics Telemetry
+
+The app can report anonymous usage telemetry to an analytics server. Telemetry
+is **disabled in development** and when no endpoint is configured.
+
+## Setup
+
+1. Provide an HTTP endpoint that accepts a `POST` request with a JSON array of
+   telemetry events. Each event contains:
+   - `event`: name of the event
+   - `data`: optional object payload
+   - `ts`: timestamp in milliseconds
+2. Set the `VITE_ANALYTICS_ENDPOINT` environment variable in your `.env` file to
+   the URL of your analytics endpoint (e.g. `/api/analytics`).
+3. Optionally set `VITE_ANALYTICS_ENABLED=false` to explicitly disable telemetry
+   even when an endpoint exists.
+
+The client sends events using `navigator.sendBeacon` when available or falls back
+to `fetch()` with best-effort delivery. Non-OK responses and network errors are
+silently ignored.

--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -6,15 +6,23 @@ export type TelemetryEvent = {
 
 const queue: TelemetryEvent[] = [];
 let timer: number | null = null;
-const endpoint = '/api/analytics';
+const endpoint = import.meta.env.VITE_ANALYTICS_ENDPOINT;
+const enabled =
+  !import.meta.env.DEV &&
+  Boolean(endpoint) &&
+  import.meta.env.VITE_ANALYTICS_ENABLED !== 'false';
 
 function flush() {
   timer = null;
   if (!queue.length) return;
   const events = queue.splice(0);
+  if (!enabled || !endpoint) return; // skip in dev or when disabled
   try {
     const body = JSON.stringify(events);
-    if (typeof navigator !== 'undefined' && typeof (navigator as any).sendBeacon === 'function') {
+    if (
+      typeof navigator !== 'undefined' &&
+      typeof (navigator as any).sendBeacon === 'function'
+    ) {
       (navigator as any).sendBeacon(endpoint, body);
     } else if (typeof fetch === 'function') {
       // fire and forget; keepalive allows it to run during unload
@@ -23,7 +31,13 @@ function flush() {
         body,
         keepalive: true,
         headers: { 'Content-Type': 'application/json' },
-      });
+      })
+        .then((res) => {
+          if (!res.ok) {
+            // ignore non-OK responses
+          }
+        })
+        .catch(() => {});
     }
   } catch {
     // ignore errors
@@ -31,6 +45,7 @@ function flush() {
 }
 
 export function track(event: string, data: Record<string, any> = {}): void {
+  if (!enabled) return;
   queue.push({ event, data, ts: Date.now() });
   if (timer === null) {
     timer = setTimeout(flush, 1000) as unknown as number;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -8,5 +8,7 @@ interface ImportMetaEnv {
   readonly VITE_SUPABASE_URL: string;
   readonly VITE_SUPABASE_ANON_KEY: string;
   readonly VITE_ELEVENLABS_DEFAULT_VOICE_ID?: string;
+  readonly VITE_ANALYTICS_ENDPOINT?: string;
+  readonly VITE_ANALYTICS_ENABLED?: string;
 }
 


### PR DESCRIPTION
## Summary
- gate client telemetry behind VITE_ANALYTICS_* flags and skip in dev
- ignore failed fetch responses when flushing telemetry
- document analytics server setup

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a10edbf06c8326b9cf24bb90a9131a