### PR TITLE
feat: add onboarding chat and galaxy path progress

### DIFF
--- a/src/components/chat/AnchoredChatBar.tsx
+++ b/src/components/chat/AnchoredChatBar.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Mic, Send, Volume2 } from "lucide-react";
 import { useChatStore } from "@/state/chat";
+import { useOnboardingStore } from "@/state/onboarding";
 import { useTextToSpeech } from "@/voice/useTextToSpeech";
 import { setChatInputRef } from "@/hooks/useChatInputFocus";
 import { useVoiceStore } from "@/state/voice";
@@ -12,7 +13,12 @@ import {
 } from "@/voice/listenHelpers";
 
 export function AnchoredChatBar() {
-  const { send, sending, messages, recall } = useChatStore();
+  const { hasRoadmap, send: obSend, sending: obSending, messages: obMessages } = useOnboardingStore((s) => ({ hasRoadmap: s.hasRoadmap, send: s.send, sending: s.sending, messages: s.messages }));
+  const { send: chatSend, sending: chatSending, messages: chatMessages, recall: chatRecall } = useChatStore();
+  const recall = hasRoadmap ? chatRecall : null;
+  const send = hasRoadmap ? chatSend : obSend;
+  const sending = hasRoadmap ? chatSending : obSending;
+  const messages = hasRoadmap ? chatMessages : obMessages;
   const { speak, blocked, resume } = useTextToSpeech();
 
   const [input, setInput] = useState("");

--- a/src/components/onboarding/OnboardingOverlay.tsx
+++ b/src/components/onboarding/OnboardingOverlay.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from "react";
+import { Button } from "@/components/ui/button";
+import { useOnboardingStore } from "@/state/onboarding";
+
+export default function OnboardingOverlay() {
+  const { messages, sending, lockStep, skip, suggestion } = useOnboardingStore();
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, sending]);
+
+  return (
+    <div
+      className="absolute inset-x-0 top-0 flex flex-col items-center pointer-events-none"
+      style={{
+        bottom: "calc(var(--dock-h) + var(--chatbar-h) + env(safe-area-inset-bottom))",
+      }}
+    >
+      <div className="flex-1 w-full max-w-md overflow-y-auto space-y-2 p-4 pointer-events-auto">
+        {messages.map((m) => (
+          <div key={m.id} className={`flex ${m.role === "assistant" ? "justify-start" : "justify-end"}`}>
+            <div
+              className={`glass-panel rounded-2xl px-3 py-2 text-sm max-w-[80%] ${
+                m.role === "assistant" ? "" : "bg-primary text-primary-foreground"
+              }`}
+            >
+              {m.content}
+            </div>
+          </div>
+        ))}
+        {sending && (
+          <div className="flex justify-start">
+            <div className="glass-panel rounded-2xl px-3 py-2 text-sm max-w-[80%]">...
+            </div>
+          </div>
+        )}
+        <div ref={bottomRef} />
+      </div>
+      <div className="pointer-events-auto flex gap-2 mb-4">
+        <Button onClick={lockStep} disabled={!suggestion || sending}>
+          Lock step
+        </Button>
+        <Button variant="ghost" onClick={skip}>
+          Skip for now
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/payments/components/PricingPage.tsx
+++ b/src/modules/payments/components/PricingPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -23,6 +23,7 @@ import { PricingTier } from '@/modules/payments/types/subscription'
 import { createCheckoutSession } from '@/modules/payments/api/subscription'
 import { useSubscription } from '@/modules/payments/hooks/useSubscription'
 import { toast } from '@/hooks/use-toast'
+import { useFeatureFlags } from '@/state/featureFlags';
 
 /**
  * TODO: Activate billing UI when payments module is ready.
@@ -142,7 +143,17 @@ function PricingPageUI() {
   const [isYearly, setIsYearly] = useState(false);
   const [showComparison, setShowComparison] = useState(false);
   const [isLoading, setIsLoading] = useState<string | null>(null);
-  const { subscription } = useSubscription();
+  const { subscription, refetch } = useSubscription();
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('session_id')) {
+      useFeatureFlags.getState().setPro(true);
+      localStorage.setItem('aurora:isPro', '1');
+      refetch();
+    }
+  }, [refetch]);
 
   const handleSubscribe = async (tier: PricingTier) => {
     if (tier.id === 'freemium') {

--- a/src/modules/payments/hooks/useSubscription.ts
+++ b/src/modules/payments/hooks/useSubscription.ts
@@ -17,7 +17,7 @@ export function useSubscription() {
       const sub = (response as any).subscription as Subscription | null;
       setSubscription(sub);
       setUsage((response as any).usage);
-      useFeatureFlags.setState({ isPro: !!sub && sub.planId !== 'freemium' });
+      useFeatureFlags.getState().setPro(!!sub && sub.planId !== 'freemium');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch subscription');
     } finally {
@@ -34,7 +34,7 @@ export function useSubscription() {
       const response = await cancelSubscription(cancelAtPeriodEnd);
       const sub = (response as any).subscription as Subscription | null;
       setSubscription(sub);
-      useFeatureFlags.setState({ isPro: !!sub && sub.planId !== 'freemium' });
+      useFeatureFlags.getState().setPro(!!sub && sub.planId !== 'freemium');
       return response;
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to cancel subscription');
@@ -47,7 +47,7 @@ export function useSubscription() {
       const response = await updateSubscription(priceId, billingCycle);
       const sub = (response as any).subscription as Subscription | null;
       setSubscription(sub);
-      useFeatureFlags.setState({ isPro: !!sub && sub.planId !== 'freemium' });
+      useFeatureFlags.getState().setPro(!!sub && sub.planId !== 'freemium');
       return response;
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to update subscription');

--- a/src/services/aiRoadmap.ts
+++ b/src/services/aiRoadmap.ts
@@ -1,0 +1,30 @@
+import type { OnboardingMessage, RoadmapDraft } from "@/state/onboarding";
+
+export interface RoadmapDraftUpdate {
+  message: string;
+  milestone: { id: string; title: string; tasks: string[] };
+}
+
+export async function proposeNextStep(
+  threadId: string,
+  messages: OnboardingMessage[],
+): Promise<RoadmapDraftUpdate> {
+  void threadId;
+  void messages;
+  await new Promise((r) => setTimeout(r, 600));
+  return {
+    message:
+      "Let's start with a 'Warm-up routine' milestone: 5-minute stretch, 10 push-ups, short meditation.",
+    milestone: {
+      id: crypto.randomUUID(),
+      title: "Warm-up routine",
+      tasks: ["5-minute stretch", "10 push-ups", "Short meditation"],
+    },
+  };
+}
+
+export async function finalizeMilestone(_draft: RoadmapDraft): Promise<void> {
+  void _draft;
+  await new Promise((r) => setTimeout(r, 400));
+}
+

--- a/src/state/featureFlags.ts
+++ b/src/state/featureFlags.ts
@@ -11,9 +11,11 @@ interface FlagsState {
 }
 
 const STORAGE_KEY = 'featureFlags';
+const PRO_KEY = 'aurora:isPro';
 
 export const useFeatureFlags = create<FlagsState>((set) => {
   const raw = typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null;
+  const persistedPro = typeof window !== 'undefined' ? localStorage.getItem(PRO_KEY) : null;
   const base = {
     hypnosisScripts: false,
     cloudRouting: false,
@@ -22,6 +24,7 @@ export const useFeatureFlags = create<FlagsState>((set) => {
     isPro: false,
   };
   const initial = raw ? { ...base, ...JSON.parse(raw) } : base;
+  if (persistedPro === '1') initial.isPro = true;
   return {
     ...initial,
     toggle: (key) =>
@@ -33,6 +36,9 @@ export const useFeatureFlags = create<FlagsState>((set) => {
             STORAGE_KEY,
             JSON.stringify({ hypnosisScripts, cloudRouting, voiceStorage, appShell, isPro })
           );
+          if (key === 'isPro') {
+            localStorage.setItem(PRO_KEY, next.isPro ? '1' : '0');
+          }
         } catch {}
         return next;
       }),
@@ -45,6 +51,7 @@ export const useFeatureFlags = create<FlagsState>((set) => {
             STORAGE_KEY,
             JSON.stringify({ hypnosisScripts, cloudRouting, voiceStorage, appShell, isPro })
           );
+          localStorage.setItem(PRO_KEY, value ? '1' : '0');
         } catch {}
         return next;
       }),

--- a/src/state/onboarding.ts
+++ b/src/state/onboarding.ts
@@ -1,0 +1,88 @@
+import { create } from "zustand";
+import { finalizeMilestone, proposeNextStep } from "@/services/aiRoadmap";
+
+export interface RoadmapDraft {
+  id?: string;
+  title?: string;
+  milestones: Array<{ id: string; title: string; tasks: string[] }>;
+  confidence: number; // 0..1
+}
+
+export type OnboardingMessage = {
+  id: string;
+  role: "assistant" | "user";
+  content: string;
+};
+
+interface OnboardingState {
+  hasRoadmap: boolean;
+  threadId: string;
+  messages: OnboardingMessage[];
+  draft: RoadmapDraft;
+  sending: boolean;
+  suggestion: { id: string; title: string; tasks: string[] } | null;
+  send: (text: string) => Promise<void>;
+  lockStep: () => Promise<void>;
+  skip: () => void;
+}
+
+const initialAssistant = [
+  "\uD83D\uDC4B I’m your mentor. Let’s craft your roadmap together. I’ll ask a couple of tiny questions and build the first sprint for you.",
+  "First—how are you feeling today, and what’s one thing you want to improve?",
+];
+
+export const useOnboardingStore = create<OnboardingState>((set, get) => ({
+  hasRoadmap: false,
+  threadId: crypto.randomUUID(),
+  messages: initialAssistant.map((content) => ({
+    id: crypto.randomUUID(),
+    role: "assistant" as const,
+    content,
+  })),
+  draft: { milestones: [], confidence: 0 },
+  sending: false,
+  suggestion: null,
+  send: async (text: string) => {
+    const userMsg: OnboardingMessage = {
+      id: crypto.randomUUID(),
+      role: "user",
+      content: text,
+    };
+    const current = get();
+    const pending = [...current.messages, userMsg];
+    set({ messages: pending, sending: true });
+    const update = await proposeNextStep(current.threadId, pending);
+    const assistantMsg: OnboardingMessage = {
+      id: crypto.randomUUID(),
+      role: "assistant",
+      content: update.message,
+    };
+    set((s) => ({
+      messages: [...s.messages, assistantMsg],
+      sending: false,
+      suggestion: update.milestone,
+    }));
+  },
+  lockStep: async () => {
+    const { suggestion, draft } = get();
+    if (!suggestion) return;
+    const nextDraft: RoadmapDraft = {
+      ...draft,
+      milestones: [...draft.milestones, suggestion],
+    };
+    set({ draft: nextDraft, hasRoadmap: true, suggestion: null });
+    await finalizeMilestone(nextDraft);
+  },
+  skip: () =>
+    set((s) => ({
+      hasRoadmap: true,
+      draft: {
+        id: s.draft.id ?? crypto.randomUUID(),
+        title: s.draft.title ?? "My Roadmap",
+        milestones: [],
+        confidence: 0,
+      },
+    })),
+}));
+
+export default useOnboardingStore;

--- a/src/views/HomeGalaxy.tsx
+++ b/src/views/HomeGalaxy.tsx
@@ -1,13 +1,13 @@
 
-import React, { useMemo, useRef, useState, useEffect } from "react";
-import { Canvas, useFrame, useThree } from "@react-three/fiber";
-import { Environment, OrbitControls, Stars, useCursor, Html } from "@react-three/drei";
+import React, { useMemo, useRef, useState } from "react";
+import { Canvas, useFrame } from "@react-three/fiber";
+import { Environment, OrbitControls, Stars, useCursor, Html, Line } from "@react-three/drei";
 import * as THREE from "three";
 import { useNavigate } from "react-router-dom";
 import { AuroraSphere } from "@/components/avatar/AuroraSphere";
+import { useOnboardingStore } from "@/state/onboarding";
 import { useRoadmapProgress } from "@/hooks/useRoadmapProgress";
-import { useChatStore } from "@/state/chat";
-import { useUIStore } from "@/state/ui";
+import OnboardingOverlay from "@/components/onboarding/OnboardingOverlay";
 
 // ----- Types -----
 type NodeStatus = "locked" | "current" | "done";
@@ -137,26 +137,41 @@ function AuroraFollower({ target }: { target: React.MutableRefObject<THREE.Vecto
 
 // ----- Scene -----
 function GalaxyScene() {
-  const { nodes, currentIndex } = useMapNodes();
-  const positions = useSpiralPositions(nodes.length);
+  const { nodes } = useMapNodes();
+  const pathPoints = useSpiralPositions(20);
+  const nodePositions = useMemo(
+    () =>
+      nodes.map((_, i) =>
+        pathPoints[
+          Math.floor((i / Math.max(1, nodes.length - 1)) * (pathPoints.length - 1))
+        ]
+      ),
+    [nodes, pathPoints]
+  );
+  const curve = useMemo(() => new THREE.CatmullRomCurve3(pathPoints), [pathPoints]);
+  const curvePoints = useMemo(() => curve.getPoints(200), [curve]);
   const navigate = useNavigate();
 
-  // Track the current node’s world position for the Aurora overlay
-  const currentRef = useRef<THREE.Vector3 | null>(null);
-  currentRef.current = positions[Math.max(0, currentIndex)] ?? positions[0];
+  // Track the sphere’s world position for the Aurora overlay
+  const sphereRef = useRef<THREE.Vector3>(new THREE.Vector3());
+  const { percent } = useRoadmapProgress();
+  const progressRef = useRef(0);
 
   const onNodeClick = (n: MapNode) => {
     if (n.status === "locked") return;
     navigate(n.route);
   };
 
-  // subtle floating camera motion
+  // subtle floating camera motion and sphere progress
   const group = useRef<THREE.Group>(null!);
-  useFrame(({ clock }) => {
-    const t = clock.getElapsedTime();
+  useFrame(({ clock }, dt) => {
+    const time = clock.getElapsedTime();
     if (group.current) {
-      group.current.position.y = Math.sin(t * 0.25) * 0.05;
+      group.current.position.y = Math.sin(time * 0.25) * 0.05;
     }
+    const target = percent / 100;
+    progressRef.current += (target - progressRef.current) * Math.min(1, dt * 3);
+    curve.getPointAt(progressRef.current, sphereRef.current);
   });
 
   return (
@@ -171,8 +186,9 @@ function GalaxyScene() {
       <Environment preset="night" />
 
       <group ref={group}>
+        <Line points={curvePoints} color="#fff" lineWidth={2} transparent opacity={0.35} />
         {nodes.map((n, i) => (
-          <Planet key={n.id} node={n} position={positions[i]} onClick={onNodeClick} />
+          <Planet key={n.id} node={n} position={nodePositions[i]} onClick={onNodeClick} />
         ))}
       </group>
 
@@ -187,22 +203,13 @@ function GalaxyScene() {
       />
 
       {/* Overlay that reuses your existing AuroraSphere */}
