### PR TITLE
Refactor roadmap progress to load tasks from Dexie

### DIFF
--- a/src/hooks/useRoadmapProgress.ts
+++ b/src/hooks/useRoadmapProgress.ts
@@ -1,14 +1,27 @@
-import { useMemo } from "react";
-import { flattenRoadmap, useRoadmapStore } from "@/state/roadmapStore";
+import { useEffect, useMemo, useState } from "react";
+import { flattenRoadmap, useRoadmapStore, type Task } from "@/state/roadmapStore";
 
 export function useRoadmapProgress(_userId?: string | null, _roadmapId?: string | null) {
   const goals = useRoadmapStore((s) => s.goals);
+  const [items, setItems] = useState<Task[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      const tasks = await flattenRoadmap(goals);
+      if (!cancelled) setItems(tasks);
+    }
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [goals]);
+
   return useMemo(() => {
-    const items = flattenRoadmap(goals);
     const total = items.length || 1;
     const done = items.filter((t) => t.status === "done").length;
     const currentIndex = items.findIndex((t) => t.status !== "done");
     const percent = Math.round((done / total) * 100);
     return { items, currentIndex, percent } as const;
-  }, [goals]);
+  }, [items]);
 }

--- a/src/state/roadmapStore.ts
+++ b/src/state/roadmapStore.ts
@@ -212,12 +212,15 @@ export async function createTask(
   useRoadmapStore.getState().addTask(goalId, sprintId, task);
 }
 
-export const flattenRoadmap = (goals: Goal[]): Task[] => {
-  const tasks: Task[] = [];
-  goals.forEach((g) =>
-    g.sprints.forEach((s) => {
-      tasks.push(...s.tasks);
-    })
-  );
-  return tasks;
+export const flattenRoadmap = async (goals: Goal[]): Promise<Task[]> => {
+  const records = (await db.tasks.toArray()) as unknown as DBTask[];
+  const goalIds = new Set(goals.map((g) => g.id));
+  return records
+    .filter((r) => !r.goal_id || goalIds.has(r.goal_id))
+    .map((r) => ({
+      id: r.id,
+      title: r.title,
+      status: r.status as TaskStatus,
+      notes: r.notes ?? r.description ?? undefined,
+    }));
 };


### PR DESCRIPTION
## Summary
- Fetch task list from Dexie in `flattenRoadmap` instead of relying on provided goals
- Use `useEffect` + state in `useRoadmapProgress` to handle async task loading and compute progress

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and Empty block statement errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a7fed144008326913c68119020c63e