### PR TITLE
Use chat drawer height to offset bottom dock

### DIFF
--- a/src/components/chat/ChatDrawer.tsx
+++ b/src/components/chat/ChatDrawer.tsx
@@ -20,12 +20,33 @@ export function ChatDrawer() {
 
   const [open, setOpen] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
+  const drawerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (open) {
       contentRef.current?.scrollTo({ top: contentRef.current.scrollHeight });
     }
   }, [messages, open]);
+
+  useEffect(() => {
+    const el = drawerRef.current;
+    const root = document.documentElement;
+    if (!el) return;
+    if (open) {
+      const set = () => {
+        root.style.setProperty('--chat-drawer-h', `${el.offsetHeight}px`);
+      };
+      set();
+      const ro = new ResizeObserver(set);
+      ro.observe(el);
+      return () => {
+        ro.disconnect();
+        root.style.setProperty('--chat-drawer-h', '0px');
+      };
+    } else {
+      root.style.setProperty('--chat-drawer-h', '0px');
+    }
+  }, [open]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -45,7 +66,11 @@ export function ChatDrawer() {
       >
         <ChevronUp className="drawer-grabber-icon" />
       </button>
-      <div className={cn('chat-drawer glass-maple', open && 'open')}>
+      <div
+        ref={drawerRef}
+        className={cn('chat-drawer glass-maple', open && 'open')}
+        style={{ zIndex: 75 }}
+      >
         <div ref={contentRef} className="p-4 space-y-2 overflow-y-auto max-h-[70vh]">
           {messages.map((m) => (
             <div key={m.id} className={cn('flex', m.role === 'assistant' ? 'justify-start' : 'justify-end')}>

--- a/src/components/navigation/BottomDock.tsx
+++ b/src/components/navigation/BottomDock.tsx
@@ -58,7 +58,7 @@ export default function BottomDock() {
         expanded ? "pb-3" : "pb-2"
       )}
       style={{
-        bottom: `calc(var(--kb-offset) + var(--safe-area-bottom) + var(--chatbar-h) + var(--gap-h))`,
+        bottom: `calc(var(--kb-offset) + var(--safe-area-bottom) + var(--chatbar-h) + var(--gap-h) + var(--chat-drawer-h))`,
         zIndex: 80,
         pointerEvents: "auto",
       }}

--- a/src/index.css
+++ b/src/index.css
@@ -100,6 +100,7 @@ All colors MUST be HSL.
 
     /* Layout gap */
     --gap-h: 12px;           /* gap above dock/chat bar */
+    --chat-drawer-h: 0px;
   }
 
   .light {


### PR DESCRIPTION
## Summary
- track chat drawer height with ResizeObserver and expose as `--chat-drawer-h`
- offset bottom dock by chat drawer height and raise drawer's z-index
- provide default `--chat-drawer-h: 0px` variable

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aab5821dec832684f7bb45e35c3cc9