-      <AuroraFollower target={currentRef} />
+      <AuroraFollower target={sphereRef} />
     </>
   );
 }
 
 export default function HomeGalaxy() {
-  const progress = useRoadmapProgress();
-  const pushed = useRef(false);
-  useEffect(() => {
-    if (progress.items.length || pushed.current) return;
-    pushed.current = true;
-    const push = useChatStore.getState().pushSystem;
-    push("👋 I’m your mentor. Let’s craft your roadmap together. I’ll ask a couple of tiny questions and build the first sprint for you.");
-    push("First—how are you feeling today, and what’s one thing you want to improve?");
-    useUIStore.getState().openModal("onboarding");
-  }, [progress.items.length]);
+  const hasRoadmap = useOnboardingStore((s) => s.hasRoadmap);
 
   // Full-bleed, frosted-dusk background that matches your dark theme
   return (
@@ -222,6 +229,7 @@ export default function HomeGalaxy() {
       >
         <GalaxyScene />
       </Canvas>
+        {!hasRoadmap && <OnboardingOverlay />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add onboarding state store and overlay component for chat-first roadmap setup
- route AnchoredChatBar messages through onboarding store when roadmap missing
- draw CatmullRom galaxy path and animate AuroraSphere along it using roadmap progress
- persist subscription unlock locally and refetch after checkout
- wire onboarding chat to mocked aiRoadmap service for milestone suggestions

## Testing
- `pnpm lint` *(fails: Unexpected any in voice and other existing files)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a47e44e9648326b20c43b6165b97d0