### PR TITLE
Refactor QuickActionBar to use quick actions store

### DIFF
--- a/src/components/navigation/QuickActionBar.tsx
+++ b/src/components/navigation/QuickActionBar.tsx
@@ -1,16 +1,7 @@
-import { Mic } from "lucide-react";
-import { useUIStore } from "@/state/ui";
-
-const actions = [
-  {
-    id: "voice",
-    label: "Voice",
-    icon: Mic,
-    onClick: () => useUIStore.getState().openModal("voice"),
-  },
-];
+import { useQuickActions } from "./quickActions";
 
 export function QuickActionBar({ iconsOnly = false }: { iconsOnly?: boolean }) {
+  const actions = useQuickActions();
   if (!actions.length) return null;
   return (
     <ul className="flex items-center gap-3">

--- a/src/state/quickActions.ts
+++ b/src/state/quickActions.ts
@@ -1,35 +1,54 @@
-import { ListTodo, Target, ChartBar, Settings as SettingsIcon } from "lucide-react";
+import {
+  ListTodo,
+  Target,
+  ChartBar,
+  Settings as SettingsIcon,
+  BookOpen,
+  Radio,
+} from "lucide-react";
 import { registerQuickAction } from "@/components/navigation/quickActions";
 import { useUIStore } from "@/state/ui";
 
-const uiStore = useUIStore.getState();
+registerQuickAction({
+  id: "journal",
+  label: "Journal",
+  icon: BookOpen,
+  onClick: () => useUIStore.getState().openModal("journal"),
+});
+
+registerQuickAction({
+  id: "live",
+  label: "Live",
+  icon: Radio,
+  onClick: () => useUIStore.getState().openModal("live"),
+});
 
 registerQuickAction({
   id: "tasks",
   label: "Tasks",
   icon: ListTodo,
-  onClick: () => uiStore.openModal("tasks"),
+  onClick: () => useUIStore.getState().openModal("tasks"),
 });
 
 registerQuickAction({
   id: "goals",
   label: "Goals",
   icon: Target,
-  onClick: () => uiStore.openModal("goals"),
+  onClick: () => useUIStore.getState().openModal("goals"),
 });
 
 registerQuickAction({
   id: "analytics",
   label: "Analytics",
   icon: ChartBar,
-  onClick: () => uiStore.openModal("analytics"),
+  onClick: () => useUIStore.getState().openModal("analytics"),
 });
 
 registerQuickAction({
   id: "settings",
   label: "Settings",
   icon: SettingsIcon,
-  onClick: () => uiStore.openModal("settings"),
+  onClick: () => useUIStore.getState().openModal("settings"),
 });
 
 export {}; // ensure this module is treated as a module


### PR DESCRIPTION
## Summary
- Replace hard-coded quick action buttons with `useQuickActions` hook
- Register journal and live quick actions with Lucide icons and modal handlers

## Testing
- `npm run lint` *(fails: Unexpected any / Empty block statement)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a130c1b6fc83268d215d726416a9e1