### PR TITLE
feat: centralize milestone color generation

### DIFF
--- a/src/game/galaxy/GalaxyPath.tsx
+++ b/src/game/galaxy/GalaxyPath.tsx
@@ -8,6 +8,7 @@ import { AuroraSphere } from "@/components/avatar/AuroraSphere";
 import { useRoadmapProgress } from "@/hooks/useRoadmapProgress";
 import { usePersonaStore } from "@/state/persona";
 import type { UserProfile } from "@/data/profile";
+import { milestoneColor } from "./palette";
 
 function makeCurve() {
   const pts = [
@@ -34,7 +35,7 @@ export default function GalaxyPath() {
     for (let i = 0; i < count; i++) {
       const t = i / (count - 1);
       const position = curve.getPointAt(t);
-      const color = new THREE.Color().setHSL(0.6 + t * 0.2, 0.6, 0.5);
+      const color = new THREE.Color(milestoneColor(i));
       samples.push({ position, color });
     }
     return samples;

--- a/src/game/galaxy/palette.ts
+++ b/src/game/galaxy/palette.ts
@@ -1,3 +1,4 @@
+// Generate visually distinct colors using the golden angle
 export function milestoneColor(i: number): string {
   return `hsl(${(i * 137.508) % 360} 65% 58%)`;
 }

--- a/src/views/HomeGalaxy.tsx
+++ b/src/views/HomeGalaxy.tsx
@@ -6,6 +6,7 @@ import * as THREE from "three";
 import { useNavigate } from "react-router-dom";
 import AuroraBallR3F from "@/components/avatar/AuroraBallR3F";
 import { useRoadmapProgress } from "@/hooks/useRoadmapProgress";
+import { milestoneColor } from "@/game/galaxy/palette";
 
 
 // ----- Types -----
@@ -17,10 +18,6 @@ type MapNode = {
   status: NodeStatus;
   color?: string;
 };
-
-// Luxe pastel palette
-const palette = ["#8ab4ff", "#a987ff", "#ffb3a7", "#9ff3e0", "#ffd479", "#e6a8ff"];
-const milestoneColor = (i: number) => palette[i % palette.length];
 
 // Build nodes with a simple default set so the home galaxy works
 // even when roadmap progress is unavailable


### PR DESCRIPTION
## Summary
- add golden-angle `milestoneColor` palette utility
- use shared milestone colors in home galaxy and galaxy path

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68a5917ce8a08326acd31ec4fb1599c2