### PR TITLE
Refactor PassiveOrbitControls with custom orbit controls

### DIFF
--- a/src/components/controls/PassiveOrbitControls.tsx
+++ b/src/components/controls/PassiveOrbitControls.tsx
@@ -1,28 +1,48 @@
-import { useEffect, useRef } from "react";
-import { useThree } from "@react-three/fiber";
-import {
-  OrbitControls as DreiOrbitControls,
-  OrbitControlsProps,
-} from "@react-three/drei";
+import { useEffect, useMemo, useRef } from "react";
+import { useThree, useFrame } from "@react-three/fiber";
+import { OrbitControlsProps } from "@react-three/drei";
 import { OrbitControls as OrbitControlsImpl } from "three-stdlib";
 
-export default function PassiveOrbitControls(props: OrbitControlsProps) {
+export default function PassiveOrbitControls({ makeDefault, enableDamping = true, ...props }: OrbitControlsProps) {
+  const { camera, gl } = useThree();
+  const set = useThree((state) => state.set);
+  const get = useThree((state) => state.get);
   const controlsRef = useRef<OrbitControlsImpl>(null);
-  const { gl } = useThree();
+
+  const controls = useMemo(() => new OrbitControlsImpl(camera), [camera]);
+
+  useFrame(() => {
+    if (controls.enabled) controls.update();
+  }, -1);
 
   useEffect(() => {
-    const controls = controlsRef.current as (OrbitControlsImpl & {
+    controls.connect(gl.domElement);
+    return () => controls.dispose();
+  }, [controls, gl]);
+
+  useEffect(() => {
+    const { _onMouseWheel: handler } = controls as OrbitControlsImpl & {
       _onMouseWheel: (event: WheelEvent) => void;
-    }) | null;
-    if (!controls) return;
-    const { _onMouseWheel: handler } = controls;
+    };
     const element = gl.domElement;
     element.removeEventListener("wheel", handler);
     element.addEventListener("wheel", handler, { passive: true });
     return () => {
       element.removeEventListener("wheel", handler);
     };
-  }, [gl]);
+  }, [controls, gl]);
 
-  return <DreiOrbitControls ref={controlsRef} {...props} />;
+  useEffect(() => {
+    if (makeDefault) {
+      const old = get().controls;
+      // @ts-ignore
+      set({ controls });
+      return () => set({ controls: old });
+    }
+  }, [makeDefault, controls, set, get]);
+
+  return controls ? (
+    <primitive ref={controlsRef} object={controls} enableDamping={enableDamping} {...props} />
+  ) : null;
 }
+


### PR DESCRIPTION
## Summary
- replace Drei OrbitControls wrapper with custom OrbitControls implementation
- ensure wheel events use passive listeners and connect/dispose manually
- support makeDefault and other props via primitive render

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any / no-empty)*

------
https://chatgpt.com/codex/tasks/task_e_68a8671051d083268f9090d6be27296c