### PR TITLE
feat: open tasks modal with default roadmap

### DIFF
--- a/src/state/quickActions.ts
+++ b/src/state/quickActions.ts
@@ -8,6 +8,7 @@ import {
 } from "lucide-react";
 import { registerQuickAction } from "@/components/navigation/quickActions";
 import { useUIStore } from "@/state/ui";
+import { supabase } from "@/integrations/supabase/client";
 
 registerQuickAction({
   id: "notes",
@@ -27,7 +28,30 @@ registerQuickAction({
   id: "tasks",
   label: "Tasks",
   icon: ListTodo,
-  onClick: () => useUIStore.getState().openModal("tasks"),
+  onClick: async () => {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    let roadmapId: string | undefined;
+
+    if (user) {
+      const { data } = await supabase
+        .from("roadmaps")
+        .select("id, status")
+        .eq("user_id", user.id)
+        .order("position", { ascending: true, nullsFirst: true });
+
+      if (data) {
+        type Roadmap = { id: string; status: string };
+        const list = data as Roadmap[];
+        const active = list.find((r) => r.status === "active");
+        roadmapId = active?.id ?? list[0]?.id;
+      }
+    }
+
+    useUIStore.getState().openModal("tasks", { roadmapId });
+  },
 });
 
 registerQuickAction({


### PR DESCRIPTION
## Summary
- fetch active or first roadmap before opening tasks modal
- pass roadmapId to `openModal('tasks')`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a23acd7bec8326b6ee9089b38e2fe6