### PR TITLE
feat: add Dexie-backed local sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "date-fns": "3.6.0",
+        "dexie": "^4.2.0",
         "embla-carousel-react": "^8.6.0",
         "framer-motion": "^12.23.12",
         "html-to-image": "^1.11.13",
@@ -9500,6 +9501,12 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/dexie": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.2.0.tgz",
+      "integrity": "sha512-OSeyyWOUetDy9oFWeddJgi83OnRA3hSFh3RrbltmPgqHszE9f24eUCVLI4mPg0ifsWk0lQTdnS+jyGNrPMvhDA==",
+      "license": "Apache-2.0"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "3.6.0",
+    "dexie": "^4.2.0",
     "embla-carousel-react": "^8.6.0",
     "framer-motion": "^12.23.12",
     "html-to-image": "^1.11.13",

--- a/src/data/db.ts
+++ b/src/data/db.ts
@@ -1,0 +1,41 @@
+import Dexie, { type Table } from 'dexie';
+
+export interface Task {
+  id: string;
+  roadmap_id: string;
+  title: string;
+  description?: string | null;
+  status: string;
+  due_at?: string | null;
+  completed_at?: string | null;
+  position?: number | null;
+  user_id: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Stat {
+  id: string;
+  level: number;
+  total_xp: number;
+  streak_count: number;
+  last_active_date?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export class AuroraDB extends Dexie {
+  tasks!: Table<Task, string>;
+  stats!: Table<Stat, string>;
+
+  constructor() {
+    super('aurora');
+    this.version(1).stores({
+      tasks: '&id,updated_at',
+      stats: '&id',
+    });
+  }
+}
+
+export const db = new AuroraDB();
+

--- a/src/data/sync.ts
+++ b/src/data/sync.ts
@@ -1,0 +1,59 @@
+import { supabase } from '@/integrations/supabase/client';
+import { db, type Task, type Stat } from './db';
+
+async function upsertIfNewer<T extends { id: string; updated_at: string }>(
+  table: string,
+  row: T,
+) {
+  const { data: existing } = await supabase
+    .from(table)
+    .select('updated_at')
+    .eq('id', row.id)
+    .maybeSingle();
+  if (!existing || new Date(row.updated_at) > new Date(existing.updated_at)) {
+    await supabase.from(table).upsert(row);
+  }
+}
+
+export async function pushToSupabase() {
+  const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+  const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+  if (!supabaseUrl || !supabaseAnonKey) return;
+
+  const tasks = await db.tasks.toArray();
+  for (const t of tasks) {
+    await upsertIfNewer<Task>('tasks', t);
+  }
+
+  const stats = await db.stats.toArray();
+  for (const s of stats) {
+    await upsertIfNewer<Stat>('user_stats', s);
+  }
+}
+
+export async function pullFromSupabase() {
+  const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+  const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+  if (!supabaseUrl || !supabaseAnonKey) return;
+
+  const { data: remoteTasks } = await supabase.from('tasks').select('*');
+  if (remoteTasks) {
+    for (const t of remoteTasks as Task[]) {
+      const local = await db.tasks.get(t.id);
+      if (!local || new Date(t.updated_at) > new Date(local.updated_at)) {
+        await db.tasks.put(t);
+      }
+    }
+  }
+
+  const { data: remoteStats } = await supabase.from('user_stats').select('*');
+  if (remoteStats) {
+    for (const s of remoteStats as Stat[]) {
+      const local = await db.stats.get(s.id);
+      if (!local || new Date(s.updated_at) > new Date(local.updated_at)) {
+        await db.stats.put(s);
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- add Dexie-powered AuroraDB with tasks and stats tables
- create sync helpers to push/pull data with Supabase using updated_at safeguards
- include Dexie dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6c75130b48326abf6d5168ed8a1c1