### PR TITLE
Dispose Three.js resources and handle WebGL context loss

### DIFF
--- a/src/components/avatar/AuroraBallR3F.tsx
+++ b/src/components/avatar/AuroraBallR3F.tsx
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 
 
-import { useMemo, useRef, forwardRef } from 'react';
+import { useMemo, useRef, forwardRef, useEffect } from 'react';
 import { useFrame } from '@react-three/fiber';
 
 export type AuroraBallProps = Omit<JSX.IntrinsicElements['group'], 'children'> & {
@@ -45,6 +45,7 @@ const AuroraBallR3F = forwardRef<THREE.Group, AuroraBallProps>(
     });
 
     const geometry = useMemo(() => new THREE.IcosahedronGeometry(1, 5), []);
+    useEffect(() => () => geometry.dispose(), [geometry]);
 
     const vertexShader = `
 uniform float uTime;

--- a/src/components/avatar/AuroraSphere.tsx
+++ b/src/components/avatar/AuroraSphere.tsx
@@ -155,6 +155,11 @@ export function AuroraSphere({
     let material: MeshStandardNodeMaterial | null = null;
     let particleGeometry: THREE.BufferGeometry | null = null;
     let particleMaterial: THREE.PointsMaterial | null = null;
+    let pmrem: THREE.PMREMGenerator | null = null;
+    let envTexture: THREE.Texture | null = null;
+    let hdrTexture: THREE.DataTexture | null = null;
+    let handleContextLost: ((e: Event) => void) | null = null;
+    let handleContextRestored: (() => void) | null = null;
 
     let disposed = false;
     let resizeObserver: ResizeObserver | null = null;
@@ -235,13 +240,26 @@ export function AuroraSphere({
       mount.appendChild(renderer.domElement);
       rendererRef.current = renderer;
 
+      handleContextLost = (e: Event) => {
+        e.preventDefault();
+        cancelAnimationFrame(frameRef.current);
+      };
+      handleContextRestored = () => {
+        animate();
+      };
+      renderer.domElement.addEventListener('webglcontextlost', handleContextLost);
+      renderer.domElement.addEventListener('webglcontextrestored', handleContextRestored);
+
       if (variant === 'full') {
-        const pmrem = new THREE.PMREMGenerator(
+        pmrem = new THREE.PMREMGenerator(
           renderer as THREE.WebGLRenderer
         );
         new RGBELoader().load('/env/hdr-small.hdr', (tex) => {
+          hdrTexture = tex;
           tex.mapping = THREE.EquirectangularReflectionMapping;
-          scene.environment = pmrem.fromEquirectangular(tex).texture;
+          const env = pmrem!.fromEquirectangular(tex);
+          envTexture = env.texture;
+          scene.environment = envTexture;
         });
       }
 
@@ -374,6 +392,16 @@ export function AuroraSphere({
         } catch {
           /* ignore */
         }
+      }
+      haloRef.current?.geometry.dispose();
+      (haloRef.current?.material as THREE.Material | undefined)?.dispose();
+      hdrTexture?.dispose();
+      envTexture?.dispose();
+      pmrem?.dispose();
+      scene.environment = null;
+      if (renderer) {
+        renderer.domElement.removeEventListener('webglcontextlost', handleContextLost!);
+        renderer.domElement.removeEventListener('webglcontextrestored', handleContextRestored!);
       }
       try {
         renderer?.dispose?.();

--- a/src/components/avatar/LipSyncAvatar.tsx
+++ b/src/components/avatar/LipSyncAvatar.tsx
@@ -25,12 +25,15 @@ export function LipSyncAvatar({ size = 96 }: Props) {
     const renderer = new THREE.WebGLRenderer({ canvas: canvasRef.current, alpha: true, antialias: true });
     renderer.setSize(size, size);
 
+    const headGeom = new THREE.SphereGeometry(1, 32, 32);
     const headMat = new THREE.MeshStandardMaterial({ color });
     matRef.current = headMat;
-    const head = new THREE.Mesh(new THREE.SphereGeometry(1, 32, 32), headMat);
+    const head = new THREE.Mesh(headGeom, headMat);
     scene.add(head);
 
-    const mouth = new THREE.Mesh(new THREE.BoxGeometry(0.6, 0.2, 0.1), new THREE.MeshStandardMaterial({ color: 0x000000 }));
+    const mouthGeom = new THREE.BoxGeometry(0.6, 0.2, 0.1);
+    const mouthMat = new THREE.MeshStandardMaterial({ color: 0x000000 });
+    const mouth = new THREE.Mesh(mouthGeom, mouthMat);
     mouth.position.y = -0.3;
     head.add(mouth);
     mouthRef.current = mouth;
@@ -56,9 +59,25 @@ export function LipSyncAvatar({ size = 96 }: Props) {
       }
       renderer.render(scene, camera);
     };
+
+    const handleContextLost = (e: Event) => {
+      e.preventDefault();
+      cancelAnimationFrame(frame);
+    };
+    const handleContextRestored = () => {
+      frame = requestAnimationFrame(animate);
+    };
+    renderer.domElement.addEventListener('webglcontextlost', handleContextLost);
+    renderer.domElement.addEventListener('webglcontextrestored', handleContextRestored);
     animate();
     return () => {
       cancelAnimationFrame(frame);
+      renderer.domElement.removeEventListener('webglcontextlost', handleContextLost);
+      renderer.domElement.removeEventListener('webglcontextrestored', handleContextRestored);
+      headGeom.dispose();
+      headMat.dispose();
+      mouthGeom.dispose();
+      mouthMat.dispose();
       renderer.dispose();
     };
   }, [color, size]);

--- a/src/components/effects/HypnoSphere.tsx
+++ b/src/components/effects/HypnoSphere.tsx
@@ -38,10 +38,22 @@ export function HypnoSphere({ size = 256, className = "" }: Props) {
       renderer.render(scene, camera);
       frameId = requestAnimationFrame(animate);
     };
+
+    const handleContextLost = (e: Event) => {
+      e.preventDefault();
+      cancelAnimationFrame(frameId);
+    };
+    const handleContextRestored = () => {
+      frameId = requestAnimationFrame(animate);
+    };
+    renderer.domElement.addEventListener('webglcontextlost', handleContextLost);
+    renderer.domElement.addEventListener('webglcontextrestored', handleContextRestored);
     animate();
 
     return () => {
       cancelAnimationFrame(frameId);
+      renderer.domElement.removeEventListener('webglcontextlost', handleContextLost);
+      renderer.domElement.removeEventListener('webglcontextrestored', handleContextRestored);
       geometry.dispose();
       material.dispose();
       renderer.dispose();

--- a/src/views/HomeGalaxy.tsx
+++ b/src/views/HomeGalaxy.tsx
@@ -1,8 +1,23 @@
-import React from "react";
-import { Canvas } from "@react-three/fiber";
+import React, { useEffect } from "react";
+import { Canvas, useThree } from "@react-three/fiber";
 import { Environment, Stars } from "@react-three/drei";
 import PassiveOrbitControls from "@/components/controls/PassiveOrbitControls";
 import GalaxyPath from "@/game/galaxy/GalaxyPath";
+
+function WebGLContextManager() {
+  const { gl } = useThree();
+  useEffect(() => {
+    const handleLost = (e: Event) => e.preventDefault();
+    const handleRestored = () => {};
+    gl.domElement.addEventListener('webglcontextlost', handleLost);
+    gl.domElement.addEventListener('webglcontextrestored', handleRestored);
+    return () => {
+      gl.domElement.removeEventListener('webglcontextlost', handleLost);
+      gl.domElement.removeEventListener('webglcontextrestored', handleRestored);
+    };
+  }, [gl]);
+  return null;
+}
 
 export default function HomeGalaxy() {
   return (
@@ -19,6 +34,7 @@ export default function HomeGalaxy() {
         camera={{ fov: 60, position: [0, 0, 8] }}
         style={{ width: "100%", height: "64svh" }}
       >
+        <WebGLContextManager />
         <ambientLight intensity={0.35} />
         <directionalLight position={[2, 2, 2]} intensity={1.2} />
         <Stars

--- a/src/views/RoadmapGalaxy.tsx
+++ b/src/views/RoadmapGalaxy.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo, useRef } from "react";
-import { Canvas, useFrame } from "@react-three/fiber";
+import React, { useMemo, useRef, useEffect } from "react";
+import { Canvas, useFrame, useThree } from "@react-three/fiber";
 import { Environment, Stars, Html } from "@react-three/drei";
 import PassiveOrbitControls from "@/components/controls/PassiveOrbitControls";
 import * as THREE from "three";
@@ -108,6 +108,21 @@ function AuroraFollower({ target }: { target: React.MutableRefObject<THREE.Vecto
   );
 }
 
+function WebGLContextManager() {
+  const { gl } = useThree();
+  useEffect(() => {
+    const handleLost = (e: Event) => e.preventDefault();
+    const handleRestored = () => {};
+    gl.domElement.addEventListener('webglcontextlost', handleLost);
+    gl.domElement.addEventListener('webglcontextrestored', handleRestored);
+    return () => {
+      gl.domElement.removeEventListener('webglcontextlost', handleLost);
+      gl.domElement.removeEventListener('webglcontextrestored', handleRestored);
+    };
+  }, [gl]);
+  return null;
+}
+
 function GalaxyScene() {
   const { taskNodes, currentPos } = useTaskNodes();
   const currentRef = useRef<THREE.Vector3 | null>(currentPos ?? null);
@@ -160,6 +175,7 @@ export default function RoadmapGalaxy() {
         camera={{ fov: 50, near: 0.1, far: 100, position: [0, 1.6, 8] }}
         style={{ width: "100%", height: "64svh" }}
       >
+        <WebGLContextManager />
         <GalaxyScene />
       </Canvas>
     </div>


### PR DESCRIPTION
## Summary
- Dispose Three.js geometries and materials to prevent GPU leaks
- Add WebGL context loss handlers and restart logic
- Attach canvas listeners to guard against context loss in galaxy views

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, Empty block statement)*

------
https://chatgpt.com/codex/tasks/task_e_68a86719600083269a4b4a4d807bfba7