### PR TITLE
feat: add actions page

### DIFF
--- a/src/components/navigation/BottomDock.tsx
+++ b/src/components/navigation/BottomDock.tsx
@@ -2,10 +2,10 @@ import { useEffect, useRef, useState, useMemo } from "react";
 import { NavLink } from "react-router-dom";
 import {
   Home,
-  Brain,
   BookOpen,
   Radio,
   Settings,
+  Grid3X3,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useGameStore } from "@/game/store";
@@ -39,7 +39,7 @@ export default function BottomDock() {
   const items = useMemo(
     () => [
       { to: "/app", label: "Home", icon: Home },
-      { to: "/app/brain", label: "Brain", icon: Brain },
+      { to: "/app/actions", label: "Actions", icon: Grid3X3 },
       { to: "/app/journal", label: "Journal", icon: BookOpen },
       { to: "/app/live", label: "Live", icon: Radio },
       { to: "/app/settings", label: "Settings", icon: Settings },

--- a/src/views/ActionsView.tsx
+++ b/src/views/ActionsView.tsx
@@ -1,0 +1,21 @@
+import { memo } from "react";
+import { QuickPodsRow } from "@/components/quick/QuickPodsRow";
+
+export default memo(function ActionsView() {
+  return (
+    <div className="container mx-auto px-4 py-4 flex flex-col gap-4">
+      <header className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold">Actions</h1>
+      </header>
+
+      {/* Quick tools that used to be on Home */}
+      <section aria-label="Quick actions">
+        <QuickPodsRow />
+      </section>
+
+      {/* Optional: drop in other small panels you had on Home */}
+      {/* <RecentChanges /> */}
+    </div>
+  );
+});
+

--- a/src/views/HomeView.tsx
+++ b/src/views/HomeView.tsx
@@ -5,7 +5,6 @@ import { Textarea } from "@/components/ui/textarea";
 import { Pencil } from "lucide-react";
 import { AuroraSphere } from "@/components/avatar/AuroraSphere";
 import { useGameStore } from "@/game/store";
-import QuickPodsRow from "@/components/quick/QuickPodsRow";
 
 function ProgressRing({ value }: { value: number }) {
   return (
@@ -111,7 +110,7 @@ export default function HomeView() {
         </div>
 
         {/* Quick pods */}
-        <QuickPodsRow />
+        {/* Quick actions moved to /app/actions */}
 
         {/* Recent changes */}
         <div className="glass-panel rounded-xl p-6">

--- a/src/views/registry.tsx
+++ b/src/views/registry.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 
 export type ViewId =
-  | "home" | "focus" | "hypno" | "voice" | "journal"
+  | "home" | "actions" | "focus" | "hypno" | "voice" | "journal"
   | "brain" | "browser" | "portal" | "archive" | "settings" | "agent" | "runner" | "plan" | "control";
 
 export type ViewMeta = {
@@ -16,6 +16,7 @@ export type ViewMeta = {
 export const views: ViewMeta[] = [
 
   { id: "home",    label: "Home",    path: "",            component: lazy(() => import("./HomeView")) },
+  { id: "actions", label: "Actions", path: "actions",     component: lazy(() => import("./ActionsView")) },
   { id: "focus",   label: "Focus",   path: "focus",      component: lazy(() => import("./FocusView")) },
   { id: "hypno",   label: "Hypno",   path: "hypno",      component: lazy(() => import("./HypnoView")) },
   { id: "voice",   label: "Voice",   path: "voice",      component: lazy(() => import("./VoiceView")) },


### PR DESCRIPTION
## Summary
- create ActionsView to host quick tool pods
- remove quick pods from HomeView
- add Actions route and navigation item

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a40a715f748326a9dc2edc3862e119