### PR TITLE
Use modals for HUD note and brain actions

### DIFF
--- a/src/game/hud/useHUDActions.ts
+++ b/src/game/hud/useHUDActions.ts
@@ -1,11 +1,11 @@
 import type { QuickActionKey } from "./hud.data";
-import { addNote, startVoiceNote } from "@/utils/moments";
+import { startVoiceNote } from "@/utils/moments";
 import { useUIStore } from "@/state/ui";
 
 export function useHUDActions() {
   const run = (a: QuickActionKey) => {
     if (a === "addNote") {
-      addNote();
+      useUIStore.getState().openModal("journal");
       return;
     }
     if (a === "voiceNote") {
@@ -16,15 +16,15 @@ export function useHUDActions() {
       useUIStore.getState().openModal("tasks");
       return;
     }
+    if (a === "openBrain") {
+      useUIStore.getState().openModal("brain");
+      return;
+    }
     const eventMap: Record<string, string> = {
       startFocus: "startFocus",
       startHypnosis: "startHypnosis",
-      voiceNote: "voiceNote",
-      addNote: "addNote",
       openMap: "openMap",
       openBrowser: "openBrowser",
-      openBrain: "openBrain",
-      openTasks: "openTasks",
     };
     const name = eventMap[a] ?? a;
     window.dispatchEvent(new CustomEvent("mos", { detail: { type: name } }));


### PR DESCRIPTION
## Summary
- open journal modal for HUD "add note" action
- open brain modal for HUD "open brain" action
- drop MOS event dispatch for note and brain quick actions

## Testing
- `npm test`
- `npm run lint` *(fails: numerous pre-existing lint errors)*
- `npx eslint src/game/hud/useHUDActions.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a130c7252083268975e2e4f016ddeb