### PR TITLE
Ensure memory backup imports standard library modules

### DIFF
--- a/memory/backup.py
+++ b/memory/backup.py
@@ -1,5 +1,5 @@
-import os
 import io
+import os
 import tarfile
 
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM

--- a/tests/test_memory_backup.py
+++ b/tests/test_memory_backup.py
@@ -1,0 +1,25 @@
+import shutil
+
+from memory import backup
+
+
+def test_export_import_round_trip(tmp_path):
+    db_file = tmp_path / "memory.db"
+    db_file.write_text("data")
+    chroma_dir = tmp_path / "chroma_db"
+    chroma_dir.mkdir()
+    (chroma_dir / "vec").write_text("vector")
+
+    backup.DB_PATH = str(db_file)
+    backup.CHROMA_PATH = str(chroma_dir)
+
+    backup_path = tmp_path / "backup.bin"
+    backup.export_backup(str(backup_path), "pass")
+    assert backup_path.exists()
+
+    db_file.unlink()
+    shutil.rmtree(chroma_dir)
+
+    backup.import_backup(str(backup_path), "pass")
+    assert db_file.exists()
+    assert chroma_dir.exists()


### PR DESCRIPTION
## Summary
- import io, os and tarfile at top of memory/backup.py
- add tests verifying export and import backup round trip

## Testing
- `ruff check memory/backup.py tests/test_memory_backup.py`
- `PYTHONPATH=. pytest tests/test_memory_backup.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1392255a08326b324af571d854753