### PR TITLE
Standardize journal modal ID

### DIFF
--- a/src/components/home/QuickPodsRow.tsx
+++ b/src/components/home/QuickPodsRow.tsx
@@ -12,7 +12,7 @@ import { useChatInputFocus } from "@/hooks/useChatInputFocus";
 const pods: { key: string; label: string; icon: LucideIcon }[] = [
   { key: "focus", label: "Focus", icon: Target },
   { key: "hypno", label: "Hypno", icon: Waves },
-  { key: "notes", label: "Notes", icon: StickyNote },
+  { key: "journal", label: "Journal", icon: StickyNote },
   { key: "voice", label: "Voice", icon: Mic },
 ];
 
@@ -32,7 +32,7 @@ export function QuickPodsRow() {
     if (!open) focusChatInput();
   };
 
-  // Notes
+  // Journal
   const [noteOpen, setNoteOpen] = useState(false);
   const handleNoteOpenChange = (open: boolean) => {
     setNoteOpen(open);
@@ -130,7 +130,9 @@ export function QuickPodsRow() {
   const stopRecording = () => {
     try {
       recorder?.stop();
-    } catch {}
+    } catch (e) {
+      console.error(e);
+    }
   };
 
   // Hypnosis
@@ -146,7 +148,7 @@ export function QuickPodsRow() {
     setPreOpen(open);
     if (!open) focusChatInput();
   };
-  const [mode, setMode] = useState<'focus' | 'calm' | 'confidence'>(() => (localStorage.getItem('hypnosis.mode') as any) || 'focus');
+  const [mode, setMode] = useState<'focus' | 'calm' | 'confidence'>(() => (localStorage.getItem('hypnosis.mode') as 'focus' | 'calm' | 'confidence' | null) || 'focus');
   const [countdown, setCountdown] = useState(3);
 
   useEffect(() => {
@@ -175,13 +177,15 @@ export function QuickPodsRow() {
       setCountdown((c) => {
         if (c <= 1) {
           window.clearInterval(id);
-          handlePreOpenChange(false);
-          setLibraryOpen(true);
-          (async () => {
-            try {
-              await awardXPRemote("hypnosis_session", 20, { mode });
-            } catch {}
-          })();
+            handlePreOpenChange(false);
+            setLibraryOpen(true);
+            (async () => {
+              try {
+                await awardXPRemote("hypnosis_session", 20, { mode });
+              } catch (err) {
+                console.error(err);
+              }
+            })();
           return 0;
         }
         return c - 1;
@@ -191,7 +195,11 @@ export function QuickPodsRow() {
   }, [preOpen]);
 
   useEffect(() => {
-    try { localStorage.setItem('hypnosis.mode', mode); } catch {}
+    try {
+      localStorage.setItem('hypnosis.mode', mode);
+    } catch (err) {
+      console.error(err);
+    }
   }, [mode]);
 
   return (
@@ -204,7 +212,7 @@ export function QuickPodsRow() {
             onClick={() => {
               if (p.key === 'focus') setFocusOpen(true);
               if (p.key === 'hypno') setPreOpen(true);
-              if (p.key === 'notes') setNoteOpen(true);
+              if (p.key === 'journal') setNoteOpen(true);
               if (p.key === 'voice') setVoiceOpen(true);
             }}
             className="glass-panel rounded-xl p-4 flex flex-col items-center gap-2 hover-scale"
@@ -298,7 +306,7 @@ export function QuickPodsRow() {
         </DialogContent>
       </Dialog>
 
-      {/* Notes */}
+      {/* Journal */}
       <Dialog open={noteOpen} onOpenChange={handleNoteOpenChange}>
         <DialogContent className="sm:max-w-md" onEscapeKeyDown={() => handleNoteOpenChange(false)}>
           <DialogHeader>

--- a/src/components/modals/ModalHost.tsx
+++ b/src/components/modals/ModalHost.tsx
@@ -74,7 +74,7 @@ export default function ModalHost() {
     case "hypno":
       content = <HypnoPanel onClose={closeModal} />;
       break;
-    case "notes":
+    case "journal":
       content = <JournalView />;
       break;
     case "voice":

--- a/src/components/navigation/BottomDock.tsx
+++ b/src/components/navigation/BottomDock.tsx
@@ -43,7 +43,7 @@ export default function BottomDock() {
     () => [
       { to: "/app", label: "Home", icon: Home },
       { to: "/app/brain", label: "Brain", icon: Brain },
-      { to: "/app/notes", label: "Journal", icon: BookOpen },
+      { to: "/app/journal", label: "Journal", icon: BookOpen },
       { to: "/app/live", label: "Live", icon: Radio },
       { to: "/app/settings", label: "Settings", icon: Settings },
     ],

--- a/src/components/overlays/FastTravel.tsx
+++ b/src/components/overlays/FastTravel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 
-const fire = (type: string, payload?: any) => {
+const fire = (type: string, payload?: unknown) => {
   window.dispatchEvent(new CustomEvent('mos', { detail: { type, payload } }));
 };
 
@@ -9,17 +9,17 @@ const ZONES = [
   { key: 'focus', label: 'Training Grounds', type: 'startFocus' },
   { key: 'hypno', label: 'Hypno Temple', event: 'open-hypno-panel' },
   { key: 'voice', label: 'Sound Studio', type: 'voiceNote' },
-  { key: 'notes', label: 'Idea Forest', type: 'addNote' },
+  { key: 'journal', label: 'Idea Forest', type: 'addNote' },
 ];
 
 export default function FastTravel() {
   const [open, setOpen] = useState(false);
 
-  useEffect(() => {
-    const h = () => setOpen(true);
-    window.addEventListener('open-fast-travel', h as any);
-    return () => window.removeEventListener('open-fast-travel', h as any);
-  }, []);
+    useEffect(() => {
+      const h = () => setOpen(true);
+      window.addEventListener('open-fast-travel', h as EventListener);
+      return () => window.removeEventListener('open-fast-travel', h as EventListener);
+    }, []);
 
   if (!open) return null;
 

--- a/src/components/quick/QuickPodsRow.tsx
+++ b/src/components/quick/QuickPodsRow.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button";
 const pods: { key: string; label: string; icon: LucideIcon }[] = [
   { key: "focus", label: "Focus", icon: Target },
   { key: "hypno", label: "Hypno", icon: Waves },
-  { key: "notes", label: "Notes", icon: StickyNote },
+  { key: "journal", label: "Journal", icon: StickyNote },
   { key: "voice", label: "Voice", icon: Mic },
 ];
 
@@ -25,7 +25,7 @@ export function QuickPodsRow() {
       window.dispatchEvent(new CustomEvent("open-hypno-panel"));
       return;
     }
-    if (key === "notes") {
+    if (key === "journal") {
       run("addNote");
       return;
     }

--- a/src/game/hud/hud.data.ts
+++ b/src/game/hud/hud.data.ts
@@ -24,7 +24,7 @@ const baseQuickSlots: QuickSlot[] = [
   { id:1, key:'1', action:'startFocus',    label:'Focus',   icon:'focus' },
   { id:2, key:'2', action:'startHypnosis', label:'Hypno',   icon:'hypno' },
   { id:3, key:'3', action:'voiceNote',     label:'Voice',   icon:'mic'   },
-  { id:4, key:'4', action:'addNote',       label:'Notes',   icon:'note'  },
+  { id:4, key:'4', action:'addNote',       label:'Journal', icon:'note'  },
   { id:5, key:'5', action:'openBrowser',   label:'Browse',  icon:'portal'},
   { id:6, key:'6', action:'openBrain',     label:'Brain',   icon:'brain' },
   { id:7, key:'7', action:'openTasks',     label:'Tasks',   icon:'task'  },

--- a/src/game/hud/useHUDActions.ts
+++ b/src/game/hud/useHUDActions.ts
@@ -5,7 +5,7 @@ import { useUIStore } from "@/state/ui";
 export function useHUDActions() {
   const run = (a: QuickActionKey) => {
     if (a === "addNote") {
-      useUIStore.getState().openModal("notes");
+      useUIStore.getState().openModal("journal");
       return;
     }
     if (a === "voiceNote") {

--- a/src/index.css
+++ b/src/index.css
@@ -469,7 +469,7 @@ All colors MUST be HSL.
 .room-focus { --primary: 222 87% 55%; --accent: 222 87% 55%; }
 .room-hypno { --primary: 270 75% 60%; --accent: 270 75% 60%; }
 .room-voice { --primary: 214 84% 56%; --accent: 214 84% 56%; }
-.room-notes { --primary: 35 95% 55%; --accent: 35 95% 55%; }
+.room-journal { --primary: 35 95% 55%; --accent: 35 95% 55%; }
 .room-browser { --primary: 210 90% 60%; --accent: 210 90% 60%; }
 .room-portal { --primary: 150 80% 50%; --accent: 150 80% 50%; }
 .room-archive { --primary: 260 60% 60%; --accent: 260 60% 60%; }

--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -66,7 +66,7 @@ export default function AppShell() {
       }
       const map: Record<string, ViewId> = {
         voiceNote: 'voice',
-        addNote: 'notes',
+        addNote: 'journal',
         openBrain: 'brain',
       };
       const vid = t ? map[t] : undefined;

--- a/src/state/quickActions.ts
+++ b/src/state/quickActions.ts
@@ -11,10 +11,10 @@ import { useUIStore } from "@/state/ui";
 import { supabase } from "@/integrations/supabase/client";
 
 registerQuickAction({
-  id: "notes",
+  id: "journal",
   label: "Journal",
   icon: BookOpen,
-  onClick: () => useUIStore.getState().openModal("notes"),
+  onClick: () => useUIStore.getState().openModal("journal"),
 });
 
 registerQuickAction({

--- a/src/state/ui.ts
+++ b/src/state/ui.ts
@@ -13,7 +13,7 @@ export type ModalId =
   // supplemental panels
   | "focus"
   | "hypno"
-  | "notes"
+  | "journal"
   | "voice"
   | "sphereFull";
 

--- a/src/views/registry.tsx
+++ b/src/views/registry.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 
 export type ViewId =
-  | "home" | "focus" | "hypno" | "voice" | "notes"
+  | "home" | "focus" | "hypno" | "voice" | "journal"
   | "brain" | "browser" | "portal" | "archive" | "settings" | "agent" | "runner" | "plan" | "control";
 
 export type ViewMeta = {
@@ -19,7 +19,7 @@ export const views: ViewMeta[] = [
   { id: "focus",   label: "Focus",   path: "focus",      component: lazy(() => import("./FocusView")) },
   { id: "hypno",   label: "Hypno",   path: "hypno",      component: lazy(() => import("./HypnoView")) },
   { id: "voice",   label: "Voice",   path: "voice",      component: lazy(() => import("./VoiceView")) },
-  { id: "notes",   label: "Journal", path: "notes",      component: lazy(() => import("./JournalView")) },
+  { id: "journal", label: "Journal", path: "journal",    component: lazy(() => import("./JournalView")) },
   { id: "brain",   label: "Brain",   path: "brain",      component: lazy(() => import("./BrainView")) },
   { id: "browser", label: "Browser", path: "browser",    component: lazy(() => import("./BrowserView")) },
   { id: "portal",  label: "Portal",  path: "portal",     component: lazy(() => import("./PortalView")) },


### PR DESCRIPTION
## Summary
- adopt `journal` as the single modal ID and remove `notes` alias
- update navigation, quick actions, and HUD to target the journal modal
- rename routes and styling to `/app/journal` and `.room-journal`

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any / Empty block statement)*
- `npx eslint src/components/modals/ModalHost.tsx src/routes/AppShell.tsx src/state/ui.ts src/state/quickActions.ts src/components/quick/QuickPodsRow.tsx src/components/home/QuickPodsRow.tsx src/components/navigation/BottomDock.tsx src/components/overlays/FastTravel.tsx src/views/registry.tsx src/game/hud/useHUDActions.ts src/game/hud/hud.data.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a23bde07f08326bb910f3030d1219d