### PR TITLE
fix: handle WebGPU cleanup

### DIFF
--- a/src/components/avatar/AuroraSphere.tsx
+++ b/src/components/avatar/AuroraSphere.tsx
@@ -356,10 +356,16 @@ export function AuroraSphere({
       materialRef.current = null;
       if (pointsRef.current) {
         scene.remove(pointsRef.current);
-        pointsRef.current = null;
       }
       particleGeometry?.dispose();
-      particleMaterial?.dispose();
+      if (!(renderer instanceof WebGPURenderer)) {
+        try {
+          particleMaterial?.dispose();
+        } catch {
+          /* ignore */
+        }
+      }
+      pointsRef.current = null;
       pointsMaterialRef.current = null;
       rendererRef.current = null;
       sceneRef.current = null;


### PR DESCRIPTION
## Summary
- prevent Points material disposal on WebGPU renderers
- remove particle Points from scene before disposing to avoid dangling references

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any / Empty block statement errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a3826c8b3c8326876d4fe3d1dbb157