### PR TITLE
fix: avoid passing children prop to AuroraBall

### DIFF
--- a/src/components/avatar/AuroraBallR3F.tsx
+++ b/src/components/avatar/AuroraBallR3F.tsx
@@ -7,7 +7,7 @@ import { useFrame } from '@react-three/fiber';
 export type AuroraBallProps = JSX.IntrinsicElements['group'] & { size?: number };
 
 const AuroraBallR3F = forwardRef<THREE.Group, AuroraBallProps>(
-  ({ size = 1, ...rest }, ref) => {
+  ({ size = 1, children, ...rest }, ref) => {
     const matRef = useRef<THREE.ShaderMaterial>(null!);
 
     const uniforms = useMemo(
@@ -104,6 +104,7 @@ void main(){
           <ringGeometry args={[1.05, 1.08, 64]} />
           <meshBasicMaterial opacity={0.2} transparent />
         </mesh>
+        {children}
       </group>
     );
   }


### PR DESCRIPTION
## Summary
- fix AuroraBallR3F to exclude the `children` prop from spread attributes and render it explicitly

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68a59755ae8483268bcf2c0b4c36c703