### PR TITLE
feat: persist tasks before updating roadmap state

### DIFF
--- a/src/ai/RoadmapBuilder.ts
+++ b/src/ai/RoadmapBuilder.ts
@@ -1,5 +1,11 @@
 import { nanoid } from "nanoid";
-import { Goal, Sprint, Task, useRoadmapStore } from "@/state/roadmapStore";
+import {
+  Goal,
+  Sprint,
+  Task,
+  useRoadmapStore,
+  createTask,
+} from "@/state/roadmapStore";
 
 /**
  * Simple helper to build and mutate the local roadmap structure.
@@ -24,9 +30,9 @@ export class RoadmapBuilder {
     return sprint;
   }
 
-  static addTask(goalId: string, sprintId: string, title: string) {
+  static async addTask(goalId: string, sprintId: string, title: string) {
     const task: Task = { id: `task-${nanoid()}`, title, status: "todo" };
-    useRoadmapStore.getState().addTask(goalId, sprintId, task);
+    await createTask(goalId, sprintId, task);
     return task;
   }
 

--- a/src/state/roadmapStore.ts
+++ b/src/state/roadmapStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import { db, type Task as DBTask } from "@/data/db";
 
 export type TaskStatus = "todo" | "doing" | "done";
 
@@ -76,6 +77,26 @@ export const useRoadmapStore = create<RoadmapState>()(
     }
   )
 );
+
+export async function createTask(
+  goalId: string,
+  sprintId: string,
+  task: Task
+) {
+  const now = new Date().toISOString();
+  const dbTask: DBTask = {
+    id: task.id,
+    roadmap_id: goalId,
+    title: task.title,
+    description: task.notes ?? null,
+    status: task.status,
+    user_id: "local",
+    created_at: now,
+    updated_at: now,
+  };
+  await db.tasks.put(dbTask);
+  useRoadmapStore.getState().addTask(goalId, sprintId, task);
+}
 
 export const flattenRoadmap = (goals: Goal[]): Task[] => {
   const tasks: Task[] = [];


### PR DESCRIPTION
## Summary
- add createTask helper to save roadmap tasks in IndexedDB before adding to store
- update RoadmapBuilder to use createTask instead of writing directly to the store

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7fd62e1488326ac2b8e13d1f7cded