### PR TITLE
feat: add agent action dispatcher

### DIFF
--- a/src/agent/actions/dispatcher.ts
+++ b/src/agent/actions/dispatcher.ts
@@ -1,0 +1,32 @@
+import { actions } from './registry';
+import type { ActionResult } from './types';
+import { useProgressStore } from '@/state/progress';
+import { track } from '@/utils/telemetry';
+
+export async function dispatch(
+  id: string,
+  params: any = {},
+): Promise<ActionResult> {
+  const action = actions.get(id);
+  if (!action) {
+    console.warn('[dispatcher] unknown action', id);
+    return { success: false, error: 'unknown_action' };
+  }
+
+  if (action.confirm && typeof window !== 'undefined') {
+    const ok = window.confirm(`Allow action ${id}?`);
+    if (!ok) {
+      track('agent/action_cancelled', { id });
+      return { success: false, error: 'cancelled' };
+    }
+  }
+
+  const result = await action.run(params).catch((e) => ({ success: false, error: String(e) }));
+  if (result.success && action.reward) {
+    try {
+      useProgressStore.getState().awardXP(action.reward, { action: id });
+    } catch {}
+  }
+  track('agent/action', { id, success: result.success });
+  return result;
+}

--- a/src/agent/actions/registry.ts
+++ b/src/agent/actions/registry.ts
@@ -1,0 +1,41 @@
+import { bus } from '@/utils/bus';
+import { useFocusTimer } from '@/state/focusTimer';
+import { AgentAction } from './types';
+
+export const actions = new Map<string, AgentAction>([
+  [
+    'view.open',
+    {
+      id: 'view.open',
+      scope: 'view',
+      run: async ({ id, params }: { id: string; params?: Record<string, string> }) => {
+        bus.emit('nav:view', { id, params });
+        return { success: true };
+      },
+    },
+  ],
+  [
+    'task.create',
+    {
+      id: 'task.create',
+      scope: 'task',
+      confirm: true,
+      run: async (p: { title: string }) => {
+        console.debug('[actions] create task', p);
+        return { success: true };
+      },
+    },
+  ],
+  [
+    'focus.start',
+    {
+      id: 'focus.start',
+      scope: 'focus',
+      reward: 10,
+      run: async () => {
+        useFocusTimer.getState().start();
+        return { success: true };
+      },
+    },
+  ],
+]);

--- a/src/agent/actions/types.ts
+++ b/src/agent/actions/types.ts
@@ -1,0 +1,19 @@
+export type ActionScope = 'view' | 'task' | 'focus';
+
+export interface ActionResult<T = unknown> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}
+
+export interface AgentAction<P = any, R = any> {
+  /** Unique identifier, e.g. "view.open" */
+  id: string;
+  scope: ActionScope;
+  description?: string;
+  /** When true, dispatcher will ask the user for confirmation before running. */
+  confirm?: boolean;
+  /** XP reward to grant upon successful completion */
+  reward?: number;
+  run: (params: P) => Promise<ActionResult<R>>;
+}

--- a/src/agent/hooks/useActionBus.ts
+++ b/src/agent/hooks/useActionBus.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand';
+
+type Handler<T = any> = (payload: T) => void;
+
+function createEmitter() {
+  const map = new Map<string, Set<Handler>>();
+  return {
+    emit(event: string, payload?: any) {
+      const set = map.get(event);
+      if (set) {
+        for (const fn of Array.from(set)) fn(payload);
+      }
+    },
+    on(event: string, handler: Handler) {
+      const set = map.get(event) || new Set<Handler>();
+      set.add(handler);
+      map.set(event, set);
+      return () => {
+        set.delete(handler);
+        if (!set.size) map.delete(event);
+      };
+    },
+  };
+}
+
+const emitter = createEmitter();
+
+export const useActionBus = create(() => emitter);

--- a/src/services/aiBridge.ts
+++ b/src/services/aiBridge.ts
@@ -1,0 +1,10 @@
+import { dispatch } from '@/agent/actions/dispatcher';
+
+export interface ParsedCommand {
+  action: string;
+  params?: any;
+}
+
+export async function runAgentCommand(cmd: ParsedCommand) {
+  return dispatch(cmd.action, cmd.params);
+}

--- a/src/state/chat.ts
+++ b/src/state/chat.ts
@@ -10,6 +10,7 @@ import {
 import { saveMemory, queryMemory } from "@/memory/store";
 import { mergeAndExplainMemories, formatMemoryContext } from "@/memory/relevance";
 import { bus } from "@/utils/bus";
+import { runAgentCommand } from "@/services/aiBridge";
 
 export type ChatEntry = ChatMessage & { id: string };
 
@@ -92,12 +93,27 @@ export const useChatStore = create<ChatState>((set, get) => ({
         }
       });
 
+      let finalText = fullText;
+      try {
+        const parsed = JSON.parse(fullText);
+        if (parsed?.content) finalText = parsed.content;
+        if (parsed?.tool_call) {
+          await runAgentCommand(parsed.tool_call);
+        }
+      } catch {}
+
+      set(state => ({
+        messages: state.messages.map(m =>
+          m.id === responseId ? { ...m, content: finalText } : m
+        ),
+      }));
+
       useAvatarStore.getState().setSentiment(sentiment);
       bus.emit('chat/stream:end', { id: responseId });
       set({ sending: false });
-      void voiceService.speak(fullText);
-      memoryStore.add("episodic", "assistant", fullText).catch(() => {});
-      saveMemory(fullText, { role: "assistant" }).catch(() => {});
+      void voiceService.speak(finalText);
+      memoryStore.add("episodic", "assistant", finalText).catch(() => {});
+      saveMemory(finalText, { role: "assistant" }).catch(() => {});
     } catch (error) {
       set(state => ({
         messages: state.messages.map(m =>


### PR DESCRIPTION
## Summary
- define ActionScope, AgentAction, and ActionResult types
- add Map-based action registry and dispatcher with confirmation, reward, analytics hooks
- expose runAgentCommand and hook chat responses to dispatch actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a619443da48326b245ad6633da17dc