### PR TITLE
fix: guard avatar material cleanup

### DIFF
--- a/src/components/avatar/AuroraSphere.tsx
+++ b/src/components/avatar/AuroraSphere.tsx
@@ -341,8 +341,14 @@ export function AuroraSphere({
         mount.removeChild(renderer.domElement);
       }
       geometry?.dispose();
+      if (material && (material as any).positionNode) {
+        try {
+          material.dispose();
+        } catch {
+          /* ignore */
+        }
+      }
       materialRef.current = null;
-      material?.dispose();
       if (pointsRef.current) {
         scene.remove(pointsRef.current);
         pointsRef.current = null;


### PR DESCRIPTION
## Summary
- guard NodeMaterial disposal with safety check
- null material reference after cleanup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a23908c530832688c896e5c4fe0f9d