### PR TITLE
Open full-screen sphere modal

### DIFF
--- a/src/components/avatar/AuroraSphere.tsx
+++ b/src/components/avatar/AuroraSphere.tsx
@@ -358,7 +358,7 @@ export function AuroraSphere({
 
   const handleClick = () => {
     if (variant === 'inline') {
-      useUIStore.getState().openModal('brain');
+      useUIStore.getState().openModal('sphereFull');
     }
   };
 


### PR DESCRIPTION
## Summary
- Open dedicated `sphereFull` modal when the inline Aurora sphere is clicked
- `sphereFull` modal is already defined in UI state and rendered by `ModalHost`

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, no-empty in voice/ files)*

------
https://chatgpt.com/codex/tasks/task_e_68a2363011e48326a5af4e2477b5e7c0