### PR TITLE
Use UI modal for map action in HUD

### DIFF
--- a/src/game/hud/useHUDActions.ts
+++ b/src/game/hud/useHUDActions.ts
@@ -20,6 +20,10 @@ export function useHUDActions() {
       useUIStore.getState().openModal("brain");
       return;
     }
+    if (a === "openMap") {
+      useUIStore.getState().openModal("map");
+      return;
+    }
     const eventMap: Record<string, string> = {
       openBrowser: "openBrowser",
     };


### PR DESCRIPTION
## Summary
- Open HUD map via UI store modal instead of global event
- Ensure AppShell no longer maps `openMap` to `portal`

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, Empty block statement)*

------
https://chatgpt.com/codex/tasks/task_e_68a237d470488326874418353d40f865