### PR TITLE
feat: track achievements

### DIFF
--- a/src/data/db.ts
+++ b/src/data/db.ts
@@ -24,15 +24,26 @@ export interface Stat {
   updated_at: string;
 }
 
+export interface Achievement {
+  id: string;
+  name: string;
+  description?: string | null;
+  earned_at: string;
+  created_at: string;
+  updated_at: string;
+}
+
 export class AuroraDB extends Dexie {
   tasks!: Table<Task, string>;
   stats!: Table<Stat, string>;
+  achievements!: Table<Achievement, string>;
 
   constructor() {
     super('aurora');
     this.version(1).stores({
       tasks: '&id,updated_at',
       stats: '&id',
+      achievements: '&id,earned_at',
     });
   }
 }

--- a/src/game/gamification/award.ts
+++ b/src/game/gamification/award.ts
@@ -1,3 +1,5 @@
+import { nanoid } from 'nanoid';
+import { db } from '../../data/db';
 import { useGamificationStore } from './store';
 
 export type AwardArgs = {
@@ -5,11 +7,21 @@ export type AwardArgs = {
   achievement?: string;
 };
 
+function logAchievement(achievement: string) {
+  db.achievements.add({
+    id: nanoid(),
+    name: achievement,
+    earned_at: new Date().toISOString(),
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  });
+}
+
 export function award({ xp = 0, achievement }: AwardArgs) {
   if (xp > 0) {
     useGamificationStore.getState().addXp(xp);
   }
   if (achievement) {
-    console.debug('achievement unlocked', achievement);
+    logAchievement(achievement);
   }
 }


### PR DESCRIPTION
## Summary
- add Achievement model and table to Dexie database
- log unlocked achievements instead of console debug

## Testing
- `npx eslint src/data/db.ts src/game/gamification/award.ts --fix`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a800bb136883268bb76749d0e8ec4d