### PR TITLE
feat: persist gamification stats

### DIFF
--- a/src/game/gamification/award.ts
+++ b/src/game/gamification/award.ts
@@ -1,5 +1,5 @@
 import { nanoid } from 'nanoid';
-import { db } from '../../data/db';
+import { db } from '@/data/db';
 import { useGamificationStore } from './store';
 
 export type AwardArgs = {
@@ -20,7 +20,7 @@ function logAchievement(achievement: string) {
 export function award({ xp = 0, achievement }: AwardArgs) {
   if (xp > 0) {
     useGamificationStore.getState().addXp(xp);
-    useGamificationStore.getState().persistStats();
+    void useGamificationStore.getState().persistStats();
   }
   if (achievement) {
     logAchievement(achievement);

--- a/src/game/gamification/store.ts
+++ b/src/game/gamification/store.ts
@@ -37,16 +37,32 @@ export const useGamificationStore = create<GamificationState>()(
         level: 1,
         streak: 0,
         lastCheckIn: null,
-        addXp: (amount) =>
+        addXp: (amount) => {
           updateStats((state) => ({
             xp: state.xp + Math.max(0, amount),
-          })),
-        checkIn: () =>
+          }));
+          get().persistStats();
+        },
+        checkIn: () => {
           updateStats((state) => {
             const today = new Date().toDateString();
             if (state.lastCheckIn === today) return {} as any;
             return { lastCheckIn: today };
-          }),
+          });
+          get().persistStats();
+        },
+        persistStats: async () => {
+          const { xp, level, streak } = get();
+          const now = new Date().toISOString();
+          await db.stats.put({
+            id: 'local',
+            xp,
+            level,
+            streak,
+            created_at: now,
+            updated_at: now,
+          });
+        },
       };
     },
 


### PR DESCRIPTION
## Summary
- add `persistStats` helper for gamification store to record xp, level, and streak
- trigger stats persistence after XP awards and daily check-ins

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a866c652e0832692333f427d736c5c