### PR TITLE
Use tiktoken for accurate token estimation

### DIFF
--- a/orchestration/router.py
+++ b/orchestration/router.py
@@ -16,6 +16,13 @@ import socket
 
 from models import preload as preload_models
 
+try:  # pragma: no cover - import guard
+    import tiktoken
+    _ENCODING = tiktoken.get_encoding("cl100k_base")
+except Exception:  # pragma: no cover - graceful fallback
+    tiktoken = None
+    _ENCODING = None
+
 
 class Model(Protocol):
     """Callable interface for language models."""
@@ -124,8 +131,14 @@ class ModelRouter:
         self.logger = logger or UsageLogger()
 
     def _estimate_tokens(self, text: str) -> int:
-        """Return a rough token count for ``text``."""
+        """Return a token count for ``text``.
 
+        The router prefers ``tiktoken`` for accuracy but falls back to a
+        simple whitespace split when the library is unavailable.
+        """
+
+        if _ENCODING is not None:
+            return len(_ENCODING.encode(text))
         return len(text.split())
 
     def route(self, prompt: str, depth: int = 0) -> str:

--- a/tests/test_model_router.py
+++ b/tests/test_model_router.py
@@ -1,6 +1,9 @@
 from pathlib import Path
 import importlib.util
+import json
 import sys
+
+import pytest
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 sys.path.append(str(BASE_DIR))
@@ -55,3 +58,30 @@ def test_model_router_sanitizes_prompt_before_cloud(monkeypatch, tmp_path):
     assert result == "cloud"
     assert captured["cloud"] == "Email [REDACTED_EMAIL] or call [REDACTED_PHONE]"
     assert "local" not in captured
+
+
+def test_token_estimation_with_tiktoken(monkeypatch, tmp_path):
+    monkeypatch.setattr(router_module, "is_online", lambda: True)
+
+    gemini_calls: list[str] = []
+    chatgpt_calls: list[str] = []
+
+    def gemini_model(prompt: str) -> str:
+        gemini_calls.append(prompt)
+        return "gemini"
+
+    def chatgpt_model(prompt: str) -> str:
+        chatgpt_calls.append(prompt)
+        return "chatgpt"
+
+    config = RouterConfig(max_gemini_tokens=3, max_chatgpt_cost=1.0)
+    logger = UsageLogger(tmp_path / "usage.log")
+    router = ModelRouter(gemini_model, chatgpt_model, config=config, logger=logger)
+
+    router.route("Hello, world!")  # 4 tokens via tiktoken, 2 words via split
+
+    assert chatgpt_calls and not gemini_calls
+
+    record = json.loads((tmp_path / "usage.log").read_text().splitlines()[-1])
+    assert record["tokens"] == 4
+    assert record["cost"] == pytest.approx(4 * config.chatgpt_cost_per_token)


### PR DESCRIPTION
## Summary
- Use tiktoken to compute precise token counts for routing decisions
- Base cost calculations and logs on the new token counts
- Add regression test ensuring the tiktoken tokenizer triggers routing when word counts would not

## Testing
- `pytest tests/test_model_router.py tests/test_router_hybrid.py tests/test_router_metrics.py`

------
https://chatgpt.com/codex/tasks/task_e_68a13a9200308326b17595a5b4c8be77