### PR TITLE
fix: define props in AuroraBallR3F to prevent runtime error

### DIFF
--- a/src/components/avatar/AuroraBallR3F.tsx
+++ b/src/components/avatar/AuroraBallR3F.tsx
@@ -10,7 +10,8 @@ export type AuroraBallProps = Omit<JSX.IntrinsicElements['group'], 'children'> &
 
 
 const AuroraBallR3F = forwardRef<THREE.Group, AuroraBallProps>(
-  ({ size = 1, children, ...restProps }, ref) => {
+  (props, ref) => {
+    const { size = 1, children, ...restProps } = props;
     const matRef = useRef<THREE.ShaderMaterial>(null!);
 
     const groupProps = useMemo(() => {

--- a/src/game/galaxy/GalaxyPath.tsx
+++ b/src/game/galaxy/GalaxyPath.tsx
@@ -4,7 +4,7 @@ import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
 import MilestoneNode from "./MilestoneNode";
-import { AuroraSphere } from "@/components/avatar/AuroraSphere";
+import AuroraBallR3F from "@/components/avatar/AuroraBallR3F";
 import { useRoadmapProgress } from "@/hooks/useRoadmapProgress";
 import { usePersonaStore } from "@/state/persona";
 import type { UserProfile } from "@/data/profile";
@@ -52,7 +52,7 @@ export default function GalaxyPath() {
     );
   };
 
-  // AuroraSphere follower
+  // Aurora avatar follower
   const sphereRef = useRef<THREE.Group>(null!);
   const tmp = useRef(new THREE.Vector3());
 
@@ -94,7 +94,7 @@ export default function GalaxyPath() {
         />
       ))}
       <group ref={sphereRef}>
-        <AuroraSphere size={0.6} />
+        <AuroraBallR3F size={0.6} />
       </group>
     </group>
   );


### PR DESCRIPTION
## Summary
- prevent `props` reference error by explicitly destructuring props inside AuroraBallR3F
- replace DOM-based `AuroraSphere` with `AuroraBallR3F` in `GalaxyPath` to keep the R3F scene free of `<div>` elements

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a7fc4123fc83268d00ae0905365388