### PR TITLE
Use asset import for sql.js wasm

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -19,5 +19,6 @@ module.exports = {
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
     '^@/(.*)$': '<rootDir>/src/$1',
+    '^sql.js/dist/sql-wasm\\.wasm\\?url$': '<rootDir>/tests/sql-wasm-url.cjs',
   },
 };

--- a/src/memory/brainDb.ts
+++ b/src/memory/brainDb.ts
@@ -1,4 +1,5 @@
 import initSqlJs, { Database } from "sql.js";
+import wasmUrl from "sql.js/dist/sql-wasm.wasm?url";
 import { toast } from "@/hooks/use-toast";
 
 const DB_FILE = "brain.db";
@@ -148,19 +149,7 @@ async function idbSet(key: string, value: Uint8Array): Promise<void> {
 export async function openBrainDb(): Promise<BrainDatabase> {
   if (cachedDb) return cachedDb;
   try {
-    const importMetaUrl = (() => {
-      try {
-        return eval('import.meta.url') as string;
-      } catch {
-        return undefined;
-      }
-    })();
-    const SQL = await initSqlJs({
-      locateFile: (file: string) =>
-        importMetaUrl
-          ? new URL(`../../node_modules/sql.js/dist/${file}`, importMetaUrl).toString()
-          : `node_modules/sql.js/dist/${file}`,
-    });
+    const SQL = await initSqlJs({ locateFile: () => wasmUrl });
 
     let opfsHandle: FileSystemFileHandle | null = null;
     if (

--- a/tests/sql-wasm-url.cjs
+++ b/tests/sql-wasm-url.cjs
@@ -1,0 +1,3 @@
+const path = require('path');
+const wasmPath = path.join(__dirname, '../node_modules/sql.js/dist/sql-wasm.wasm');
+module.exports = { default: wasmPath };


### PR DESCRIPTION
## Summary
- load sql.js wasm via explicit asset import and drop manual node_modules path
- provide Jest mapping to resolve wasm URL during tests

## Testing
- `npm test`
- `npm run build` *(fails: Conversion of type 'SelectQueryError…')*
- `curl -I http://localhost:8080/node_modules/sql.js/dist/sql-wasm.wasm`


------
https://chatgpt.com/codex/tasks/task_e_68a12c1d3d6c8326b69893a7905f0a47