### PR TITLE
Document offline-only mode when Supabase is unconfigured

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Aurora Documentation
+
+Key guides and references:
+
+- [Data Backup](./backup.md)
+- [Deploying Supabase Functions](./deploy-supabase-functions.md)
+- [Offline Mode](./offline-mode.md)

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -18,3 +18,5 @@ python -m memory.backup import /path/to/backup.bin --passphrase "your-passphrase
 ```
 
 The command decrypts the archive and restores `memory.db` and `chroma_db` in the `memory/` directory.
+
+> **Tip:** Running without Supabase credentials enables [offline mode](./offline-mode.md), so backups contain all current data.

--- a/docs/deploy-supabase-functions.md
+++ b/docs/deploy-supabase-functions.md
@@ -16,3 +16,5 @@ supabase functions deploy synthesize-mission --project-ref aybygkwfqpsphhopatso 
 ```
 
 The command builds the function and makes it accessible at `/functions/v1/synthesize-mission` in your project.
+
+> **Note:** If `SUPABASE_URL` or the anonymous key is missing, sync helpers treat the app as [offline-only](./offline-mode.md) and skip remote requests.

--- a/docs/offline-mode.md
+++ b/docs/offline-mode.md
@@ -1,0 +1,15 @@
+# Offline Mode
+
+Aurora's sync helpers immediately resolve when Supabase credentials are missing. This allows the app to operate purely on local data without attempting any remote operations.
+
+## Behavior
+- Functions like `pushToSupabase` and `pullFromSupabase` check the `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` environment variables.
+- If either variable is absent, the function returns early without contacting Supabase.
+
+## How to Handle It
+Calling code should treat this as **offline-only** mode:
+- Skip any remote synchronization steps.
+- Operate on the local IndexedDB data.
+- Optionally notify the user that cloud sync is disabled.
+
+This setup is useful for privacy-sensitive environments or during development when Supabase is not configured.


### PR DESCRIPTION
## Summary
- Document offline mode behavior when Supabase credentials are missing
- Reference offline mode from backup and Supabase function docs for visibility
- Add a simple docs index pointing to key guides

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8693c184083269c1dfb25373ce27a