### PR TITLE
fix: import Html for Aurora follower

### DIFF
--- a/src/views/HomeGalaxy.tsx
+++ b/src/views/HomeGalaxy.tsx
@@ -1,7 +1,7 @@
 
 import React, { useMemo, useRef, useState, useEffect } from "react";
 import { Canvas, useFrame, useThree } from "@react-three/fiber";
-import { Environment, OrbitControls, Stars, useCursor } from "@react-three/drei";
+import { Environment, OrbitControls, Stars, useCursor, Html } from "@react-three/drei";
 import * as THREE from "three";
 import { useNavigate } from "react-router-dom";
 import { AuroraSphere } from "@/components/avatar/AuroraSphere";


### PR DESCRIPTION
## Summary
- fix HomeGalaxy AuroraFollower by importing `Html` from `@react-three/drei`

## Testing
- `npm run lint` *(fails: Unexpected any… and other existing lint errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a48085e29c8326a8d0b4e7f64e4db1