### PR TITLE
Handle voice service failures

### DIFF
--- a/src/voice/__tests__/voiceService.test.ts
+++ b/src/voice/__tests__/voiceService.test.ts
@@ -82,9 +82,10 @@ beforeEach(() => {
     value: { getUserMedia: jest.fn().mockResolvedValue(new MockMediaStream()) },
     configurable: true,
   });
-  (global as any).fetch = jest
-    .fn()
-    .mockResolvedValue({ json: async () => ({ sdp: 'answer', type: 'answer' }) });
+  (global as any).fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ sdp: 'answer', type: 'answer' }),
+  });
 
   (window as any).speechSynthesis = {
     cancel: jest.fn(),

--- a/src/voice/voiceService.ts
+++ b/src/voice/voiceService.ts
@@ -110,22 +110,46 @@ class VoiceService {
       this.audios.add(audio);
     };
 
-    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-    this.stream = stream;
-    this.streams.add(stream);
-    stream.getTracks().forEach((t) => pc.addTrack(t, stream));
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      this.stream = stream;
+      this.streams.add(stream);
+      if (pc.signalingState === 'closed') {
+        this.stopListening();
+        return;
+      }
+      stream.getTracks().forEach((t) => pc.addTrack(t, stream));
 
-    const offer = await pc.createOffer();
-    await pc.setLocalDescription(offer);
-    const res = await fetch('/voice', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ sdp: offer.sdp, type: offer.type }),
-    });
-    const answer = await res.json();
-    await pc.setRemoteDescription(answer);
-    useVoiceStore.getState().setListening(true);
-    useVoiceStore.getState().setThinking(false);
+      const offer = await pc.createOffer();
+      await pc.setLocalDescription(offer);
+      let res: Response;
+      try {
+        res = await fetch('/voice', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sdp: offer.sdp, type: offer.type }),
+        });
+      } catch {
+        bus.emit('tts/pill', {
+          message: 'Unable to reach the voice server. Please try again later.',
+        });
+        throw new Error('voice endpoint unreachable');
+      }
+
+      if (!res.ok) {
+        bus.emit('tts/pill', {
+          message: 'Unable to reach the voice server. Please try again later.',
+        });
+        throw new Error(`voice endpoint error: ${res.status}`);
+      }
+
+      const answer = await res.json();
+      await pc.setRemoteDescription(answer);
+      useVoiceStore.getState().setListening(true);
+      useVoiceStore.getState().setThinking(false);
+    } catch {
+      this.stopListening();
+    }
   }
 
   stopListening() {


### PR DESCRIPTION
## Summary
- Guard against closed WebRTC connections before adding tracks
- Reset voice state on any startListening failure and check voice endpoint status
- Ensure tests mock successful voice endpoint responses

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a10ee00cfc8326991abdfcdc86e45f