### PR TITLE
Handle WebGL context loss and dispose Three.js resources

### DIFF
--- a/src/components/avatar/AuroraBallR3F.tsx
+++ b/src/components/avatar/AuroraBallR3F.tsx
@@ -44,6 +44,8 @@ const AuroraBallR3F = forwardRef<THREE.Group, AuroraBallProps>(
       }
     });
 
+    useEffect(() => () => matRef.current?.dispose(), []);
+
     const geometry = useMemo(() => new THREE.IcosahedronGeometry(1, 5), []);
     useEffect(() => () => geometry.dispose(), [geometry]);
 

--- a/src/components/avatar/AuroraSphere.tsx
+++ b/src/components/avatar/AuroraSphere.tsx
@@ -245,6 +245,7 @@ export function AuroraSphere({
         cancelAnimationFrame(frameRef.current);
       };
       handleContextRestored = () => {
+        renderer.resetState();
         animate();
       };
       renderer.domElement.addEventListener('webglcontextlost', handleContextLost);

--- a/src/components/avatar/LipSyncAvatar.tsx
+++ b/src/components/avatar/LipSyncAvatar.tsx
@@ -65,6 +65,7 @@ export function LipSyncAvatar({ size = 96 }: Props) {
       cancelAnimationFrame(frame);
     };
     const handleContextRestored = () => {
+      renderer.resetState();
       frame = requestAnimationFrame(animate);
     };
     renderer.domElement.addEventListener('webglcontextlost', handleContextLost);

--- a/src/components/effects/HypnoSphere.tsx
+++ b/src/components/effects/HypnoSphere.tsx
@@ -44,6 +44,7 @@ export function HypnoSphere({ size = 256, className = "" }: Props) {
       cancelAnimationFrame(frameId);
     };
     const handleContextRestored = () => {
+      renderer.resetState();
       frameId = requestAnimationFrame(animate);
     };
     renderer.domElement.addEventListener('webglcontextlost', handleContextLost);

--- a/src/views/HomeGalaxy.tsx
+++ b/src/views/HomeGalaxy.tsx
@@ -8,7 +8,9 @@ function WebGLContextManager() {
   const { gl } = useThree();
   useEffect(() => {
     const handleLost = (e: Event) => e.preventDefault();
-    const handleRestored = () => {};
+    const handleRestored = () => {
+      gl.resetState();
+    };
     gl.domElement.addEventListener('webglcontextlost', handleLost);
     gl.domElement.addEventListener('webglcontextrestored', handleRestored);
     return () => {

--- a/src/views/RoadmapGalaxy.tsx
+++ b/src/views/RoadmapGalaxy.tsx
@@ -115,7 +115,9 @@ function WebGLContextManager() {
   const { gl } = useThree();
   useEffect(() => {
     const handleLost = (e: Event) => e.preventDefault();
-    const handleRestored = () => {};
+    const handleRestored = () => {
+      gl.resetState();
+    };
     gl.domElement.addEventListener('webglcontextlost', handleLost);
     gl.domElement.addEventListener('webglcontextrestored', handleRestored);
     return () => {


### PR DESCRIPTION
## Summary
- reset Three.js renderer state when WebGL context is restored
- dispose manually created shader material in `AuroraBallR3F`
- add context loss recovery to HypnoSphere and LipSyncAvatar
- reinitialize renderer state on context restore in galaxy views

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a86acb2af483269f912556fdb4b282