### PR TITLE
feat: add onboarding chat overlay

### DIFF
--- a/src/components/chat/AnchoredChatBar.tsx
+++ b/src/components/chat/AnchoredChatBar.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Mic, Send, Volume2 } from "lucide-react";
 import { useChatStore } from "@/state/chat";
+import { useOnboardingStore } from "@/state/onboarding";
 import { useTextToSpeech } from "@/voice/useTextToSpeech";
 import { setChatInputRef } from "@/hooks/useChatInputFocus";
 import { useVoiceStore } from "@/state/voice";
@@ -12,7 +13,12 @@ import {
 } from "@/voice/listenHelpers";
 
 export function AnchoredChatBar() {
-  const { send, sending, messages, recall } = useChatStore();
+  const { hasRoadmap, send: obSend, sending: obSending, messages: obMessages } = useOnboardingStore((s) => ({ hasRoadmap: s.hasRoadmap, send: s.send, sending: s.sending, messages: s.messages }));
+  const { send: chatSend, sending: chatSending, messages: chatMessages, recall: chatRecall } = useChatStore();
+  const recall = hasRoadmap ? chatRecall : null;
+  const send = hasRoadmap ? chatSend : obSend;
+  const sending = hasRoadmap ? chatSending : obSending;
+  const messages = hasRoadmap ? chatMessages : obMessages;
   const { speak, blocked, resume } = useTextToSpeech();
 
   const [input, setInput] = useState("");

--- a/src/components/onboarding/OnboardingOverlay.tsx
+++ b/src/components/onboarding/OnboardingOverlay.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from "react";
+import { Button } from "@/components/ui/button";
+import { useOnboardingStore } from "@/state/onboarding";
+
+export default function OnboardingOverlay() {
+  const { messages, sending, lockStep, skip } = useOnboardingStore();
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, sending]);
+
+  return (
+    <div
+      className="absolute inset-x-0 top-0 flex flex-col items-center pointer-events-none"
+      style={{
+        bottom: "calc(var(--dock-h) + var(--chatbar-h) + env(safe-area-inset-bottom))",
+      }}
+    >
+      <div className="flex-1 w-full max-w-md overflow-y-auto space-y-2 p-4 pointer-events-auto">
+        {messages.map((m) => (
+          <div key={m.id} className={`flex ${m.role === "assistant" ? "justify-start" : "justify-end"}`}>
+            <div
+              className={`glass-panel rounded-2xl px-3 py-2 text-sm max-w-[80%] ${
+                m.role === "assistant" ? "" : "bg-primary text-primary-foreground"
+              }`}
+            >
+              {m.content}
+            </div>
+          </div>
+        ))}
+        {sending && (
+          <div className="flex justify-start">
+            <div className="glass-panel rounded-2xl px-3 py-2 text-sm max-w-[80%]">...
+            </div>
+          </div>
+        )}
+        <div ref={bottomRef} />
+      </div>
+      <div className="pointer-events-auto flex gap-2 mb-4">
+        <Button onClick={lockStep}>Lock step</Button>
+        <Button variant="ghost" onClick={skip}>
+          Skip for now
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/state/onboarding.ts
+++ b/src/state/onboarding.ts
@@ -1,0 +1,81 @@
+import { create } from "zustand";
+
+export interface RoadmapDraft {
+  id?: string;
+  title?: string;
+  milestones: Array<{ id: string; title: string; tasks: string[] }>;
+  confidence: number; // 0..1
+}
+
+export type OnboardingMessage = {
+  id: string;
+  role: "assistant" | "user";
+  content: string;
+};
+
+interface OnboardingState {
+  hasRoadmap: boolean;
+  threadId: string;
+  messages: OnboardingMessage[];
+  draft: RoadmapDraft;
+  sending: boolean;
+  send: (text: string) => Promise<void>;
+  lockStep: () => void;
+  skip: () => void;
+}
+
+const initialAssistant = [
+  "\uD83D\uDC4B I’m your mentor. Let’s craft your roadmap together. I’ll ask a couple of tiny questions and build the first sprint for you.",
+  "First—how are you feeling today, and what’s one thing you want to improve?",
+];
+
+export const useOnboardingStore = create<OnboardingState>((set) => ({
+  hasRoadmap: false,
+  threadId: crypto.randomUUID(),
+  messages: initialAssistant.map((content) => ({
+    id: crypto.randomUUID(),
+    role: "assistant" as const,
+    content,
+  })),
+  draft: { milestones: [], confidence: 0 },
+  sending: false,
+  send: async (text: string) => {
+    const userMsg: OnboardingMessage = {
+      id: crypto.randomUUID(),
+      role: "user",
+      content: text,
+    };
+    set((s) => ({ messages: [...s.messages, userMsg], sending: true }));
+    setTimeout(() => {
+      const assistantMsg: OnboardingMessage = {
+        id: crypto.randomUUID(),
+        role: "assistant",
+        content: "Noted.",
+      };
+      set((s) => ({ messages: [...s.messages, assistantMsg], sending: false }));
+    }, 600);
+  },
+  lockStep: () =>
+    set((s) => ({
+      hasRoadmap: true,
+      draft: {
+        ...s.draft,
+        milestones: [
+          ...s.draft.milestones,
+          { id: crypto.randomUUID(), title: "First step", tasks: [] },
+        ],
+      },
+    })),
+  skip: () =>
+    set((s) => ({
+      hasRoadmap: true,
+      draft: {
+        id: s.draft.id ?? crypto.randomUUID(),
+        title: s.draft.title ?? "My Roadmap",
+        milestones: [],
+        confidence: 0,
+      },
+    })),
+}));
+
+export default useOnboardingStore;

--- a/src/views/HomeGalaxy.tsx
+++ b/src/views/HomeGalaxy.tsx
@@ -1,13 +1,12 @@
 
-import React, { useMemo, useRef, useState, useEffect } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import { Canvas, useFrame, useThree } from "@react-three/fiber";
 import { Environment, OrbitControls, Stars, useCursor, Html } from "@react-three/drei";
 import * as THREE from "three";
 import { useNavigate } from "react-router-dom";
 import { AuroraSphere } from "@/components/avatar/AuroraSphere";
-import { useRoadmapProgress } from "@/hooks/useRoadmapProgress";
-import { useChatStore } from "@/state/chat";
-import { useUIStore } from "@/state/ui";
+import { useOnboardingStore } from "@/state/onboarding";
+import OnboardingOverlay from "@/components/onboarding/OnboardingOverlay";
 
 // ----- Types -----
 type NodeStatus = "locked" | "current" | "done";
@@ -193,16 +192,7 @@ function GalaxyScene() {
 }
 
 export default function HomeGalaxy() {
-  const progress = useRoadmapProgress();
-  const pushed = useRef(false);
-  useEffect(() => {
-    if (progress.items.length || pushed.current) return;
-    pushed.current = true;
-    const push = useChatStore.getState().pushSystem;
-    push("👋 I’m your mentor. Let’s craft your roadmap together. I’ll ask a couple of tiny questions and build the first sprint for you.");
-    push("First—how are you feeling today, and what’s one thing you want to improve?");
-    useUIStore.getState().openModal("onboarding");
-  }, [progress.items.length]);
+  const hasRoadmap = useOnboardingStore((s) => s.hasRoadmap);
 
   // Full-bleed, frosted-dusk background that matches your dark theme
   return (
@@ -222,6 +212,7 @@ export default function HomeGalaxy() {
       >
         <GalaxyScene />
       </Canvas>
+        {!hasRoadmap && <OnboardingOverlay />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add onboarding state store and overlay component for chat-first roadmap setup
- route AnchoredChatBar messages through onboarding store when roadmap missing
- show onboarding overlay on HomeGalaxy until roadmap exists

## Testing
- `pnpm lint` *(fails: Unexpected any in voice files)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a47e44e9648326b20c43b6165b97d0