### PR TITLE
refactor: use orbitcontrols component

### DIFF
--- a/src/components/controls/PassiveOrbitControls.tsx
+++ b/src/components/controls/PassiveOrbitControls.tsx
@@ -1,49 +1,62 @@
-import { useEffect, useMemo, useRef } from "react";
-import { useThree, useFrame } from "@react-three/fiber";
+import { useEffect, useRef } from "react";
+import { useThree, useFrame, extend, ReactThreeFiber } from "@react-three/fiber";
 import type { OrbitControlsProps } from "@react-three/drei";
 import { OrbitControls as OrbitControlsImpl } from "three-stdlib";
+
+extend({ OrbitControls: OrbitControlsImpl });
+
+declare global {
+  namespace JSX {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    interface IntrinsicElements {
+      orbitControls: ReactThreeFiber.Object3DNode<
+        OrbitControlsImpl,
+        typeof OrbitControlsImpl
+      >;
+    }
+  }
+}
 
 export default function PassiveOrbitControls({ makeDefault, enableDamping = true, ...props }: OrbitControlsProps) {
   const { camera, gl } = useThree();
   const set = useThree((state) => state.set);
   const get = useThree((state) => state.get);
-
-  // Create the controls instance once for the current camera
-  const controls = useMemo(() => new OrbitControlsImpl(camera), [camera]);
-  const controlsRef = useRef<OrbitControlsImpl>(controls);
+  const controlsRef = useRef<OrbitControlsImpl>(null!);
 
   // Update the controls every frame so damping and auto-rotate work correctly
   useFrame(() => {
-    controls.update();
+    controlsRef.current?.update();
   }, -1);
-
-  // Attach controls to the WebGL context and dispose on unmount
-  useEffect(() => {
-    controls.connect(gl.domElement);
-    return () => controls.dispose();
-  }, [controls, gl]);
 
   // Rebind the wheel listener with `passive: true` to avoid blocking the main thread
   useEffect(() => {
-    const handler = (controls as OrbitControlsImpl & {
-      _onMouseWheel: (event: WheelEvent) => void;
-    })._onMouseWheel;
+    const controls = controlsRef.current as OrbitControlsImpl & {
+      _onMouseWheel?: (event: WheelEvent) => void;
+    };
+    const handler = controls._onMouseWheel;
+    if (!handler) return;
     const element = gl.domElement;
     element.removeEventListener("wheel", handler);
     element.addEventListener("wheel", handler, { passive: true });
     return () => element.removeEventListener("wheel", handler);
-  }, [controls, gl]);
+  }, [gl]);
 
   // Support Drei's `makeDefault` prop so the controls can be accessed via `useThree()`
   useEffect(() => {
     if (!makeDefault) return;
     const previous = get().controls;
     // @ts-ignore - the three fiber typings don't include our custom controls
-    set({ controls });
+    set({ controls: controlsRef.current });
     return () => set({ controls: previous });
-  }, [makeDefault, controls, set, get]);
+  }, [makeDefault, set, get]);
 
-  // Only render the primitive once controls have been instantiated
-  return controls ? <primitive ref={controlsRef} object={controls} enableDamping={enableDamping} {...props} /> : null;
+  return (
+    <orbitControls
+      ref={controlsRef}
+      args={[camera, gl.domElement]}
+      enableDamping={enableDamping}
+      {...props}
+    />
+  );
 }
 


### PR DESCRIPTION
## Summary
- switch PassiveOrbitControls to use `<orbitControls>` component via `extend`
- add passive wheel handler and `makeDefault` support using new ref

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa616f74883269731c305a2ca1063