### PR TITLE
fix: define props in AuroraBallR3F to prevent runtime error

### DIFF
--- a/src/components/avatar/AuroraBallR3F.tsx
+++ b/src/components/avatar/AuroraBallR3F.tsx
@@ -10,7 +10,8 @@ export type AuroraBallProps = Omit<JSX.IntrinsicElements['group'], 'children'> &
 
 
 const AuroraBallR3F = forwardRef<THREE.Group, AuroraBallProps>(
-  ({ size = 1, children, ...restProps }, ref) => {
+  (props, ref) => {
+    const { size = 1, children, ...restProps } = props;
     const matRef = useRef<THREE.ShaderMaterial>(null!);
 
     const groupProps = useMemo(() => {


### PR DESCRIPTION
## Summary
- prevent `props` reference error by explicitly destructuring props inside AuroraBallR3F

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a7fc4123fc83268d00ae0905365388