### PR TITLE
fix: handle renderer debug check properly

### DIFF
--- a/src/components/avatar/AuroraSphere.tsx
+++ b/src/components/avatar/AuroraSphere.tsx
@@ -160,7 +160,10 @@ export function AuroraSphere({
 
       if (disposed || !renderer) return;
 
-      (renderer as any)?.debug?.checkShaderErrors = true;
+      const debug = (renderer as any).debug;
+      if (debug) {
+        debug.checkShaderErrors = true;
+      }
 
       renderer.setSize(size, size);
       mount.appendChild(renderer.domElement);


### PR DESCRIPTION
## Summary
- ensure shader debug checks are enabled only when debug object is present

## Testing
- `npm run build` *(fails: Argument of type ...)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a12e910b248326b094294c4da8a5ed