### PR TITLE
Add API key protection for memory API

### DIFF
--- a/api/memory.py
+++ b/api/memory.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
-from fastapi import FastAPI, HTTPException
+import os
+
+from fastapi import Depends, FastAPI, Header, HTTPException, status
 from pydantic import BaseModel
 
-from memory.store import (
-    delete_memory,
-    list_memories,
-    save_memory,
-    update_memory,
-)
+from memory.store import delete_memory, list_memories, save_memory, update_memory
 
-app = FastAPI()
+
+def verify_api_key(x_api_key: str | None = Header(None, alias="X-API-Key")) -> None:
+    """Ensure the provided API key matches the configured value."""
+    expected = os.getenv("MEMORY_API_KEY")
+    if expected is None or x_api_key != expected:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+
+
+app = FastAPI(dependencies=[Depends(verify_api_key)])
 
 
 class Memory(BaseModel):

--- a/docs/memory-api.md
+++ b/docs/memory-api.md
@@ -1,0 +1,20 @@
+# Memory API
+
+All endpoints in `api/memory.py` require a valid API key.
+
+## Configuration
+
+Set the expected key in the `MEMORY_API_KEY` environment variable before starting the server:
+
+```bash
+export MEMORY_API_KEY="your-secret-key"
+uvicorn api.memory:app
+```
+
+## Usage
+
+Clients must send the same value in the `X-API-Key` header with every request:
+
+```bash
+curl -H "X-API-Key: your-secret-key" http://localhost:8000/memories
+```

--- a/tests/test_memory_api.py
+++ b/tests/test_memory_api.py
@@ -1,7 +1,12 @@
+import os
+
 from fastapi.testclient import TestClient
 
 from api.memory import app
 from memory import store as mem
+
+
+API_KEY = "secret"
 
 
 def setup_function(_):
@@ -9,6 +14,11 @@ def setup_function(_):
     mem.cur.execute("DELETE FROM memories")
     mem.conn.commit()
     mem.vector_store.clear()
+    os.environ["MEMORY_API_KEY"] = API_KEY
+
+
+def auth_headers(key: str = API_KEY) -> dict[str, str]:
+    return {"X-API-Key": key}
 
 
 def test_delete_removes_embedding_and_metadata():
@@ -16,6 +26,7 @@ def test_delete_removes_embedding_and_metadata():
     resp = client.post(
         "/memories",
         json={"text": "delete me", "metadata": {"tag": "temp"}},
+        headers=auth_headers(),
     )
     assert resp.status_code == 200
     mem_id = resp.json()["id"]
@@ -23,7 +34,7 @@ def test_delete_removes_embedding_and_metadata():
     # ensure the memory can be retrieved before deletion
     assert mem.query_memory("delete me")
 
-    del_resp = client.delete(f"/memories/{mem_id}")
+    del_resp = client.delete(f"/memories/{mem_id}", headers=auth_headers())
     assert del_resp.status_code == 200
 
     # embedding should be gone
@@ -32,3 +43,15 @@ def test_delete_removes_embedding_and_metadata():
     # database row should be removed
     mem.cur.execute("SELECT id FROM memories WHERE id=?", (mem_id,))
     assert mem.cur.fetchone() is None
+
+
+def test_request_without_api_key_is_unauthorized():
+    client = TestClient(app)
+    resp = client.get("/memories")
+    assert resp.status_code == 401
+
+
+def test_request_with_wrong_api_key_is_unauthorized():
+    client = TestClient(app)
+    resp = client.get("/memories", headers=auth_headers("bad"))
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- require `X-API-Key` header for all memory API routes
- document `MEMORY_API_KEY` configuration and header usage
- test authorized and unauthorized access to memory API

## Testing
- `PYTHONPATH=. pytest tests/test_memory_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a13be882608326b989550cc8c50759