### PR TITLE
feat: add gamification state and award flow

### DIFF
--- a/src/components/home/QuickPodsRow.tsx
+++ b/src/components/home/QuickPodsRow.tsx
@@ -6,6 +6,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { toast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
 import { awardXPRemote } from "@/integrations/supabase/gameSync";
+import { award } from "@/game/gamification/award";
 import FocusRunner from "@/nodes/FocusRunner";
 import { useChatInputFocus } from "@/hooks/useChatInputFocus";
 
@@ -182,6 +183,7 @@ export function QuickPodsRow() {
             (async () => {
               try {
                 await awardXPRemote("hypnosis_session", 20, { mode });
+                award({ xp: 20 });
               } catch (err) {
                 console.error(err);
               }

--- a/src/components/hud/StatsCard.tsx
+++ b/src/components/hud/StatsCard.tsx
@@ -1,0 +1,12 @@
+import { useGamificationStore } from '@/game/gamification/store';
+
+export default function StatsCard() {
+  const { xp, level, streak } = useGamificationStore();
+  return (
+    <div className="glass-panel rounded-xl p-4 text-sm">
+      <div>Level: {level}</div>
+      <div>XP: {xp}</div>
+      <div>Streak: {streak}</div>
+    </div>
+  );
+}

--- a/src/components/hypno/HypnoPanel.tsx
+++ b/src/components/hypno/HypnoPanel.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import HypnosisLauncher from "@/components/hypnosis/HypnosisLauncher";
 import { useGameStore } from "@/game/store";
 import { REWARDS } from "@/game/QuestEngine";
+import { award } from "@/game/gamification/award";
 import { supabase } from "@/integrations/supabase/client";
 import { logEvent } from "@/integrations/supabase/gameSync";
 import { DialogTitle } from "@/components/ui/dialog";
@@ -14,7 +15,6 @@ type Props = {
 
 export default function HypnoPanel({ onClose }: Props) {
   const [open, setOpen] = useState(false);
-  const awardXP = useGameStore((s) => s.awardXP);
   const completeQuest = useGameStore((s) => s.completeQuest);
   const mood = useGameStore((s) => s.mood);
 
@@ -29,7 +29,7 @@ export default function HypnoPanel({ onClose }: Props) {
   const onStart = async () => {
     // Local: complete quest + award XP
     completeQuest('start-hypno');
-    awardXP(REWARDS.completeQuest);
+    award({ xp: REWARDS.completeQuest });
 
     // Server: create a session start row (if signed-in)
     const { data } = await supabase.auth.getUser();

--- a/src/components/live/CurrentFocusCard.tsx
+++ b/src/components/live/CurrentFocusCard.tsx
@@ -3,6 +3,7 @@ import { toast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
 import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
 import { awardXPRemote } from "@/integrations/supabase/gameSync";
+import { award } from "@/game/gamification/award";
 import { useState } from "react";
 import { StickyNote } from "lucide-react";
 
@@ -63,6 +64,7 @@ export function CurrentFocusCard({
     // Award XP for task completion and update streak
     try {
       await awardXPRemote("task_complete", 10, { task_id: task.id });
+      award({ xp: 10 });
     } catch (e) { console.error(e); }
 
     onAdvance();

--- a/src/components/mindworld/MindWorldDashboard.tsx
+++ b/src/components/mindworld/MindWorldDashboard.tsx
@@ -9,6 +9,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { useGameStore } from "@/game/store";
 import { REWARDS } from "@/game/QuestEngine";
+import { award } from "@/game/gamification/award";
 
 export default function MindWorldDashboard() {
   const [vec, setVec] = useState({ x: 0, y: 0 });
@@ -21,7 +22,6 @@ export default function MindWorldDashboard() {
   const [joyEnabled, setJoyEnabled] = useLocalStorage<boolean>("joystick.enabled", isMobile);
 
   // Game store actions
-  const awardXP = useGameStore(s => s.awardXP);
   const completeQuest = useGameStore(s => s.completeQuest);
 
   // Toggle joystick via global event and persist
@@ -67,14 +67,14 @@ export default function MindWorldDashboard() {
     const set = (id: OverlayId | null) => setOverlay(id);
     const onMos = (e: any) => {
       const t = e.detail?.type;
-      if (t === 'startFocus') { set('focus'); completeQuest('pick-focus'); awardXP(REWARDS.completeQuest); }
-      if (t === 'startHypnosis') { set('mentor'); completeQuest('start-hypno'); awardXP(REWARDS.completeQuest); }
-      if (t === 'voiceNote') { set('library'); completeQuest('record-voice'); awardXP(REWARDS.completeQuest); }
-      if (t === 'addNote') { set('library'); completeQuest('add-note'); awardXP(REWARDS.completeQuest); }
+      if (t === 'startFocus') { set('focus'); completeQuest('pick-focus'); award({ xp: REWARDS.completeQuest }); }
+      if (t === 'startHypnosis') { set('mentor'); completeQuest('start-hypno'); award({ xp: REWARDS.completeQuest }); }
+      if (t === 'voiceNote') { set('library'); completeQuest('record-voice'); award({ xp: REWARDS.completeQuest }); }
+      if (t === 'addNote') { set('library'); completeQuest('add-note'); award({ xp: REWARDS.completeQuest }); }
     };
     window.addEventListener('mos', onMos as any);
     return () => window.removeEventListener('mos', onMos as any);
-  }, [awardXP, completeQuest]);
+  }, [completeQuest]);
 
   // Close overlay with Escape key
   useEffect(() => {

--- a/src/game/gamification/award.ts
+++ b/src/game/gamification/award.ts
@@ -1,0 +1,15 @@
+import { useGamificationStore } from './store';
+
+export type AwardArgs = {
+  xp?: number;
+  achievement?: string;
+};
+
+export function award({ xp = 0, achievement }: AwardArgs) {
+  if (xp > 0) {
+    useGamificationStore.getState().addXp(xp);
+  }
+  if (achievement) {
+    console.debug('achievement unlocked', achievement);
+  }
+}

--- a/src/game/gamification/model.ts
+++ b/src/game/gamification/model.ts
@@ -1,0 +1,5 @@
+export const XP_PER_LEVEL = 100;
+
+export function levelForXp(xp: number): number {
+  return Math.floor(xp / XP_PER_LEVEL) + 1;
+}

--- a/src/game/gamification/store.ts
+++ b/src/game/gamification/store.ts
@@ -1,0 +1,45 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { levelForXp } from './model';
+
+export type GamificationState = {
+  xp: number;
+  level: number;
+  streak: number;
+  lastCheckIn: string | null;
+  addXp: (amount: number) => void;
+  checkIn: () => void;
+};
+
+export const useGamificationStore = create<GamificationState>()(
+  persist(
+    (set, get) => ({
+      xp: 0,
+      level: 1,
+      streak: 0,
+      lastCheckIn: null,
+      addXp: (amount) =>
+        set((state) => {
+          const xp = state.xp + Math.max(0, amount);
+          const level = levelForXp(xp);
+          return { xp, level };
+        }),
+      checkIn: () =>
+        set((state) => {
+          const today = new Date().toDateString();
+          if (state.lastCheckIn === today) return {} as any;
+          const streak = state.streak + 1;
+          return { streak, lastCheckIn: today };
+        }),
+    }),
+    {
+      name: 'gamification',
+      partialize: (s) => ({
+        xp: s.xp,
+        level: s.level,
+        streak: s.streak,
+        lastCheckIn: s.lastCheckIn,
+      }),
+    }
+  )
+);

--- a/src/nodes/FocusRunner.tsx
+++ b/src/nodes/FocusRunner.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useProgressStore } from "@/state/progress";
 import { awardXPRemote } from "@/integrations/supabase/gameSync";
+import { award } from "@/game/gamification/award";
 
 type Props = { node: { id: string; label: string; minutes?: number; induction?: number }; onExit: () => void };
 
@@ -37,6 +38,7 @@ export default function FocusRunner({ node, onExit }: Props) {
     pause();
     setEnded(true);
     awardXP(40, { activity: "focus", nodeId: node.id });
+    award({ xp: 40 });
     await awardXPRemote("focus", 40, { nodeId: node.id }).catch(() => {});
     complete(node.id);
   };

--- a/src/nodes/HypnosisRunner.tsx
+++ b/src/nodes/HypnosisRunner.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useRef, useState } from "react";
 import { useProgressStore } from "@/state/progress";
-import { useGameStore } from "@/game/store";
 import { playHypno, type PlaybackHandle } from "@/hypno/tts";
 import HypnoSphere from "@/components/effects/HypnoSphere";
-import { awardXPRemote } from "@/integrations/supabase/gameSync";
+import { award } from "@/game/gamification/award";
+import { useGamificationStore } from "@/game/gamification/store";
 
 type Props = { node: { id: string; label: string; script?: string; duration?: number }; onExit: () => void };
 
@@ -39,8 +39,8 @@ export default function HypnosisRunner({ node, onExit }: Props) {
     // Award XP + streak
     const amount = 25;
     awardXP(amount, { activity: "hypnosis", nodeId: node.id });
-    useGameStore.getState().awardXP(amount);
-    useGameStore.getState().incStreak();
+    award({ xp: amount });
+    useGamificationStore.getState().checkIn();
     complete(node.id);
   };
 

--- a/src/nodes/RewardRunner.tsx
+++ b/src/nodes/RewardRunner.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useProgressStore } from "@/state/progress";
 import { AuroraSphere } from "@/components/avatar/AuroraSphere";
 import { useVoiceStore } from "@/state/voice";
+import { award } from "@/game/gamification/award";
 
 type Props = { node: { id: string; label: string }; onExit: () => void };
 
@@ -11,6 +12,7 @@ export default function RewardRunner({ node, onExit }: Props) {
 
   useEffect(() => {
     awardXP(20, { activity: "reward", nodeId: node.id });
+    award({ xp: 20 });
     complete(node.id);
   }, [awardXP, complete, node.id]);
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -19,6 +19,8 @@ import FastTravel from '@/components/overlays/FastTravel';
 import HypnoPanel from '@/components/hypno/HypnoPanel';
 import { useGameStore } from '@/game/store';
 import { REWARDS, DAILY_QUESTS } from '@/game/QuestEngine';
+import { award } from '@/game/gamification/award';
+import { useGamificationStore } from '@/game/gamification/store';
 type PanelKey = 'live' | 'archive' | 'control' | 'create';
 
 const panelMap: Record<
@@ -399,9 +401,8 @@ const Index = () => {
   const { user, initializing } = useSupabaseAuth();
 
   const completeQuest = useGameStore((s) => s.completeQuest);
-  const awardXP = useGameStore((s) => s.awardXP);
   const resetDaily = useGameStore((s) => s.resetDaily);
-  const incStreak = useGameStore((s) => s.incStreak);
+  const checkIn = useGamificationStore((s) => s.checkIn);
 
   // Signature moment: soft reactive spotlight following pointer
   const glowRef = useRef<HTMLDivElement>(null);
@@ -502,8 +503,8 @@ const Index = () => {
         (q) => (useGameStore.getState().quests as any)[q.id]
       );
       if (allDone && localStorage.getItem('mos.fullclear') !== today) {
-        awardXP(REWARDS.fullClear);
-        incStreak();
+        award({ xp: REWARDS.fullClear });
+        checkIn();
         try {
           localStorage.setItem('mos.fullclear', today);
         } catch {}
@@ -513,7 +514,7 @@ const Index = () => {
     const onFocus = () => {
       go('live', 'Focus', 'Starting focus session…');
       completeQuest('pick-focus');
-      awardXP(REWARDS.completeQuest);
+      award({ xp: REWARDS.completeQuest });
       checkFullClear();
     };
     const onHypno = () => {
@@ -524,13 +525,13 @@ const Index = () => {
     const onVoice = () => {
       go('archive', 'Voice', 'Opening voice notes…');
       completeQuest('record-voice');
-      awardXP(REWARDS.completeQuest);
+      award({ xp: REWARDS.completeQuest });
       checkFullClear();
     };
     const onNote = () => {
       go('create', 'Notes', 'Capture a quick note');
       completeQuest('add-note');
-      awardXP(REWARDS.completeQuest);
+      award({ xp: REWARDS.completeQuest });
       checkFullClear();
     };
     const onMos = (e: any) => {
@@ -544,7 +545,7 @@ const Index = () => {
     return () => {
       window.removeEventListener('mos', onMos as any);
     };
-  }, [gotoPanel, completeQuest, awardXP, incStreak]);
+  }, [gotoPanel, completeQuest, checkIn]);
 
   if (!initializing && !user) {
     return <LandingPage />;


### PR DESCRIPTION
## Summary
- add gamification model, store and award helper
- expose StatsCard component bound to gamification store
- route XP rewards through new award flow and check-in streaks

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68a6195f37748326a23fba7d11a2a23a