### PR TITLE
Remove unused email trigger logging

### DIFF
--- a/src/lib/triggers.test.ts
+++ b/src/lib/triggers.test.ts
@@ -1,0 +1,22 @@
+import { scheduleTrigger, Trigger } from './triggers';
+
+describe('triggers', () => {
+  it('does not log to console when email delivery has no address', () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const trigger: Trigger = {
+      message: 'Test',
+      schedule: new Date(Date.now() - 1000),
+      delivery: 'email',
+    };
+
+    scheduleTrigger(trigger);
+
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+});

--- a/src/lib/triggers.ts
+++ b/src/lib/triggers.ts
@@ -59,8 +59,6 @@ async function fireTrigger(trigger: Trigger, email?: string) {
       const subject = encodeURIComponent('Task Reminder');
       const body = encodeURIComponent(trigger.message);
       window.location.href = `mailto:${email}?subject=${subject}&body=${body}`;
-    } else {
-      console.log('Email trigger:', trigger.message);
     }
   }
 }


### PR DESCRIPTION
## Summary
- remove console logging when an email trigger has no recipient
- add a unit test ensuring scheduleTrigger doesn't write to console without an email address

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a142c2433883269e54f68ba2059f56