### PR TITLE
fix: robust passive orbit controls

### DIFF
--- a/src/components/controls/PassiveOrbitControls.tsx
+++ b/src/components/controls/PassiveOrbitControls.tsx
@@ -1,43 +1,36 @@
 import { useEffect, useRef } from "react";
-import { useThree, useFrame } from "@react-three/fiber";
-import { OrbitControls as OrbitControls } from "@react-three/drei";
-import type { OrbitControlsProps } from "@react-three/drei";
+import { useThree, useFrame, extend } from "@react-three/fiber";
+import {
+  OrbitControls as DreiOrbitControls,
+  type OrbitControlsProps,
+} from "@react-three/drei";
 import { OrbitControls as OrbitControlsImpl } from "three-stdlib";
 
 extend({ OrbitControls: OrbitControlsImpl });
 
-declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace JSX {
-    interface IntrinsicElements {
-      orbitControls: ReactThreeFiber.Object3DNode<
-        OrbitControlsImpl,
-        typeof OrbitControlsImpl
-      >;
-    }
-  }
-}
-
-export default function PassiveOrbitControls({ makeDefault, enableDamping = true, ...props }: OrbitControlsProps) {
+export default function PassiveOrbitControls({
+  makeDefault,
+  enableDamping = true,
+  ...props
+}: OrbitControlsProps) {
   const { camera, gl } = useThree();
   const set = useThree((state) => state.set);
   const get = useThree((state) => state.get);
   const controlsRef = useRef<OrbitControlsImpl>(null!);
 
-  // Update the controls every frame so damping and auto-rotate work correctly
+  // Update controls every frame so damping and auto-rotate work correctly
   useFrame(() => {
     controlsRef.current?.update();
   }, -1);
 
   // Rebind the wheel listener with `passive: true` to avoid blocking the main thread
   useEffect(() => {
-    if (!controlsRef.current?._onMouseWheel) return;
-    const handler = (
-      controlsRef.current as OrbitControlsImpl & {
-        _onMouseWheel: (event: WheelEvent) => void;
-      }
-    )._onMouseWheel;
-
+    const controls = controlsRef.current as OrbitControlsImpl & {
+      _onMouseWheel?: (event: WheelEvent) => void;
+    };
+    const handler = controls._onMouseWheel;
+    if (!handler) return;
+    const element = gl.domElement;
     element.removeEventListener("wheel", handler);
     element.addEventListener("wheel", handler, { passive: true });
     return () => element.removeEventListener("wheel", handler);
@@ -52,11 +45,10 @@ export default function PassiveOrbitControls({ makeDefault, enableDamping = true
     return () => set({ controls: previous });
   }, [makeDefault, set, get]);
 
-
   return (
-    <OrbitControls
+    <DreiOrbitControls
       ref={controlsRef}
-      args={args}
+      args={[camera, gl.domElement]}
       enableDamping={enableDamping}
       makeDefault={makeDefault}
       {...props}


### PR DESCRIPTION
## Summary
- refactor PassiveOrbitControls to use Drei OrbitControls with ref and args
- safely rebind wheel listener with passive flag

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npx eslint src/components/controls/PassiveOrbitControls.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68aaa58c9d308326be1c9349f1c646d0