### PR TITLE
refactor: use notes modal id

### DIFF
--- a/src/components/modals/ModalHost.tsx
+++ b/src/components/modals/ModalHost.tsx
@@ -43,9 +43,6 @@ export default function ModalHost() {
     case "brain":
       content = <BrainView />;
       break;
-    case "journal":
-      content = <JournalView />;
-      break;
     case "focus":
       content = <FocusView />;
       break;

--- a/src/game/hud/useHUDActions.ts
+++ b/src/game/hud/useHUDActions.ts
@@ -5,7 +5,7 @@ import { useUIStore } from "@/state/ui";
 export function useHUDActions() {
   const run = (a: QuickActionKey) => {
     if (a === "addNote") {
-      useUIStore.getState().openModal("journal");
+      useUIStore.getState().openModal("notes");
       return;
     }
     if (a === "voiceNote") {

--- a/src/state/quickActions.ts
+++ b/src/state/quickActions.ts
@@ -10,10 +10,10 @@ import { registerQuickAction } from "@/components/navigation/quickActions";
 import { useUIStore } from "@/state/ui";
 
 registerQuickAction({
-  id: "journal",
+  id: "notes",
   label: "Journal",
   icon: BookOpen,
-  onClick: () => useUIStore.getState().openModal("journal"),
+  onClick: () => useUIStore.getState().openModal("notes"),
 });
 
 registerQuickAction({

--- a/src/state/ui.ts
+++ b/src/state/ui.ts
@@ -4,7 +4,6 @@ import { track } from '@/utils/telemetry';
 
 export type ModalId =
   | "brain"
-  | "journal"
   | "live"
   | "analytics"
   | "tasks"


### PR DESCRIPTION
## Summary
- drop journal alias from ModalHost so the notes modal is canonical
- update HUD actions and quick actions to open the notes modal
- remove journal from modal types

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, Empty block statement)*

------
https://chatgpt.com/codex/tasks/task_e_68a20dd770888326b1c63f7647fb96aa