### PR TITLE
feat: add passive orbit controls wrapper

### DIFF
--- a/src/components/controls/PassiveOrbitControls.tsx
+++ b/src/components/controls/PassiveOrbitControls.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from "react";
+import { useThree } from "@react-three/fiber";
+import {
+  OrbitControls as DreiOrbitControls,
+  OrbitControlsProps,
+} from "@react-three/drei";
+import { OrbitControls as OrbitControlsImpl } from "three-stdlib";
+
+export default function PassiveOrbitControls(props: OrbitControlsProps) {
+  const controlsRef = useRef<OrbitControlsImpl>(null);
+  const { gl } = useThree();
+
+  useEffect(() => {
+    const controls = controlsRef.current as (OrbitControlsImpl & {
+      _onMouseWheel: (event: WheelEvent) => void;
+    }) | null;
+    if (!controls) return;
+    const { _onMouseWheel: handler } = controls;
+    const element = gl.domElement;
+    element.removeEventListener("wheel", handler);
+    element.addEventListener("wheel", handler, { passive: true });
+    return () => {
+      element.removeEventListener("wheel", handler);
+    };
+  }, [gl]);
+
+  return <DreiOrbitControls ref={controlsRef} {...props} />;
+}

--- a/src/views/HomeGalaxy.tsx
+++ b/src/views/HomeGalaxy.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Canvas } from "@react-three/fiber";
-import { Environment, OrbitControls, Stars } from "@react-three/drei";
+import { Environment, Stars } from "@react-three/drei";
+import PassiveOrbitControls from "@/components/controls/PassiveOrbitControls";
 import GalaxyPath from "@/game/galaxy/GalaxyPath";
 
 export default function HomeGalaxy() {
@@ -30,7 +31,7 @@ export default function HomeGalaxy() {
           speed={0.4}
         />
         <Environment preset="night" />
-        <OrbitControls
+        <PassiveOrbitControls
           makeDefault
           enablePan={false}
           enableZoom

--- a/src/views/RoadmapGalaxy.tsx
+++ b/src/views/RoadmapGalaxy.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useRef } from "react";
 import { Canvas, useFrame } from "@react-three/fiber";
-import { Environment, OrbitControls, Stars, Html } from "@react-three/drei";
+import { Environment, Stars, Html } from "@react-three/drei";
+import PassiveOrbitControls from "@/components/controls/PassiveOrbitControls";
 import * as THREE from "three";
 import { AuroraSphere } from "@/components/avatar/AuroraSphere";
 import PlanetNode, { NodeStatus } from "@/components/roadmap/PlanetNode";
@@ -129,7 +130,15 @@ function GalaxyScene() {
       {taskNodes.map((n) => (
         <PlanetNode key={n.id} position={n.position} color={n.color} status={n.status} onClick={() => onClick(n)} />
       ))}
-      <OrbitControls makeDefault enablePan={false} enableZoom zoomSpeed={0.6} rotateSpeed={0.6} minDistance={3.2} maxDistance={12} />
+      <PassiveOrbitControls
+        makeDefault
+        enablePan={false}
+        enableZoom
+        zoomSpeed={0.6}
+        rotateSpeed={0.6}
+        minDistance={3.2}
+        maxDistance={12}
+      />
       <AuroraFollower target={currentRef} />
     </>
   );


### PR DESCRIPTION
## Summary
- create PassiveOrbitControls wrapper that adds passive wheel listeners
- replace OrbitControls in HomeGalaxy and RoadmapGalaxy with PassiveOrbitControls

## Testing
- `npm test`
- `npm run lint` *(fails: 247 problems (226 errors, 21 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a85eed15b88326a6a40200accc0f39