### PR TITLE
fix: guard galaxy path progress

### DIFF
--- a/src/game/galaxy/GalaxyPath.tsx
+++ b/src/game/galaxy/GalaxyPath.tsx
@@ -57,7 +57,8 @@ export default function GalaxyPath() {
   const tmp = useRef(new THREE.Vector3());
 
   useFrame((_, dt) => {
-    curve.getPointAt(progressT, tmp.current);
+    const t = Number.isFinite(progressT) ? progressT : 0;
+    curve.getPointAt(t, tmp.current);
     if (sphereRef.current) {
       sphereRef.current.position.x = THREE.MathUtils.damp(
         sphereRef.current.position.x,


### PR DESCRIPTION
## Summary
- avoid non-finite progress values for galaxy path avatar

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a85b2a6d388326bbb674e1154bc4e5