### PR TITLE
feat: add milestone color palette

### DIFF
--- a/src/game/galaxy/palette.ts
+++ b/src/game/galaxy/palette.ts
@@ -1,0 +1,3 @@
+export function milestoneColor(i: number): string {
+  return `hsl(${(i * 137.508) % 360} 65% 58%)`;
+}

--- a/src/views/HomeGalaxy.tsx
+++ b/src/views/HomeGalaxy.tsx
@@ -8,6 +8,7 @@ import { AuroraSphere } from "@/components/avatar/AuroraSphere";
 import { useOnboardingStore } from "@/state/onboarding";
 import { useRoadmapProgress } from "@/hooks/useRoadmapProgress";
 import OnboardingOverlay from "@/components/onboarding/OnboardingOverlay";
+import { milestoneColor } from "@/game/galaxy/palette";
 
 // ----- Types -----
 type NodeStatus = "locked" | "current" | "done";
@@ -18,9 +19,6 @@ type MapNode = {
   status: NodeStatus;
   color?: string;
 };
-
-// Luxe pastel palette
-const palette = ["#8ab4ff", "#a987ff", "#ffb3a7", "#9ff3e0", "#ffd479", "#e6a8ff"];
 
 // Build nodes with a simple default set so the home galaxy works
 // even when roadmap progress is unavailable
@@ -34,7 +32,7 @@ function useMapNodes(): { nodes: MapNode[]; currentIndex: number } {
     return stub.map((n, i) => ({
       ...n,
       status: i === 0 ? "current" : "locked",
-      color: palette[i % palette.length],
+      color: milestoneColor(i),
     }));
   }, []);
 

--- a/src/views/RoadmapGalaxy.tsx
+++ b/src/views/RoadmapGalaxy.tsx
@@ -1,14 +1,12 @@
-import React, { useMemo, useRef, useState } from "react";
-import { Canvas, useFrame, useThree } from "@react-three/fiber";
+import React, { useMemo, useRef } from "react";
+import { Canvas, useFrame } from "@react-three/fiber";
 import { Environment, OrbitControls, Stars, Html } from "@react-three/drei";
 import * as THREE from "three";
 import { AuroraSphere } from "@/components/avatar/AuroraSphere";
 import PlanetNode, { NodeStatus } from "@/components/roadmap/PlanetNode";
 import { useRoadmapStore } from "@/state/roadmapStore";
 import { useRoadmapProgress } from "@/hooks/useRoadmapProgress";
-
-// Luxe pastel palette reused from HomeGalaxy
-const palette = ["#8ab4ff", "#a987ff", "#ffb3a7", "#9ff3e0", "#ffd479", "#e6a8ff"];
+import { milestoneColor } from "@/game/galaxy/palette";
 
 function useSpiralPositions(count: number) {
   return useMemo(() => {
@@ -74,7 +72,7 @@ function useTaskNodes() {
             : index === progress.currentIndex
             ? "current"
             : "locked";
-        const color = new THREE.Color(palette[taskNodes.length % palette.length]);
+        const color = new THREE.Color(milestoneColor(taskNodes.length));
         taskNodes.push({ id: t.id, title: t.title, position: taskPos, status, color });
       });
     });


### PR DESCRIPTION
## Summary
- add golden-angle `milestoneColor` helper
- use `milestoneColor` in Home and Roadmap galaxy views

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and Empty block statement)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e4db7ff88326b7494d4f749b9d4f