### PR TITLE
Refactor HUD actions to open modals directly

### DIFF
--- a/src/game/hud/useHUDActions.ts
+++ b/src/game/hud/useHUDActions.ts
@@ -24,6 +24,14 @@ export function useHUDActions() {
       useUIStore.getState().openModal("map");
       return;
     }
+    if (a === "startFocus") {
+      useUIStore.getState().openModal("focus");
+      return;
+    }
+    if (a === "startHypnosis") {
+      useUIStore.getState().openModal("hypno");
+      return;
+    }
     const eventMap: Record<string, string> = {
       openBrowser: "openBrowser",
     };

--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -56,14 +56,6 @@ export default function AppShell() {
         open('browser', { url: last });
         return;
       }
-      if (t === 'startFocus') {
-        useUIStore.getState().openModal('focus');
-        return;
-      }
-      if (t === 'startHypnosis') {
-        useUIStore.getState().openModal('hypno');
-        return;
-      }
       const map: Record<string, ViewId> = {
         voiceNote: 'voice',
         addNote: 'notes',


### PR DESCRIPTION
## Summary
- open focus and hypnosis actions via `openModal` instead of dispatching events
- drop now-unused focus and hypnosis cases from AppShell's `mos` listener

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a23be14a908326aac45f08f168e768