### PR TITLE
fix: declare particle shell resources

### DIFF
--- a/src/components/avatar/AuroraSphere.tsx
+++ b/src/components/avatar/AuroraSphere.tsx
@@ -133,6 +133,8 @@ export function AuroraSphere({
     let renderer: THREE.WebGLRenderer | WebGPURenderer | null = null;
     let geometry: THREE.IcosahedronGeometry | null = null;
     let material: MeshBasicNodeMaterial | null = null;
+    let particleGeometry: THREE.BufferGeometry | null = null;
+    let particleMaterial: THREE.PointsMaterial | null = null;
 
     let disposed = false;
 


### PR DESCRIPTION
## Summary
- declare particleGeometry and particleMaterial to fix ReferenceError
- ensure particle shell materials are disposed during cleanup

## Testing
- `npm test`
- `npm run build` *(fails: conversion of type 'SelectQueryError...' in PlanView.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a1386d92b48326aaabf8deb388e596