### PR TITLE
refactor: custom orbit controls implementation

### DIFF
--- a/src/components/controls/PassiveOrbitControls.tsx
+++ b/src/components/controls/PassiveOrbitControls.tsx
@@ -1,48 +1,49 @@
 import { useEffect, useMemo, useRef } from "react";
 import { useThree, useFrame } from "@react-three/fiber";
-import { OrbitControlsProps } from "@react-three/drei";
+import type { OrbitControlsProps } from "@react-three/drei";
 import { OrbitControls as OrbitControlsImpl } from "three-stdlib";
 
 export default function PassiveOrbitControls({ makeDefault, enableDamping = true, ...props }: OrbitControlsProps) {
   const { camera, gl } = useThree();
   const set = useThree((state) => state.set);
   const get = useThree((state) => state.get);
-  const controlsRef = useRef<OrbitControlsImpl>(null);
 
+  // Create the controls instance once for the current camera
   const controls = useMemo(() => new OrbitControlsImpl(camera), [camera]);
+  const controlsRef = useRef<OrbitControlsImpl>(controls);
 
+  // Update the controls every frame so damping and auto-rotate work correctly
   useFrame(() => {
-    if (controls.enabled) controls.update();
+    controls.update();
   }, -1);
 
+  // Attach controls to the WebGL context and dispose on unmount
   useEffect(() => {
     controls.connect(gl.domElement);
     return () => controls.dispose();
   }, [controls, gl]);
 
+  // Rebind the wheel listener with `passive: true` to avoid blocking the main thread
   useEffect(() => {
-    const { _onMouseWheel: handler } = controls as OrbitControlsImpl & {
+    const handler = (controls as OrbitControlsImpl & {
       _onMouseWheel: (event: WheelEvent) => void;
-    };
+    })._onMouseWheel;
     const element = gl.domElement;
     element.removeEventListener("wheel", handler);
     element.addEventListener("wheel", handler, { passive: true });
-    return () => {
-      element.removeEventListener("wheel", handler);
-    };
+    return () => element.removeEventListener("wheel", handler);
   }, [controls, gl]);
 
+  // Support Drei's `makeDefault` prop so the controls can be accessed via `useThree()`
   useEffect(() => {
-    if (makeDefault) {
-      const old = get().controls;
-      // @ts-ignore
-      set({ controls });
-      return () => set({ controls: old });
-    }
+    if (!makeDefault) return;
+    const previous = get().controls;
+    // @ts-ignore - the three fiber typings don't include our custom controls
+    set({ controls });
+    return () => set({ controls: previous });
   }, [makeDefault, controls, set, get]);
 
-  return controls ? (
-    <primitive ref={controlsRef} object={controls} enableDamping={enableDamping} {...props} />
-  ) : null;
+  // Only render the primitive once controls have been instantiated
+  return controls ? <primitive ref={controlsRef} object={controls} enableDamping={enableDamping} {...props} /> : null;
 }
 


### PR DESCRIPTION
## Summary
- refactor PassiveOrbitControls to directly manage OrbitControls and add passive wheel listener

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a86ac9fb70832688b745959ad79f7e