### PR TITLE
feat: enable react-router v7 flags

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -99,7 +99,7 @@ const App = () => {
         <Toaster />
         <Sonner />
         <TTSPill />
-        <BrowserRouter>
+        <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
           {appShell ? <AppRoutesWithShell /> : <LegacyRoutes />}
         </BrowserRouter>
       </TooltipProvider>


### PR DESCRIPTION
## Summary
- enable React Router v7 `future` flags for BrowserRouter

## Testing
- `npm test`
- `npm run lint` *(fails: unexpected any, empty block statement)*
- `npx eslint src/App.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a85eec994c8326823bbe62b603a1e1