### PR TITLE
feat: add env lighting to full aurora

### DIFF
--- a/src/components/avatar/AuroraSphere.tsx
+++ b/src/components/avatar/AuroraSphere.tsx
@@ -13,6 +13,7 @@ import {
   triNoise3D,
 } from 'three/tsl';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
 import { useAvatarStore } from '@/state/avatar';
 import { useVoiceStore } from '@/state/voice';
 import { useUIStore } from '@/state/ui';
@@ -229,6 +230,16 @@ export function AuroraSphere({
 
       mount.appendChild(renderer.domElement);
       rendererRef.current = renderer;
+
+      if (variant === 'full') {
+        const pmrem = new THREE.PMREMGenerator(
+          renderer as THREE.WebGLRenderer
+        );
+        new RGBELoader().load('/env/hdr-small.hdr', (tex) => {
+          tex.mapping = THREE.EquirectangularReflectionMapping;
+          scene.environment = pmrem.fromEquirectangular(tex).texture;
+        });
+      }
 
       const resize = () => {
         if (disposed) return;

--- a/src/components/navigation/BottomDock.tsx
+++ b/src/components/navigation/BottomDock.tsx
@@ -95,7 +95,15 @@ export default function BottomDock() {
           {expanded && (
             <>
               <div className="flex items-center gap-3 min-w-0 mb-2">
-                {avatarEnabled && <AuroraSphere size={44} />}
+                {avatarEnabled && (
+                  <div
+                    style={{
+                      filter: 'drop-shadow(0 12px 28px rgba(0,0,0,.45))',
+                    }}
+                  >
+                    <AuroraSphere size={52} />
+                  </div>
+                )}
                 <div className="min-w-0">
                   <div className="text-[13px] opacity-90 truncate">
                     Lv. {stats.level} • Streak {stats.streak}


### PR DESCRIPTION
## Summary
- add PMREM-based environment map for full-screen AuroraSphere
- enlarge and shadow AuroraSphere in BottomDock

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, Empty block statement)*

------
https://chatgpt.com/codex/tasks/task_e_68a382ce0e1483269404c6e7c53c2476