### PR TITLE
fix: guard AuroraSphere time uniform update

### DIFF
--- a/src/components/avatar/AuroraSphere.tsx
+++ b/src/components/avatar/AuroraSphere.tsx
@@ -169,7 +169,7 @@ export function AuroraSphere({
 
       // shader time
       const time = performance.now() / 1000;
-      if (mat) {
+      if (mat?.uniforms?.uTime) {
         (mat.uniforms.uTime as THREE.IUniform<number>).value = time;
       }
 


### PR DESCRIPTION
## Summary
- avoid runtime errors by checking `uTime` uniform before updating the shader

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any - 231 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a13d0077c883268dda9450b6135c58