### PR TITLE
chore: clean up unused HUD modals

### DIFF
--- a/src/components/mindworld/MindWorldDashboard.tsx
+++ b/src/components/mindworld/MindWorldDashboard.tsx
@@ -71,7 +71,6 @@ export default function MindWorldDashboard() {
       if (t === 'startHypnosis') { set('mentor'); completeQuest('start-hypno'); awardXP(REWARDS.completeQuest); }
       if (t === 'voiceNote') { set('library'); completeQuest('record-voice'); awardXP(REWARDS.completeQuest); }
       if (t === 'addNote') { set('library'); completeQuest('add-note'); awardXP(REWARDS.completeQuest); }
-      if (t === 'openMap') { document.dispatchEvent(new CustomEvent('open-fast-travel')); }
     };
     window.addEventListener('mos', onMos as any);
     return () => window.removeEventListener('mos', onMos as any);

--- a/src/components/overlays/FastTravel.tsx
+++ b/src/components/overlays/FastTravel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { useUIStore } from "@/state/ui";
 
 const fire = (type: string, payload?: unknown) => {
   window.dispatchEvent(new CustomEvent('mos', { detail: { type, payload } }));
@@ -14,6 +15,7 @@ const ZONES = [
 
 export default function FastTravel() {
   const [open, setOpen] = useState(false);
+  const openModal = useUIStore.getState().openModal;
 
     useEffect(() => {
       const h = () => setOpen(true);
@@ -23,10 +25,13 @@ export default function FastTravel() {
 
   if (!open) return null;
 
-  const onSelect = (z: { type?: string; event?: string }) => {
+  const onSelect = (
+    z: { type?: string; event?: string; modal?: Parameters<typeof openModal>[0] }
+  ) => {
     setOpen(false);
     if (z.type) fire(z.type);
     else if (z.event) window.dispatchEvent(new CustomEvent(z.event));
+    else if (z.modal) openModal(z.modal);
   };
 
   return (
@@ -47,7 +52,11 @@ export default function FastTravel() {
               <div className="text-xs text-muted-foreground">{z.key}</div>
             </Button>
           ))}
-          <Button className="rounded-xl p-3 bg-white/10 hover:bg-white/15 text-left" type="button" onClick={() => onSelect({ type: 'openMap' })}>
+          <Button
+            className="rounded-xl p-3 bg-white/10 hover:bg-white/15 text-left"
+            type="button"
+            onClick={() => onSelect({ modal: 'tasks' })}
+          >
             <div className="font-medium">Control</div>
             <div className="text-xs text-muted-foreground">Roadmaps & Tasks</div>
           </Button>

--- a/src/game/hud/useHUDActions.ts
+++ b/src/game/hud/useHUDActions.ts
@@ -20,10 +20,6 @@ export function useHUDActions() {
       useUIStore.getState().openModal("brain");
       return;
     }
-    if (a === "openMap") {
-      useUIStore.getState().openModal("map");
-      return;
-    }
     if (a === "startFocus") {
       useUIStore.getState().openModal("focus");
       return;

--- a/src/index.css
+++ b/src/index.css
@@ -382,19 +382,6 @@ All colors MUST be HSL.
   radial-gradient(circle at 50% 50%, hsl(0 0% 100%) 30%, transparent 31%),
   conic-gradient(hsl(0 0% 100%) 0 10%, transparent 10% 100%);
 }
-.hud-icon.bag { background:
-  linear-gradient(hsl(0 0% 100%), hsl(0 0% 92%));
-  clip-path: polygon(12% 30%,88% 30%,88% 85%,12% 85%);
-}
-.hud-icon.map { background:
-  linear-gradient(45deg, hsl(var(--accent)) 50%, hsl(var(--primary)) 50%);
-  clip-path: polygon(10% 80%,35% 20%,60% 75%,85% 30%,90% 80%,10% 80%);
-}
-.hud-icon.stick {
-  background: radial-gradient(circle, hsl(var(--primary)) 45%, transparent 46%);
-  box-shadow: inset 0 0 0 6px hsl(0 0% 100% / 0.27);
-  border-radius: 9999px;
-}
 
 /* HUD tokens and utilities */
 :root{

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -533,17 +533,12 @@ const Index = () => {
       awardXP(REWARDS.completeQuest);
       checkFullClear();
     };
-    const onMap = () => {
-      window.dispatchEvent(new CustomEvent('open-fast-travel'));
-    };
-
     const onMos = (e: any) => {
       const t = e.detail?.type;
       if (t === 'startFocus') onFocus();
       if (t === 'startHypnosis') onHypno();
       if (t === 'voiceNote') onVoice();
       if (t === 'addNote') onNote();
-      if (t === 'openMap') onMap();
     };
     window.addEventListener('mos', onMos as any);
     return () => {


### PR DESCRIPTION
## Summary
- remove unused HUD map/inventory/controls icons and handlers
- drop unreachable openMap quick action
- open Tasks from Fast Travel overlay

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_68a23e91b19c8326b9f9d5821799dea0