### PR TITLE
refactor: register orbit controls once

### DIFF
--- a/src/components/controls/PassiveOrbitControls.tsx
+++ b/src/components/controls/PassiveOrbitControls.tsx
@@ -6,14 +6,13 @@ import {
 } from "@react-three/drei";
 import { OrbitControls as OrbitControlsImpl } from "three-stdlib";
 
+extend({ OrbitControls: OrbitControlsImpl });
+
 export default function PassiveOrbitControls({
   makeDefault,
   enableDamping = true,
   ...props
 }: OrbitControlsProps) {
-  useEffect(() => {
-    extend({ OrbitControls: OrbitControlsImpl });
-  }, []);
   const { camera, gl } = useThree();
   const set = useThree((state) => state.set);
   const get = useThree((state) => state.get);


### PR DESCRIPTION
## Summary
- register OrbitControls implementation once on module load in PassiveOrbitControls
- remove now-unnecessary effect wrapper

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and no-empty in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68aaaf176a2483268722e2341bff7c07