### PR TITLE
feat: open map modal

### DIFF
--- a/src/game/hud/useHUDActions.ts
+++ b/src/game/hud/useHUDActions.ts
@@ -20,10 +20,13 @@ export function useHUDActions() {
       useUIStore.getState().openModal("brain");
       return;
     }
+    if (a === "openMap") {
+      useUIStore.getState().openModal("map");
+      return;
+    }
     const eventMap: Record<string, string> = {
       startFocus: "startFocus",
       startHypnosis: "startHypnosis",
-      openMap: "openMap",
       openBrowser: "openBrowser",
     };
     const name = eventMap[a] ?? a;

--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -60,7 +60,6 @@ export default function AppShell() {
         startHypnosis: 'hypno',
         voiceNote: 'voice',
         addNote: 'notes',
-        openMap: 'portal',
         openBrain: 'brain',
       };
       const vid = t ? map[t] : undefined;


### PR DESCRIPTION
## Summary
- open the map modal directly via UI store
- remove unused `openMap` portal mapping

## Testing
- `npm test`
- `npm run lint` *(fails: 225 errors, 21 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a20dc5b5748326975fe3fdbc99b04d