### PR TITLE
feat: expose normalized roadmap progress

### DIFF
--- a/src/hooks/useRoadmapProgress.ts
+++ b/src/hooks/useRoadmapProgress.ts
@@ -20,8 +20,9 @@ export function useRoadmapProgress(_userId?: string | null, _roadmapId?: string 
   return useMemo(() => {
     const total = items.length || 1;
     const done = items.filter((t) => t.status === "done").length;
-    const currentIndex = items.findIndex((t) => t.status !== "done");
-    const percent = Math.round((done / total) * 100);
-    return { items, currentIndex, percent } as const;
+    const activeIndex = items.findIndex((t) => t.status !== "done");
+    const progressT = done / total;
+    const percent = Math.round(progressT * 100);
+    return { items, activeIndex, progressT, percent } as const;
   }, [items]);
 }

--- a/src/views/RoadmapGalaxy.tsx
+++ b/src/views/RoadmapGalaxy.tsx
@@ -67,9 +67,9 @@ function useTaskNodes() {
         const status: NodeStatus =
           index === -1
             ? "locked"
-            : index < progress.currentIndex
+            : index < progress.activeIndex
             ? "done"
-            : index === progress.currentIndex
+            : index === progress.activeIndex
             ? "current"
             : "locked";
         const color = new THREE.Color(milestoneColor(taskNodes.length));
@@ -78,7 +78,7 @@ function useTaskNodes() {
     });
   });
 
-  const currentTask = progress.items[progress.currentIndex];
+  const currentTask = progress.items[progress.activeIndex];
   const currentPos = currentTask ? taskPosMap.get(currentTask.id) : undefined;
   return { taskNodes, currentPos } as const;
 }


### PR DESCRIPTION
## Summary
- compute normalized roadmap progress and expose `progressT`
- rename `currentIndex` to `activeIndex` in `useRoadmapProgress`
- update roadmap galaxy view to consume new active index

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8584c7f308326b4cbe2231662ffba