### PR TITLE
chore: skip component tagging for three.js scenes

### DIFF
--- a/src/components/avatar/AuroraBallR3F.tsx
+++ b/src/components/avatar/AuroraBallR3F.tsx
@@ -12,17 +12,18 @@ export type AuroraBallProps = Omit<JSX.IntrinsicElements['group'], 'children'> &
 const AuroraBallR3F = forwardRef<THREE.Group, AuroraBallProps>(
   (props, ref) => {
     const { size = 1, children, ...restProps } = props;
+    const { lov, ...safeProps } = restProps;
     const matRef = useRef<THREE.ShaderMaterial>(null!);
 
     const groupProps = useMemo(() => {
-      const entries = Object.entries(restProps as Record<string, unknown>).filter(
+      const entries = Object.entries(safeProps as Record<string, unknown>).filter(
         ([key]) => !key.startsWith('data-') && !key.startsWith('aria-')
       );
       return Object.fromEntries(entries) as Omit<
         JSX.IntrinsicElements['group'],
         'children'
       >;
-    }, [restProps]);
+    }, [safeProps]);
 
 
     const uniforms = useMemo(

--- a/src/components/controls/PassiveOrbitControls.tsx
+++ b/src/components/controls/PassiveOrbitControls.tsx
@@ -11,6 +11,7 @@ export default function PassiveOrbitControls({
   enableDamping = true,
   ...props
 }: OrbitControlsProps) {
+  const { lov, ...safeProps } = props;
   useEffect(() => {
     extend({ OrbitControls: OrbitControlsImpl });
   }, []);
@@ -47,12 +48,12 @@ export default function PassiveOrbitControls({
   }, [makeDefault, set, get]);
 
   return (
-    <DreiOrbitControls
+      <DreiOrbitControls
       ref={controlsRef}
       args={[camera, gl.domElement]}
       enableDamping={enableDamping}
       makeDefault={makeDefault}
-      {...props}
+      {...safeProps}
     />
   );
 }

--- a/src/types/picomatch.d.ts
+++ b/src/types/picomatch.d.ts
@@ -1,0 +1,1 @@
+declare module "picomatch";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,8 @@ import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
 import { VitePWA } from "vite-plugin-pwa";
+// @ts-ignore - no type definitions for picomatch
+import picomatch from "picomatch";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -19,8 +21,27 @@ export default defineConfig(({ mode }) => {
         manifest: false,
         workbox: { globPatterns: ['**/*.{js,css,html,ico,png,svg}'] }
       }),
-      mode === 'development' &&
-      componentTagger(),
+      mode === 'development' && (() => {
+        const tagger = componentTagger();
+        const excludeGlobs = [
+          'src/components/avatar/**',
+          'src/components/controls/**',
+          'src/components/roadmap/**',
+          'src/components/WebGLContextManager.tsx',
+          'src/game/**',
+          'src/views/HomeGalaxy.tsx',
+          'src/views/RoadmapGalaxy.tsx',
+        ];
+        const isExcluded = picomatch(excludeGlobs);
+        return {
+          ...tagger,
+          transform(this: any, code: string, id: string, ...args: any[]) {
+            const rel = path.relative(process.cwd(), id);
+            if (isExcluded(rel)) return null;
+            return (tagger.transform as any)?.call(this, code, id, ...args);
+          },
+        };
+      })(),
     ].filter(Boolean),
     resolve: {
       alias: {


### PR DESCRIPTION
## Summary
- avoid componentTagger processing React-Three-Fiber scenes
- strip `lov` prop before forwarding to Three.js objects
- add picomatch type stub for Vite config

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*
- `npm test`
- `npm run build` *(fails: TypeScript errors in voice tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aaaf0d9da88326834056b3640365cf