### PR TITLE
feat: persist gamification stats

### DIFF
--- a/src/game/gamification/award.ts
+++ b/src/game/gamification/award.ts
@@ -8,6 +8,7 @@ export type AwardArgs = {
 export function award({ xp = 0, achievement }: AwardArgs) {
   if (xp > 0) {
     useGamificationStore.getState().addXp(xp);
+    useGamificationStore.getState().persistStats();
   }
   if (achievement) {
     console.debug('achievement unlocked', achievement);

--- a/src/game/gamification/store.ts
+++ b/src/game/gamification/store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { db } from '@/data/db';
 import { levelForXp } from './model';
 
 export type GamificationState = {
@@ -9,6 +10,7 @@ export type GamificationState = {
   lastCheckIn: string | null;
   addXp: (amount: number) => void;
   checkIn: () => void;
+  persistStats: () => Promise<void>;
 };
 
 export const useGamificationStore = create<GamificationState>()(
@@ -18,19 +20,38 @@ export const useGamificationStore = create<GamificationState>()(
       level: 1,
       streak: 0,
       lastCheckIn: null,
-      addXp: (amount) =>
+      addXp: (amount) => {
         set((state) => {
           const xp = state.xp + Math.max(0, amount);
           const level = levelForXp(xp);
           return { xp, level };
-        }),
-      checkIn: () =>
+        });
+        get().persistStats();
+      },
+      checkIn: () => {
+        let updated = false;
         set((state) => {
           const today = new Date().toDateString();
           if (state.lastCheckIn === today) return {} as any;
+          updated = true;
           const streak = state.streak + 1;
           return { streak, lastCheckIn: today };
-        }),
+        });
+        if (updated) get().persistStats();
+      },
+      persistStats: async () => {
+        const { xp, level, streak } = get();
+        const now = new Date().toISOString();
+        await db.stats.put({
+          id: 'local',
+          level,
+          total_xp: xp,
+          streak_count: streak,
+          last_active_date: now,
+          created_at: now,
+          updated_at: now,
+        });
+      },
     }),
     {
       name: 'gamification',


### PR DESCRIPTION
## Summary
- add async gamification statistics persistence helper
- persist stats after XP or streak updates and award events

## Testing
- `npm test`
- `npm run lint` (fails: Unexpected any ...)

------
https://chatgpt.com/codex/tasks/task_e_68a800ba8e04832685139bb77daf0e61