### PR TITLE
guard sphere resize against zero dimensions

### DIFF
--- a/src/components/avatar/AuroraSphere.tsx
+++ b/src/components/avatar/AuroraSphere.tsx
@@ -231,7 +231,12 @@ export function AuroraSphere({
       rendererRef.current = renderer;
 
       const resize = () => {
+        if (disposed) return;
         const { clientWidth, clientHeight } = container;
+        if (clientWidth === 0 || clientHeight === 0) {
+          requestAnimationFrame(resize);
+          return;
+        }
         renderer!.setSize(clientWidth, clientHeight);
         camera.aspect = clientWidth / clientHeight;
         camera.updateProjectionMatrix();


### PR DESCRIPTION
## Summary
- prevent AuroraSphere resize from operating on zero-sized containers
- retry resizing via requestAnimationFrame until container dimensions are valid

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2390ec4d8832684783d1d0822b3cf