### PR TITLE
fix: prevent WebGPU node disposal error in AuroraSphere

### DIFF
--- a/src/components/avatar/AuroraSphere.tsx
+++ b/src/components/avatar/AuroraSphere.tsx
@@ -361,14 +361,6 @@ export function AuroraSphere({
       controlsRef.current?.dispose();
       controlsRef.current = null;
       resizeObserver?.disconnect();
-      try {
-        renderer?.dispose?.();
-      } catch {
-        /* ignore */
-      }
-      if (renderer && mount.contains(renderer.domElement)) {
-        mount.removeChild(renderer.domElement);
-      }
       geometry?.dispose();
       material?.dispose();
       materialRef.current = null;
@@ -382,6 +374,14 @@ export function AuroraSphere({
         } catch {
           /* ignore */
         }
+      }
+      try {
+        renderer?.dispose?.();
+      } catch {
+        /* ignore */
+      }
+      if (renderer && mount.contains(renderer.domElement)) {
+        mount.removeChild(renderer.domElement);
       }
       pointsRef.current = null;
       pointsMaterialRef.current = null;


### PR DESCRIPTION
## Summary
- dispose geometry and node materials before disposing the renderer to avoid `usedTimes` errors when cleaning up AuroraSphere

## Testing
- `npm run lint` *(fails: repository has existing lint errors)*
- `npx eslint src/components/avatar/AuroraSphere.tsx`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a48feb34948326b7b3add195a781d0