### PR TITLE
refactor: use modal for focus and hypno

### DIFF
--- a/src/game/hud/useHUDActions.ts
+++ b/src/game/hud/useHUDActions.ts
@@ -24,9 +24,15 @@ export function useHUDActions() {
       useUIStore.getState().openModal("map");
       return;
     }
+    if (a === "startFocus") {
+      useUIStore.getState().openModal("focus");
+      return;
+    }
+    if (a === "startHypnosis") {
+      useUIStore.getState().openModal("hypno");
+      return;
+    }
     const eventMap: Record<string, string> = {
-      startFocus: "startFocus",
-      startHypnosis: "startHypnosis",
       openBrowser: "openBrowser",
     };
     const name = eventMap[a] ?? a;

--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -15,6 +15,7 @@ import useDailyCheckIn from "@/hooks/useDailyCheckIn";
 import useWeeklyBrainBackup from "@/hooks/useWeeklyBrainBackup";
 import { useKeyboardOffset } from "@/hooks/useKeyboardOffset";
 import AppHeader from "@/components/layout/AppHeader";
+import { useUIStore } from "@/state/ui";
 
 export default function AppShell() {
   const { user, initializing } = useSupabaseAuth();
@@ -55,9 +56,15 @@ export default function AppShell() {
         open('browser', { url: last });
         return;
       }
+      if (t === 'startFocus') {
+        useUIStore.getState().openModal('focus');
+        return;
+      }
+      if (t === 'startHypnosis') {
+        useUIStore.getState().openModal('hypno');
+        return;
+      }
       const map: Record<string, ViewId> = {
-        startFocus: 'focus',
-        startHypnosis: 'hypno',
         voiceNote: 'voice',
         addNote: 'notes',
         openBrain: 'brain',


### PR DESCRIPTION
## Summary
- open focus and hypno modals directly from HUD actions instead of dispatching events
- handle focus and hypno MOS events by opening modals in AppShell

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, Empty block statement)*

------
https://chatgpt.com/codex/tasks/task_e_68a20f504914832693d647c378f3b88b