### PR TITLE
feat: preload Dexie data on startup

### DIFF
--- a/src/game/gamification/store.ts
+++ b/src/game/gamification/store.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import { db } from '@/data/db';
+import { db, type Stat } from '@/data/db';
 import { levelForXp } from './model';
 
 export type GamificationState = {
@@ -52,13 +52,14 @@ export const useGamificationStore = create<GamificationState>()(
           get().persistStats();
         },
         persistStats: async () => {
-          const { xp, level, streak } = get();
+          const { xp, level, streak, lastCheckIn } = get();
           const now = new Date().toISOString();
           await db.stats.put({
             id: 'local',
             xp,
             level,
             streak,
+            lastCheckIn,
             created_at: now,
             updated_at: now,
           });
@@ -77,3 +78,12 @@ export const useGamificationStore = create<GamificationState>()(
     }
   )
 );
+
+export function initializeGamificationStore(stat?: Stat) {
+  useGamificationStore.setState({
+    xp: stat?.xp ?? 0,
+    level: levelForXp(stat?.xp ?? 0),
+    streak: stat?.streak ?? 0,
+    lastCheckIn: stat?.lastCheckIn ?? null,
+  });
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,22 +1,43 @@
-import { createRoot } from 'react-dom/client'
-import App from './App.tsx'
-import ErrorBoundary from './components/ErrorBoundary'
-import './index.css'
-import './styles/hud-fixes.css'
+import { createRoot } from 'react-dom/client';
+import App from './App.tsx';
+import ErrorBoundary from './components/ErrorBoundary';
+import './index.css';
+import './styles/hud-fixes.css';
 import { registerSW } from 'virtual:pwa-register';
 import { initSettings } from './state/settings';
 import { preloadLocalModels } from './models/preload';
 import './state/quickActions';
+import { db } from './data/db';
+import { initializeGamificationStore } from './game/gamification/store';
+import { initializeRoadmapStore } from './state/roadmapStore';
 
 if ('serviceWorker' in navigator) {
-  registerSW({ immediate: true })
+  registerSW({ immediate: true });
 }
 
-initSettings();
-preloadLocalModels().catch(() => {});
+async function bootstrap() {
+  initSettings();
+  preloadLocalModels().catch(() => {});
 
-createRoot(document.getElementById('root')!).render(
-  <ErrorBoundary>
-    <App />
-  </ErrorBoundary>
-)
+  try {
+    await db.open();
+    const [tasks, stats] = await Promise.all([
+      db.tasks.toArray(),
+      db.stats.get('local'),
+    ]);
+    initializeRoadmapStore(tasks as any);
+    initializeGamificationStore(stats ?? undefined);
+  } catch (err) {
+    console.warn('Dexie unavailable', err);
+    initializeRoadmapStore([]);
+    initializeGamificationStore();
+  }
+
+  createRoot(document.getElementById('root')!).render(
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
+  );
+}
+
+void bootstrap();

--- a/src/state/roadmapStore.ts
+++ b/src/state/roadmapStore.ts
@@ -1,6 +1,5 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
-import { db, type Task as DBTask } from "@/data/db";
+import { db, type Task as DBTaskBase } from "@/data/db";
 
 export type TaskStatus = "todo" | "doing" | "done";
 
@@ -41,35 +40,6 @@ interface DBTask extends DBTaskBase {
 }
 
 export const useRoadmapStore = create<RoadmapState>((set, get) => {
-  const loadFromDB = async () => {
-    const records = (await db.tasks.toArray()) as unknown as DBTask[];
-    const goalsMap = new Map<string, Goal>();
-    records.forEach((r) => {
-      const goalId = r.goal_id;
-      const sprintId = r.sprint_id;
-      if (!goalId || !sprintId) return;
-      let goal = goalsMap.get(goalId);
-      if (!goal) {
-        goal = { id: goalId, title: r.goal_title ?? "", sprints: [] };
-        goalsMap.set(goalId, goal);
-      }
-      let sprint = goal.sprints.find((s) => s.id === sprintId);
-      if (!sprint) {
-        sprint = { id: sprintId, title: r.sprint_title ?? "", tasks: [] };
-        goal.sprints.push(sprint);
-      }
-      sprint.tasks.push({
-        id: r.id,
-        title: r.title,
-        status: r.status as TaskStatus,
-        notes: r.notes ?? r.description ?? undefined,
-      });
-    });
-    set({ goals: Array.from(goalsMap.values()) });
-  };
-
-  void loadFromDB();
-
   return {
     goals: [],
     setGoals: (goals) => set({ goals }),
@@ -191,6 +161,36 @@ export const useRoadmapStore = create<RoadmapState>((set, get) => {
     },
   };
 });
+
+function buildGoals(records: DBTask[]): Goal[] {
+  const goalsMap = new Map<string, Goal>();
+  records.forEach((r) => {
+    const goalId = r.goal_id;
+    const sprintId = r.sprint_id;
+    if (!goalId || !sprintId) return;
+    let goal = goalsMap.get(goalId);
+    if (!goal) {
+      goal = { id: goalId, title: r.goal_title ?? "", sprints: [] };
+      goalsMap.set(goalId, goal);
+    }
+    let sprint = goal.sprints.find((s) => s.id === sprintId);
+    if (!sprint) {
+      sprint = { id: sprintId, title: r.sprint_title ?? "", tasks: [] };
+      goal.sprints.push(sprint);
+    }
+    sprint.tasks.push({
+      id: r.id,
+      title: r.title,
+      status: r.status as TaskStatus,
+      notes: r.notes ?? r.description ?? undefined,
+    });
+  });
+  return Array.from(goalsMap.values());
+}
+
+export function initializeRoadmapStore(records: DBTask[] = []) {
+  useRoadmapStore.setState({ goals: buildGoals(records) });
+}
 
 export async function createTask(
   goalId: string,


### PR DESCRIPTION
## Summary
- open Dexie during app bootstrap and preload tasks and gamification stats
- allow gamification store to initialize and persist stats from Dexie
- expose task store initializer to hydrate from preloaded tasks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a868c1c378832687a0812eeec75e56