### PR TITLE
Handle speech recognition state

### DIFF
--- a/src/components/chat/AnchoredChatBar.tsx
+++ b/src/components/chat/AnchoredChatBar.tsx
@@ -20,6 +20,7 @@ export function AnchoredChatBar() {
   const listenMode = useVoiceStore((s) => s.listenMode);
   const [suggestion, setSuggestion] = useState<string | null>(null);
   const recognitionRef = useRef<SpeechRecognition | null>(null);
+  const recognizingRef = useRef(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const pressStartRef = useRef<number | null>(null);
   const ref = useRef<HTMLDivElement>(null);
@@ -60,19 +61,38 @@ export function AnchoredChatBar() {
         setSuggestion(transcript);
       }
     };
-    rec.onend = () => stopBusListening();
+    rec.onstart = () => {
+      recognizingRef.current = true;
+    };
+    rec.onend = () => {
+      recognizingRef.current = false;
+      stopBusListening();
+    };
     recognitionRef.current = rec;
     return () => {
       rec.stop();
       recognitionRef.current = null;
+      recognizingRef.current = false;
     };
   }, []);
 
   const startListening = () => {
     const rec = recognitionRef.current;
-    if (!rec || listening) return;
+    if (!rec || listening || recognizingRef.current) return;
     startBusListening();
-    rec.start();
+    try {
+      rec.start();
+    } catch (err) {
+      if ((err as DOMException)?.name === "InvalidStateError") {
+        recognizingRef.current = false;
+        stopBusListening();
+        try {
+          useVoiceStore.getState().setListening(false);
+        } catch {
+          /* empty */
+        }
+      }
+    }
   };
 
   const stopListening = () => {
@@ -81,6 +101,12 @@ export function AnchoredChatBar() {
     rec.stop();
     stopBusListening();
   };
+
+  useEffect(() => {
+    return () => {
+      stopListening();
+    };
+  }, [listenMode]);
 
   const handlePressStart = () => {
     pressStartRef.current = Date.now();


### PR DESCRIPTION
## Summary
- Track speech recognition lifecycle to avoid duplicate starts and stop voice bus when ending
- Catch InvalidStateError from SpeechRecognition.start and reset listening state
- Stop listening on component unmount or listen mode changes

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any errors across repo)*

------
https://chatgpt.com/codex/tasks/task_e_68a10ee3413c8326bf0c442e126875eb