### PR TITLE
Guard wheel listener rebinding in PassiveOrbitControls

### DIFF
--- a/src/components/controls/PassiveOrbitControls.tsx
+++ b/src/components/controls/PassiveOrbitControls.tsx
@@ -25,9 +25,17 @@ export default function PassiveOrbitControls({ makeDefault, enableDamping = true
 
   // Rebind the wheel listener with `passive: true` to avoid blocking the main thread
   useEffect(() => {
-    const handler = (controls as OrbitControlsImpl & {
-      _onMouseWheel: (event: WheelEvent) => void;
-    })._onMouseWheel;
+    const handler = (
+      controls as OrbitControlsImpl & {
+        _onMouseWheel?: (event: WheelEvent) => void;
+      }
+    )._onMouseWheel;
+    if (!handler) {
+      console.warn(
+        "PassiveOrbitControls: _onMouseWheel handler not found; skipping wheel listener rebind."
+      );
+      return;
+    }
     const element = gl.domElement;
     element.removeEventListener("wheel", handler);
     element.addEventListener("wheel", handler, { passive: true });


### PR DESCRIPTION
## Summary
- skip wheel listener rebinding when `_onMouseWheel` handler is missing
- log a warning if `_onMouseWheel` isn't defined to avoid runtime errors

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa6a30c988326bc1302c689cf263f