### PR TITLE
feat(galaxy): add milestone node component

### DIFF
--- a/src/game/galaxy/MilestoneNode.tsx
+++ b/src/game/galaxy/MilestoneNode.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import { useRef } from "react";
 import { ThreeEvent, useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
@@ -10,11 +10,13 @@ export interface MilestoneNodeProps {
   onClick?: (index: number) => void;
 }
 
-export default function MilestoneNode({ position, color, index, active = false, onClick }: MilestoneNodeProps) {
-  const sphereRef = useRef<THREE.Mesh>(null!);
+export function MilestoneNode({ position, color, index, active = false, onClick }: MilestoneNodeProps) {
+  const sphereRef = useRef<THREE.Mesh>(null);
 
-  useFrame((_, dt) => {
-    if (sphereRef.current) sphereRef.current.rotation.y += dt * 0.6;
+  useFrame((_, delta) => {
+    if (sphereRef.current) {
+      sphereRef.current.rotation.y += delta * 0.6;
+    }
   });
 
   const handleClick = (e: ThreeEvent<MouseEvent>) => {
@@ -28,7 +30,12 @@ export default function MilestoneNode({ position, color, index, active = false, 
     <group position={position} onClick={handleClick}>
       <mesh ref={sphereRef} castShadow receiveShadow>
         <sphereGeometry args={[0.24, 48, 48]} />
-        <meshStandardMaterial color={color} metalness={0.35} roughness={0.4} emissive={color.clone().multiplyScalar(0.25)} />
+        <meshStandardMaterial
+          color={color}
+          metalness={0.35}
+          roughness={0.4}
+          emissive={color.clone().multiplyScalar(0.25)}
+        />
       </mesh>
       <mesh rotation={[Math.PI / 2, 0, 0]}>
         <torusGeometry args={[0.34, 0.006, 16, 64]} />
@@ -43,4 +50,6 @@ export default function MilestoneNode({ position, color, index, active = false, 
     </group>
   );
 }
+
+export default MilestoneNode;
 


### PR DESCRIPTION
## Summary
- create `MilestoneNode` for galaxy game with rotating sphere and torus rings
- invoke click handler and show an extra ring when active

## Testing
- `npm test`
- `npm run lint src/game/galaxy/MilestoneNode.tsx` *(fails: many existing lint errors)*
- `npx eslint src/game/galaxy/MilestoneNode.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a592dcabd48326ad7ea9c2dbdd6116