### PR TITLE
feat: persist roadmap tasks with Dexie

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "date-fns": "3.6.0",
+        "dexie": "^3.2.4",
         "embla-carousel-react": "^8.6.0",
         "framer-motion": "^12.23.12",
         "html-to-image": "^1.11.13",
@@ -9500,6 +9501,15 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/dexie": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.2.4.tgz",
+      "integrity": "sha512-VKoTQRSv7+RnffpOJ3Dh6ozknBqzWw/F3iqMdsZg958R0AS8AnY9x9d1lbwENr0gzeGJHXKcGhAMRaqys6SxqA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=6.0"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "3.6.0",
+    "dexie": "^3.2.4",
     "embla-carousel-react": "^8.6.0",
     "framer-motion": "^12.23.12",
     "html-to-image": "^1.11.13",

--- a/src/ai/RoadmapBuilder.ts
+++ b/src/ai/RoadmapBuilder.ts
@@ -1,5 +1,5 @@
 import { nanoid } from "nanoid";
-import { Goal, Sprint, Task, useRoadmapStore } from "@/state/roadmapStore";
+import { Goal, Sprint, Task, useRoadmapStore, createTask } from "@/state/roadmapStore";
 
 /**
  * Simple helper to build and mutate the local roadmap structure.
@@ -24,10 +24,8 @@ export class RoadmapBuilder {
     return sprint;
   }
 
-  static addTask(goalId: string, sprintId: string, title: string) {
-    const task: Task = { id: `task-${nanoid()}`, title, status: "todo" };
-    useRoadmapStore.getState().addTask(goalId, sprintId, task);
-    return task;
+  static async addTask(goalId: string, sprintId: string, title: string) {
+    return await createTask(goalId, sprintId, title);
   }
 
   static markTaskDone(taskId: string) {

--- a/src/data/db.ts
+++ b/src/data/db.ts
@@ -1,0 +1,27 @@
+import Dexie, { Table } from 'dexie';
+
+export type TaskStatus = "todo" | "doing" | "done";
+
+export interface TaskRecord {
+  id: string;
+  title: string;
+  status: TaskStatus;
+  notes?: string;
+  goalId: string;
+  goalTitle: string;
+  sprintId: string;
+  sprintTitle: string;
+}
+
+class RoadmapDB extends Dexie {
+  tasks!: Table<TaskRecord, string>;
+
+  constructor() {
+    super('aurora');
+    this.version(1).stores({
+      tasks: 'id, goalId, sprintId, status'
+    });
+  }
+}
+
+export const db = new RoadmapDB();

--- a/src/hooks/useRoadmapProgress.ts
+++ b/src/hooks/useRoadmapProgress.ts
@@ -1,14 +1,17 @@
-import { useMemo } from "react";
-import { flattenRoadmap, useRoadmapStore } from "@/state/roadmapStore";
+import { useEffect, useState } from "react";
+import { flattenRoadmap, useRoadmapStore, Task } from "@/state/roadmapStore";
 
 export function useRoadmapProgress(_userId?: string | null, _roadmapId?: string | null) {
   const goals = useRoadmapStore((s) => s.goals);
-  return useMemo(() => {
-    const items = flattenRoadmap(goals);
-    const total = items.length || 1;
-    const done = items.filter((t) => t.status === "done").length;
-    const currentIndex = items.findIndex((t) => t.status !== "done");
-    const percent = Math.round((done / total) * 100);
-    return { items, currentIndex, percent } as const;
+  const [items, setItems] = useState<Task[]>([]);
+
+  useEffect(() => {
+    flattenRoadmap().then(setItems);
   }, [goals]);
+
+  const total = items.length || 1;
+  const done = items.filter((t) => t.status === "done").length;
+  const currentIndex = items.findIndex((t) => t.status !== "done");
+  const percent = Math.round((done / total) * 100);
+  return { items, currentIndex, percent } as const;
 }

--- a/src/state/roadmapStore.ts
+++ b/src/state/roadmapStore.ts
@@ -26,26 +26,13 @@ interface RoadmapState {
   setGoals: (goals: Goal[]) => void;
   addGoal: (goal: Goal) => void;
   addSprint: (goalId: string, sprint: Sprint) => void;
-  addTask: (goalId: string, sprintId: string, task: Task) => void;
+  addTask: (
+    goalId: string,
+    sprintId: string,
+    task: Task,
+    persist?: boolean
+  ) => void;
   markTaskDone: (taskId: string) => void;
-}
-
-function collectTasks(goals: Goal[]): TaskRecord[] {
-  const list: TaskRecord[] = [];
-  goals.forEach((g) =>
-    g.sprints.forEach((s) =>
-      s.tasks.forEach((t) =>
-        list.push({
-          ...t,
-          goalId: g.id,
-          goalTitle: g.title,
-          sprintId: s.id,
-          sprintTitle: s.title,
-        })
-      )
-    )
-  );
-  return list;
 }
 
 export const useRoadmapStore = create<RoadmapState>((set, get) => {
@@ -68,23 +55,15 @@ export const useRoadmapStore = create<RoadmapState>((set, get) => {
     set({ goals: Array.from(goalsMap.values()) });
   }
 
-  async function save() {
-    const tasks = collectTasks(get().goals);
-    await db.tasks.clear();
-    await db.tasks.bulkPut(tasks);
-  }
-
   void load();
 
   return {
     goals: [],
     setGoals: (goals) => {
       set({ goals });
-      void save();
     },
     addGoal: (goal) => {
       set({ goals: [...get().goals, goal] });
-      void save();
     },
     addSprint: (goalId, sprint) => {
       set({
@@ -92,9 +71,8 @@ export const useRoadmapStore = create<RoadmapState>((set, get) => {
           g.id === goalId ? { ...g, sprints: [...g.sprints, sprint] } : g
         ),
       });
-      void save();
     },
-    addTask: (goalId, sprintId, task) => {
+    addTask: (goalId, sprintId, task, persist = true) => {
       set({
         goals: get().goals.map((g) =>
           g.id === goalId
@@ -107,7 +85,17 @@ export const useRoadmapStore = create<RoadmapState>((set, get) => {
             : g
         ),
       });
-      void save();
+      if (persist) {
+        const goal = get().goals.find((g) => g.id === goalId);
+        const sprint = goal?.sprints.find((s) => s.id === sprintId);
+        void db.tasks.put({
+          ...task,
+          goalId,
+          goalTitle: goal?.title ?? "",
+          sprintId,
+          sprintTitle: sprint?.title ?? "",
+        });
+      }
     },
     markTaskDone: (taskId) => {
       set({
@@ -142,6 +130,7 @@ export async function createTask(goalId: string, sprintId: string, title: string
     sprintId,
     sprintTitle: sprint?.title ?? "",
   });
-  state.addTask(goalId, sprintId, task);
+  state.addTask(goalId, sprintId, task, false);
   return task;
 }
+

--- a/src/state/roadmapStore.ts
+++ b/src/state/roadmapStore.ts
@@ -1,7 +1,6 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
-
-export type TaskStatus = "todo" | "doing" | "done";
+import { db, TaskRecord, TaskStatus } from "@/data/db";
+import { nanoid } from "nanoid";
 
 export interface Task {
   id: string;
@@ -31,58 +30,118 @@ interface RoadmapState {
   markTaskDone: (taskId: string) => void;
 }
 
-export const useRoadmapStore = create<RoadmapState>()(
-  persist(
-    (set, get) => ({
-      goals: [],
-      setGoals: (goals) => set({ goals }),
-      addGoal: (goal) => set({ goals: [...get().goals, goal] }),
-      addSprint: (goalId, sprint) =>
-        set({
-          goals: get().goals.map((g) =>
-            g.id === goalId ? { ...g, sprints: [...g.sprints, sprint] } : g
-          ),
-        }),
-      addTask: (goalId, sprintId, task) =>
-        set({
-          goals: get().goals.map((g) =>
-            g.id === goalId
-              ? {
-                  ...g,
-                  sprints: g.sprints.map((s) =>
-                    s.id === sprintId
-                      ? { ...s, tasks: [...s.tasks, task] }
-                      : s
-                  ),
-                }
-              : g
-          ),
-        }),
-      markTaskDone: (taskId) =>
-        set({
-          goals: get().goals.map((g) => ({
-            ...g,
-            sprints: g.sprints.map((s) => ({
-              ...s,
-              tasks: s.tasks.map((t) =>
-                t.id === taskId ? { ...t, status: "done" } : t
-              ),
-            })),
-          })),
-        }),
-    }),
-    {
-      name: "aurora-roadmap",
-    }
-  )
-);
-
-export const flattenRoadmap = (goals: Goal[]): Task[] => {
-  const tasks: Task[] = [];
+function collectTasks(goals: Goal[]): TaskRecord[] {
+  const list: TaskRecord[] = [];
   goals.forEach((g) =>
-    g.sprints.forEach((s) => {
-      tasks.push(...s.tasks);
-    })
+    g.sprints.forEach((s) =>
+      s.tasks.forEach((t) =>
+        list.push({
+          ...t,
+          goalId: g.id,
+          goalTitle: g.title,
+          sprintId: s.id,
+          sprintTitle: s.title,
+        })
+      )
+    )
   );
-  return tasks;
+  return list;
+}
+
+export const useRoadmapStore = create<RoadmapState>((set, get) => {
+  async function load() {
+    const records = await db.tasks.toArray();
+    const goalsMap = new Map<string, Goal>();
+    records.forEach(({ goalId, goalTitle, sprintId, sprintTitle, ...task }) => {
+      let goal = goalsMap.get(goalId);
+      if (!goal) {
+        goal = { id: goalId, title: goalTitle, sprints: [] };
+        goalsMap.set(goalId, goal);
+      }
+      let sprint = goal.sprints.find((s) => s.id === sprintId);
+      if (!sprint) {
+        sprint = { id: sprintId, title: sprintTitle, tasks: [] };
+        goal.sprints.push(sprint);
+      }
+      sprint.tasks.push(task);
+    });
+    set({ goals: Array.from(goalsMap.values()) });
+  }
+
+  async function save() {
+    const tasks = collectTasks(get().goals);
+    await db.tasks.clear();
+    await db.tasks.bulkPut(tasks);
+  }
+
+  void load();
+
+  return {
+    goals: [],
+    setGoals: (goals) => {
+      set({ goals });
+      void save();
+    },
+    addGoal: (goal) => {
+      set({ goals: [...get().goals, goal] });
+      void save();
+    },
+    addSprint: (goalId, sprint) => {
+      set({
+        goals: get().goals.map((g) =>
+          g.id === goalId ? { ...g, sprints: [...g.sprints, sprint] } : g
+        ),
+      });
+      void save();
+    },
+    addTask: (goalId, sprintId, task) => {
+      set({
+        goals: get().goals.map((g) =>
+          g.id === goalId
+            ? {
+                ...g,
+                sprints: g.sprints.map((s) =>
+                  s.id === sprintId ? { ...s, tasks: [...s.tasks, task] } : s
+                ),
+              }
+            : g
+        ),
+      });
+      void save();
+    },
+    markTaskDone: (taskId) => {
+      set({
+        goals: get().goals.map((g) => ({
+          ...g,
+          sprints: g.sprints.map((s) => ({
+            ...s,
+            tasks: s.tasks.map((t) =>
+              t.id === taskId ? { ...t, status: "done" } : t
+            ),
+          })),
+        })),
+      });
+      void db.tasks.update(taskId, { status: "done" });
+    },
+  };
+});
+
+export const flattenRoadmap = async (): Promise<TaskRecord[]> => {
+  return await db.tasks.toArray();
 };
+
+export async function createTask(goalId: string, sprintId: string, title: string) {
+  const task: Task = { id: `task-${nanoid()}`, title, status: "todo" };
+  const state = useRoadmapStore.getState();
+  const goal = state.goals.find((g) => g.id === goalId);
+  const sprint = goal?.sprints.find((s) => s.id === sprintId);
+  await db.tasks.put({
+    ...task,
+    goalId,
+    goalTitle: goal?.title ?? "",
+    sprintId,
+    sprintTitle: sprint?.title ?? "",
+  });
+  state.addTask(goalId, sprintId, task);
+  return task;
+}


### PR DESCRIPTION
## Summary
- introduce Dexie database and schema for roadmap tasks
- replace zustand persistence with Dexie-backed load/save utilities
- add helper to create tasks and update store plus Dexie

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c75d564c832683547cf87004cec0