### PR TITLE
Use basic embedding for vector store

### DIFF
--- a/memory/vector_store.py
+++ b/memory/vector_store.py
@@ -80,8 +80,8 @@ class VectorStore:
     def _embed(self, text: str) -> np.ndarray:
         if self._embedder is not None:
             return np.array(self._embedder.encode(text))
-        # Fallback embedding using deterministic hash to avoid heavy deps
-        return np.array([float(abs(hash(text)) % 1_000_000)], dtype=float)
+        # Fallback embedding using lightweight hashing to approximate semantics
+        return self._basic_embed(text)
 
     # ------------------------------------------------------------------
     def embed(self, text: str) -> np.ndarray:

--- a/tests/test_memory_recall.py
+++ b/tests/test_memory_recall.py
@@ -26,8 +26,13 @@ def _brain() -> BrainAgent:
 
 def test_similarity_recall(monkeypatch):
     """The store should return memories relevant to the query."""
-    mem.save_memory("My secret hobby is alpine-unicycling")
+    mem.cur.execute("DELETE FROM memories")
+    mem.conn.commit()
+    mem.vector_store.clear()
+
+    # Insert an unrelated memory first to ensure retrieval is similarity based
     mem.save_memory("Completely unrelated fact")
+    mem.save_memory("My secret hobby is alpine-unicycling")
 
     results = mem.query_memory("alpine-unicycling", k=1)
     assert results and "alpine-unicycling" in results[0]["text"]


### PR DESCRIPTION
## Summary
- replace one-element hash embeddings with lightweight hashed character embeddings
- adjust memory recall test to verify similarity-based retrieval

## Testing
- `python -m pytest tests/test_memory_recall.py tests/test_memory_api.py tests/test_memory_dedupe.py tests/test_memory_daily_compaction.py`


------
https://chatgpt.com/codex/tasks/task_e_68a13a909eb88326be80e27ba421570c