### PR TITLE
feat: add ViewHeader helper

### DIFF
--- a/src/components/live/LiveFocusView.tsx
+++ b/src/components/live/LiveFocusView.tsx
@@ -6,11 +6,7 @@ import { Button } from '@/components/ui/button';
 import { useCurrentTask, type Task } from '@/state/task';
 import { FocusTimer } from './FocusTimer';
 import { useViewNav } from '@/state/view';
-import {
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+import ViewHeader from '@/components/view/ViewHeader';
 
 type Roadmap = {
   id: string;
@@ -179,12 +175,11 @@ export default function LiveFocusView() {
       <Button variant="ghost" className="self-start" onClick={() => open('home')}>
         Back
       </Button>
-      <DialogHeader className="text-center">
-        <DialogTitle>{task ? task.title : 'No task selected'}</DialogTitle>
-        <DialogDescription>
-          Stay focused on your current task.
-        </DialogDescription>
-      </DialogHeader>
+      <ViewHeader
+        className="text-center"
+        title={task ? task.title : 'No task selected'}
+        description="Stay focused on your current task."
+      />
       <FocusTimer />
     </section>
   );

--- a/src/components/view/ViewHeader.tsx
+++ b/src/components/view/ViewHeader.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useRef, useState } from "react";
+import { DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+
+interface ViewHeaderProps {
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  className?: string;
+}
+
+export default function ViewHeader({ title, description, className }: ViewHeaderProps) {
+  const titleRef = useRef<HTMLHeadingElement>(null);
+  const [inDialog, setInDialog] = useState(false);
+
+  useEffect(() => {
+    const el = titleRef.current;
+    if (el && el.closest('[role="dialog"]')) {
+      setInDialog(true);
+    }
+  }, []);
+
+  if (inDialog) {
+    return (
+      <DialogHeader className={className}>
+        <DialogTitle ref={titleRef}>{title}</DialogTitle>
+        {description && <DialogDescription>{description}</DialogDescription>}
+      </DialogHeader>
+    );
+  }
+
+  return (
+    <header className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)}>
+      <h1 ref={titleRef} className="text-lg font-semibold leading-none tracking-tight">
+        {title}
+      </h1>
+      {description && <p className="text-sm text-muted-foreground">{description}</p>}
+    </header>
+  );
+}
+

--- a/src/views/BrainView.tsx
+++ b/src/views/BrainView.tsx
@@ -4,14 +4,8 @@ import { exportEncryptedBrain, importEncryptedBrain } from '@/memory/brainBackup
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-  DialogFooter,
-} from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogFooter } from '@/components/ui/dialog';
+import ViewHeader from '@/components/view/ViewHeader';
 import { useChatInputFocus } from '@/hooks/useChatInputFocus';
 import {
   Select,
@@ -200,12 +194,10 @@ export default function BrainView() {
 
   return (
     <div className="container mx-auto px-4 py-6 space-y-6">
-      <DialogHeader>
-        <DialogTitle>Brain</DialogTitle>
-        <DialogDescription>
-          Search and manage stored memories.
-        </DialogDescription>
-      </DialogHeader>
+      <ViewHeader
+        title="Brain"
+        description="Search and manage stored memories."
+      />
       <div className="flex flex-wrap gap-2 items-center">
         <Input
           placeholder="Search memories"
@@ -351,9 +343,7 @@ export default function BrainView() {
             focusChatInput();
           }}
         >
-          <DialogHeader>
-            <DialogTitle>Edit Memory</DialogTitle>
-          </DialogHeader>
+          <ViewHeader title="Edit Memory" />
           <div className="space-y-2 py-2">
             <Input
               value={editContent}

--- a/src/views/JournalView.tsx
+++ b/src/views/JournalView.tsx
@@ -3,11 +3,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
-import {
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import ViewHeader from "@/components/view/ViewHeader";
 import { Flame, Mic, MicOff } from "lucide-react";
 import { toast } from "@/hooks/use-toast";
 import { VoiceIO } from "@/voice/voiceio";
@@ -114,18 +110,16 @@ export default function JournalView() {
 
   return (
     <div className="container mx-auto px-4 py-6 space-y-4">
-      <DialogHeader>
-        <div className="flex items-center justify-between">
-          <DialogTitle>Journal</DialogTitle>
-          <div className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-secondary text-secondary-foreground text-sm">
-            <Flame className="w-4 h-4 text-destructive" />
-            <span className="font-medium tabular-nums">{streak}</span>
-          </div>
+      <div className="flex items-start justify-between">
+        <ViewHeader
+          title="Journal"
+          description="Record your thoughts and feelings."
+        />
+        <div className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-secondary text-secondary-foreground text-sm">
+          <Flame className="w-4 h-4 text-destructive" />
+          <span className="font-medium tabular-nums">{streak}</span>
         </div>
-        <DialogDescription>
-          Record your thoughts and feelings.
-        </DialogDescription>
-      </DialogHeader>
+      </div>
 
       <Card>
         <CardContent className="space-y-2 pt-4">

--- a/src/views/VoiceView.tsx
+++ b/src/views/VoiceView.tsx
@@ -1,11 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import ViewHeader from "@/components/view/ViewHeader";
 import { toast } from "@/components/ui/use-toast";
 import { Mic, MicOff, Save, Sparkles, Send } from "lucide-react";
 import { useViewNav } from "@/state/view";
@@ -69,12 +65,10 @@ export default function VoiceView() {
 
   return (
     <div className="container mx-auto px-4 py-6">
-      <DialogHeader>
-        <DialogTitle>Voice</DialogTitle>
-        <DialogDescription>
-          Press to talk. I’ll transcribe as you speak.
-        </DialogDescription>
-      </DialogHeader>
+      <ViewHeader
+        title="Voice"
+        description="Press to talk. I’ll transcribe as you speak."
+      />
 
       <div className="grid gap-4 md:grid-cols-3">
         <Card className="md:col-span-2">


### PR DESCRIPTION
## Summary
- create ViewHeader component that uses DialogHeader/Title/Description when inside a dialog and falls back to semantic header markup otherwise
- refactor JournalView, VoiceView, BrainView, and LiveFocusView to use ViewHeader instead of direct dialog imports

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a10fb1d4a483269ffe8ddd9f5690ee