### PR TITLE
feat: show default roadmap in tasks modal

### DIFF
--- a/src/components/modals/TasksModal.tsx
+++ b/src/components/modals/TasksModal.tsx
@@ -1,16 +1,45 @@
+import { useEffect, useState } from "react";
 import { DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import TasksManager from "@/components/control/TasksManager";
 import { useUIStore } from "@/state/ui";
+import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
+import { supabase } from "@/integrations/supabase/client";
 
 export default function TasksModal() {
   const tasksRoadmapId = useUIStore((s) => s.tasksRoadmapId);
+  const { user } = useSupabaseAuth();
+  const [defaultId, setDefaultId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (tasksRoadmapId || !user) return;
+    let cancelled = false;
+    (async () => {
+      const { data } = await supabase
+        .from("roadmaps")
+        .select("id, status")
+        .eq("user_id", user.id)
+        .order("position", { ascending: true, nullsFirst: true });
+      if (!cancelled && data) {
+        type Roadmap = { id: string; status: string };
+        const list = data as Roadmap[];
+        const active = list.find((r) => r.status === "active");
+        setDefaultId(active?.id ?? list[0]?.id ?? null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [tasksRoadmapId, user]);
+
+  const roadmapId = tasksRoadmapId ?? defaultId;
+
   return (
     <>
       <DialogHeader>
         <DialogTitle>Tasks</DialogTitle>
       </DialogHeader>
-      {tasksRoadmapId ? (
-        <TasksManager roadmapId={tasksRoadmapId} />
+      {roadmapId ? (
+        <TasksManager roadmapId={roadmapId} />
       ) : (
         <div className="text-sm text-muted-foreground">No roadmap selected.</div>
       )}


### PR DESCRIPTION
## Summary
- automatically load the active or first roadmap in the Tasks modal when no roadmap is selected
- fallback to a helpful message when no roadmaps exist

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type... etc.)*
- `npx eslint src/components/modals/TasksModal.tsx && echo 'eslint: no problems found'`


------
https://chatgpt.com/codex/tasks/task_e_68a20dcd34f88326bcbeb4a3b630fee6