### PR TITLE
Fix AuroraBall useMemo dependency

### DIFF
--- a/src/components/avatar/AuroraBallR3F.tsx
+++ b/src/components/avatar/AuroraBallR3F.tsx
@@ -15,15 +15,13 @@ const AuroraBallR3F = forwardRef<THREE.Group, AuroraBallProps>(
 
     const groupProps = useMemo(() => {
       const entries = Object.entries(restProps as Record<string, unknown>).filter(
-
         ([key]) => !key.startsWith('data-') && !key.startsWith('aria-')
       );
       return Object.fromEntries(entries) as Omit<
         JSX.IntrinsicElements['group'],
         'children'
       >;
-
-    }, [props]);
+    }, [restProps]);
 
 
     const uniforms = useMemo(


### PR DESCRIPTION
## Summary
- fix AuroraBallR3F groupProps memoization to depend on restProps

## Testing
- `npm test`
- `npm run build` *(fails: TS errors)*
- `npm run lint` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ad1a634083268f1b0822fb31fabd