### PR TITLE
refactor: share WebGL context manager

### DIFF
--- a/src/components/WebGLContextManager.tsx
+++ b/src/components/WebGLContextManager.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+import { useThree } from "@react-three/fiber";
+
+export default function WebGLContextManager() {
+  const { gl } = useThree();
+  useEffect(() => {
+    const handleLost = (e: Event) => e.preventDefault();
+    const handleRestored = () => {
+      gl.resetState();
+    };
+    gl.domElement.addEventListener("webglcontextlost", handleLost);
+    gl.domElement.addEventListener("webglcontextrestored", handleRestored);
+    return () => {
+      gl.domElement.removeEventListener("webglcontextlost", handleLost);
+      gl.domElement.removeEventListener("webglcontextrestored", handleRestored);
+    };
+  }, [gl]);
+  return null;
+}

--- a/src/views/HomeGalaxy.tsx
+++ b/src/views/HomeGalaxy.tsx
@@ -1,25 +1,9 @@
-import React, { useEffect } from "react";
-import { Canvas, useThree } from "@react-three/fiber";
+import React from "react";
+import { Canvas } from "@react-three/fiber";
 import { Environment, Stars } from "@react-three/drei";
 import PassiveOrbitControls from "@/components/controls/PassiveOrbitControls";
 import GalaxyPath from "@/game/galaxy/GalaxyPath";
-
-function WebGLContextManager() {
-  const { gl } = useThree();
-  useEffect(() => {
-    const handleLost = (e: Event) => e.preventDefault();
-    const handleRestored = () => {
-      gl.resetState();
-    };
-    gl.domElement.addEventListener('webglcontextlost', handleLost);
-    gl.domElement.addEventListener('webglcontextrestored', handleRestored);
-    return () => {
-      gl.domElement.removeEventListener('webglcontextlost', handleLost);
-      gl.domElement.removeEventListener('webglcontextrestored', handleRestored);
-    };
-  }, [gl]);
-  return null;
-}
+import WebGLContextManager from "@/components/WebGLContextManager";
 
 export default function HomeGalaxy() {
   return (

--- a/src/views/RoadmapGalaxy.tsx
+++ b/src/views/RoadmapGalaxy.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useRef, useEffect } from "react";
-import { Canvas, useFrame, useThree } from "@react-three/fiber";
+import { Canvas, useFrame } from "@react-three/fiber";
 import { Environment, Stars, Html } from "@react-three/drei";
 import PassiveOrbitControls from "@/components/controls/PassiveOrbitControls";
 import * as THREE from "three";
@@ -8,6 +8,7 @@ import PlanetNode, { NodeStatus } from "@/components/roadmap/PlanetNode";
 import { useRoadmapStore } from "@/state/roadmapStore";
 import { useRoadmapProgress } from "@/hooks/useRoadmapProgress";
 import { milestoneColor } from "@/game/galaxy/palette";
+import WebGLContextManager from "@/components/WebGLContextManager";
 
 function useSpiralPositions(count: number) {
   return useMemo(() => {
@@ -111,22 +112,6 @@ function AuroraFollower({ target }: { target: React.MutableRefObject<THREE.Vecto
   );
 }
 
-function WebGLContextManager() {
-  const { gl } = useThree();
-  useEffect(() => {
-    const handleLost = (e: Event) => e.preventDefault();
-    const handleRestored = () => {
-      gl.resetState();
-    };
-    gl.domElement.addEventListener('webglcontextlost', handleLost);
-    gl.domElement.addEventListener('webglcontextrestored', handleRestored);
-    return () => {
-      gl.domElement.removeEventListener('webglcontextlost', handleLost);
-      gl.domElement.removeEventListener('webglcontextrestored', handleRestored);
-    };
-  }, [gl]);
-  return null;
-}
 
 function GalaxyScene() {
   const { taskNodes, currentPos } = useTaskNodes();


### PR DESCRIPTION
## Summary
- extract WebGLContextManager into src/components for reuse
- use shared WebGLContextManager in HomeGalaxy and RoadmapGalaxy views

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, Empty block statement, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68aaa793d8448326b4f52d6df97949bf