### PR TITLE
fix: register OrbitControls in browser context

### DIFF
--- a/src/components/controls/PassiveOrbitControls.tsx
+++ b/src/components/controls/PassiveOrbitControls.tsx
@@ -6,13 +6,14 @@ import {
 } from "@react-three/drei";
 import { OrbitControls as OrbitControlsImpl } from "three-stdlib";
 
-extend({ OrbitControls: OrbitControlsImpl });
-
 export default function PassiveOrbitControls({
   makeDefault,
   enableDamping = true,
   ...props
 }: OrbitControlsProps) {
+  useEffect(() => {
+    extend({ OrbitControls: OrbitControlsImpl });
+  }, []);
   const { camera, gl } = useThree();
   const set = useThree((state) => state.set);
   const get = useThree((state) => state.get);


### PR DESCRIPTION
## Summary
- import `extend` from `@react-three/fiber`
- register `OrbitControls` inside a `useEffect` to avoid server-side execution

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, Empty block statement)*
- `npm run build` *(fails: Cannot find name 'SpeechRecognition', Argument of type 'never')*

------
https://chatgpt.com/codex/tasks/task_e_68aaad051be48326b642a24e6b6cab4c