### PR TITLE
Handle mintStoreNFT errors in StoreCreation

### DIFF
--- a/src/components/StoreCreation.test.tsx
+++ b/src/components/StoreCreation.test.tsx
@@ -1,0 +1,31 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import StoreCreation from './StoreCreation';
+import { mintStoreNFT } from '@/agent/stores-agent';
+
+jest.mock('@/agent/stores-agent', () => ({
+  mintStoreNFT: jest.fn(),
+}));
+
+jest.mock('@/hooks/useSupabaseAuth', () => ({
+  useSupabaseAuth: () => ({ user: { id: 'user-1' } }),
+}));
+
+describe('StoreCreation', () => {
+  test('shows error when mintStoreNFT fails', async () => {
+    const user = userEvent.setup();
+    (mintStoreNFT as jest.Mock).mockRejectedValue(new Error('Mint failed'));
+
+    render(<StoreCreation />);
+
+    await user.type(screen.getByPlaceholderText('Store name'), 'Test');
+    await user.click(screen.getByRole('button', { name: /create store/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText('Mint failed')).toBeInTheDocument()
+    );
+  });
+});

--- a/src/components/StoreCreation.tsx
+++ b/src/components/StoreCreation.tsx
@@ -24,28 +24,36 @@ export default function StoreCreation() {
       const created = await mintStoreNFT({ name, owner: user.id });
       setStore(created);
       setName("");
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to create store."
+      );
     } finally {
       setCreating(false);
     }
   };
 
   return (
-    <form onSubmit={onSubmit} className="space-y-4">
-      <Input
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        placeholder="Store name"
-      />
-      <Button type="submit" disabled={creating || !name || !user}>
-        {creating ? "Creating..." : "Create Store"}
-      </Button>
-      {error && <p className="text-sm text-destructive">{error}</p>}
+    <>
+      <form onSubmit={onSubmit} className="space-y-4">
+        <Input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Store name"
+        />
+        <Button type="submit" disabled={creating || !name || !user}>
+          {creating ? "Creating..." : "Create Store"}
+        </Button>
+      </form>
+      {error && (
+        <p className="mt-2 text-sm text-destructive">{error}</p>
+      )}
 
       {store && (
-        <p className="text-sm text-muted-foreground">
+        <p className="mt-2 text-sm text-muted-foreground">
           Minted store NFT {store.nftId}
         </p>
       )}
-    </form>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Add error handling in `StoreCreation` to surface mint failures below the form
- Test `StoreCreation` to ensure mint errors display when NFT minting rejects

## Testing
- `npm test src/components/StoreCreation.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68a13fe25fbc8326b59099f31282ae39