### PR TITLE
Refactor bottom dock to use expanded glass container

### DIFF
--- a/src/components/navigation/BottomDock.tsx
+++ b/src/components/navigation/BottomDock.tsx
@@ -1,15 +1,31 @@
 import { useEffect, useRef, useState, useMemo } from "react";
 import { NavLink } from "react-router-dom";
-import { Home, Brain, BookOpen, Radio, Settings } from "lucide-react";
+import {
+  Home,
+  Brain,
+  BookOpen,
+  Radio,
+  Settings,
+  ListTodo,
+  Target,
+  BarChart3,
+  MoreHorizontal,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useGameStore } from "@/game/store";
 import { useAvatarStore } from "@/state/avatar";
 import { AuroraSphere } from "@/components/avatar/AuroraSphere";
-import { QuickActionBar } from "./QuickActionBar";
 import { useKeyboardOffset } from "@/hooks/useKeyboardOffset";
 import { Button } from "@/components/ui/button";
 
-const DOCK_COLLAPSE_KEY = "ui:dock:collapsed";
+const ACTIONS = [
+  { id: "journal", label: "Journal", icon: BookOpen },
+  { id: "live", label: "Live", icon: Radio },
+  { id: "tasks", label: "Tasks", icon: ListTodo },
+  { id: "goals", label: "Goals", icon: Target },
+  { id: "analytics", label: "Analytics", icon: BarChart3 },
+  { id: "settings", label: "Settings", icon: Settings },
+];
 
 export default function BottomDock() {
   const stats = useGameStore((s) => s.stats);
@@ -17,13 +33,7 @@ export default function BottomDock() {
   const ref = useRef<HTMLDivElement>(null);
   useKeyboardOffset();
 
-  // collapsed state persisted in localStorage
-  const [collapsed, setCollapsed] = useState<boolean>(() => {
-    return localStorage.getItem(DOCK_COLLAPSE_KEY) === "1";
-  });
-  useEffect(() => {
-    localStorage.setItem(DOCK_COLLAPSE_KEY, collapsed ? "1" : "0");
-  }, [collapsed]);
+  const [expanded, setExpanded] = useState(true);
 
   // measure height -> --dock-h
   useEffect(() => {
@@ -50,7 +60,7 @@ export default function BottomDock() {
     []
   );
 
-  const onEdgeClick = () => setCollapsed((c) => !c);
+  const toggle = () => setExpanded((e) => !e);
 
   return (
     <div
@@ -58,7 +68,7 @@ export default function BottomDock() {
       className={cn(
         "fixed left-0 right-0 mx-3 select-none",
         "transition-[transform,opacity] duration-200",
-        collapsed ? "pb-2" : "pb-3"
+        expanded ? "pb-3" : "pb-2"
       )}
       style={{
         bottom: `calc(var(--kb-offset) + var(--safe-area-bottom) + var(--chatbar-h) + var(--hud-gap))`,
@@ -66,24 +76,100 @@ export default function BottomDock() {
         pointerEvents: "auto",
       }}
     >
-      <Button
-        type="button"
-        aria-label={collapsed ? "Expand dock" : "Collapse dock"}
-        onClick={onEdgeClick}
-        className="absolute -top-2 left-0 right-0 h-3 rounded-t-2xl opacity-30 hover:opacity-60 focus:opacity-80 outline-none"
-        style={{ WebkitTapHighlightColor: "transparent" }}
-      />
+      <div className="relative">
+        <Button
+          type="button"
+          aria-label={expanded ? "Collapse dock" : "Expand dock"}
+          onClick={toggle}
+          className="absolute -top-2 left-0 right-0 h-3 rounded-t-2xl opacity-30 hover:opacity-60 focus:opacity-80 outline-none"
+          style={{ WebkitTapHighlightColor: "transparent" }}
+        />
 
-      <div
-        className={cn(
-          "hud-panel hud-maple rounded-2xl px-4",
-          collapsed ? "py-2" : "py-3",
-          "backdrop-blur-md"
-        )}
-      >
-        {collapsed ? (
+        <div
+          className={cn(
+            "glass-maple rounded-2xl px-4",
+            expanded ? "py-3" : "py-2",
+            "backdrop-blur-md"
+          )}
+        >
+          {expanded && (
+            <>
+              <div className="flex items-center gap-3 min-w-0 mb-2">
+                {avatarEnabled && <AuroraSphere size={44} />}
+                <div className="min-w-0">
+                  <div className="text-[13px] opacity-90 truncate">
+                    Lv. {stats.level} • Streak {stats.streak}
+                  </div>
+                  <div className="text-[15px] font-semibold truncate">Dean</div>
+                </div>
+              </div>
+
+              <div className="flex md:flex-row flex-col gap-2 md:items-center mb-1">
+                <div className="maple-gauge">
+                  <div className="maple-gauge__top">
+                    <span className="maple-gauge__label">HP</span>
+                    <span className="maple-gauge__val">
+                      {Math.floor(stats.hp)}%
+                    </span>
+                  </div>
+                  <div className="maple-gauge__bar hp">
+                    <span style={{ width: `${stats.hp}%` }} />
+                  </div>
+                </div>
+                <div className="maple-gauge">
+                  <div className="maple-gauge__top">
+                    <span className="maple-gauge__label">MP</span>
+                    <span className="maple-gauge__val">
+                      {Math.floor(stats.mp)}%
+                    </span>
+                  </div>
+                  <div className="maple-gauge__bar mp">
+                    <span style={{ width: `${stats.mp}%` }} />
+                  </div>
+                </div>
+                <div className="maple-gauge">
+                  <div className="maple-gauge__top">
+                    <span className="maple-gauge__label">XP</span>
+                    <span className="maple-gauge__val">
+                      {Math.floor(stats.xp)}%
+                    </span>
+                  </div>
+                  <div className="maple-gauge__bar xp">
+                    <span style={{ width: `${stats.xp}%` }} />
+                  </div>
+                </div>
+              </div>
+            </>
+          )}
+
           <div className="flex items-center justify-between gap-3">
-            <QuickActionBar iconsOnly />
+            <ul className="flex items-center gap-3">
+              {ACTIONS.map(({ id, label, icon: Icon }) => (
+                <li key={id}>
+                  <Button
+                    type="button"
+                    className="flex flex-col items-center gap-1 px-2 py-1 rounded-lg hover:opacity-90 focus:outline-none focus:ring-2"
+                    aria-label={label}
+                    title={label}
+                  >
+                    <Icon className="w-5 h-5" />
+                    {expanded && <span className="text-xs">{label}</span>}
+                  </Button>
+                </li>
+              ))}
+              <li>
+                <Button
+                  type="button"
+                  className="flex flex-col items-center gap-1 px-2 py-1 rounded-lg hover:opacity-90 focus:outline-none focus:ring-2"
+                  aria-label="More"
+                  title="More"
+                >
+                  <MoreHorizontal className="w-5 h-5" />
+                  {expanded && <span className="text-xs">More</span>}
+                </Button>
+              </li>
+            </ul>
+
             <nav aria-label="Main navigation">
               <ul className="flex gap-5">
                 {items.map(({ to, label, icon: Icon }) => (
@@ -93,89 +179,25 @@ export default function BottomDock() {
                       end={to === "/app"}
                       className={({ isActive }) =>
                         cn(
-                          "flex flex-col items-center text-[11px] gap-1",
+                          "flex flex-col items-center text-xs gap-1",
                           isActive ? "text-primary" : "text-muted-foreground"
                         )
                       }
                     >
                       <Icon className="w-5 h-5" />
-                      <span className="sr-only">{label}</span>
+                      {expanded ? (
+                        <span>{label}</span>
+                      ) : (
+                        <span className="sr-only">{label}</span>
+                      )}
                     </NavLink>
                   </li>
                 ))}
               </ul>
             </nav>
           </div>
-        ) : (
-          <>
-            <div className="flex items-center gap-3 min-w-0 mb-2">
-              {avatarEnabled && <AuroraSphere size={44} />}
-              <div className="min-w-0">
-                <div className="text-[13px] opacity-90 truncate">
-                  Lv. {stats.level} • Streak {stats.streak}
-                </div>
-                <div className="text-[15px] font-semibold truncate">Dean</div>
-              </div>
-            </div>
-
-            <div className="flex md:flex-row flex-col gap-2 md:items-center mb-1">
-              <div className="maple-gauge">
-                <div className="maple-gauge__top">
-                  <span className="maple-gauge__label">HP</span>
-                  <span className="maple-gauge__val">{Math.floor(stats.hp)}%</span>
-                </div>
-                <div className="maple-gauge__bar hp">
-                  <span style={{ width: `${stats.hp}%` }} />
-                </div>
-              </div>
-              <div className="maple-gauge">
-                <div className="maple-gauge__top">
-                  <span className="maple-gauge__label">MP</span>
-                  <span className="maple-gauge__val">{Math.floor(stats.mp)}%</span>
-                </div>
-                <div className="maple-gauge__bar mp">
-                  <span style={{ width: `${stats.mp}%` }} />
-                </div>
-              </div>
-              <div className="maple-gauge">
-                <div className="maple-gauge__top">
-                  <span className="maple-gauge__label">XP</span>
-                  <span className="maple-gauge__val">{Math.floor(stats.xp)}%</span>
-                </div>
-                <div className="maple-gauge__bar xp">
-                  <span style={{ width: `${stats.xp}%` }} />
-                </div>
-              </div>
-            </div>
-
-            <div className="flex items-center justify-between gap-3">
-              <QuickActionBar />
-              <nav aria-label="Main navigation">
-                <ul className="flex gap-5">
-                  {items.map(({ to, label, icon: Icon }) => (
-                    <li key={label}>
-                      <NavLink
-                        to={to}
-                        end={to === "/app"}
-                        className={({ isActive }) =>
-                          cn(
-                            "flex flex-col items-center text-xs gap-1",
-                            isActive ? "text-primary" : "text-muted-foreground"
-                          )
-                        }
-                      >
-                        <Icon className="w-5 h-5" />
-                        <span>{label}</span>
-                      </NavLink>
-                    </li>
-                  ))}
-                </ul>
-              </nav>
-            </div>
-          </>
-        )}
+        </div>
       </div>
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- replace legacy collapse logic with expanded state
- render dock in a glass-maple container with toggle handle
- inline quick actions and simplify navigation labels

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68a3800159908326bf7c4ed10ab6a794