### PR TITLE
Hide quick action pills and style dock nav links

### DIFF
--- a/src/components/navigation/BottomDock.tsx
+++ b/src/components/navigation/BottomDock.tsx
@@ -136,7 +136,7 @@ export default function BottomDock() {
               </div>
             </>
           )}
-          <nav aria-label="Main navigation">
+          <nav aria-label="Main navigation" className="dock-nav">
             <ul
               className={cn(
                 "flex justify-center",
@@ -151,11 +151,11 @@ export default function BottomDock() {
                     aria-label={label}
                     className={({ isActive }) =>
                       cn(
-                        "flex text-xs",
+                        "flex text-xs text-muted-foreground",
                         expanded
                           ? "flex-col items-center gap-1"
                           : "items-center justify-center",
-                        isActive ? "text-primary" : "text-muted-foreground",
+                        isActive && "active",
                       )
                     }
                   >

--- a/src/index.css
+++ b/src/index.css
@@ -459,6 +459,15 @@ All colors MUST be HSL.
 
 .qx-item {
   font-size: 13px;
+  display: none;
+}
+
+.dock-nav a {
+  text-decoration: none;
+}
+
+.dock-nav .active {
+  color: var(--primary);
 }
 
 /* white floor line under map */


### PR DESCRIPTION
## Summary
- Hide quick action pills via `.qx-item { display: none; }`
- Add dock navigation link styles and active color
- Mark BottomDock nav items with `dock-nav` and rely on `.active` class

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any & empty block statement)*

------
https://chatgpt.com/codex/tasks/task_e_68a3abfc6ca88326bdcbb5fa4a196aaf