### PR TITLE
Propagate errors for empty aurora-chat responses

### DIFF
--- a/src/agent/AuroraAgent.ts
+++ b/src/agent/AuroraAgent.ts
@@ -93,7 +93,7 @@ export class AuroraAgent {
         this.say(content, sentiment);
       } catch (e) {
         console.error('aurora-chat failed', e);
-        this.say('Could you elaborate?');
+        this.events.onError?.(e);
       }
       return;
     }
@@ -152,7 +152,7 @@ export class AuroraAgent {
       this.say(content, sentiment);
     } catch (e) {
       console.error('aurora-chat failed', e);
-      this.say('Okay.');
+      this.events.onError?.(e);
     }
   }
 

--- a/src/agent/router.ts
+++ b/src/agent/router.ts
@@ -65,5 +65,8 @@ export async function routeChat(
     body: { messages: safeMessages, profile: safeProfile, ...options },
   });
   if (error) throw error;
-  return data ?? { content: '', sentiment: 0 };
+  if (!data?.content) {
+    throw new Error('Empty response from aurora-chat');
+  }
+  return data;
 }

--- a/src/pages/OnboardingFlow.tsx
+++ b/src/pages/OnboardingFlow.tsx
@@ -267,9 +267,9 @@ export default function OnboardingFlow() {
     setMessages(newMessages);
     setInput("");
 
-    let error: string | null = null;
+    let validationError: string | null = null;
     if (phase === "question") {
-      error = validateAnswer(userMsg.content, currentModule, questionIndex);
+      validationError = validateAnswer(userMsg.content, currentModule, questionIndex);
     }
 
     const baseMessages: ChatMsg[] = [
@@ -277,10 +277,10 @@ export default function OnboardingFlow() {
       ...newMessages,
     ];
 
-    if (error) {
+    if (validationError) {
       baseMessages.push({
         role: "system",
-        content: `The user's last answer failed validation: ${error} Ask them to clarify or provide more detail.`,
+        content: `The user's last answer failed validation: ${validationError} Ask them to clarify or provide more detail.`,
       });
     }
 
@@ -300,11 +300,17 @@ export default function OnboardingFlow() {
       });
     }
 
-    const { data } = await supabase.functions.invoke("aurora-chat", { body: { messages: baseMessages } });
-    if (data?.content) {
+    const { data, error } = await supabase.functions.invoke<{ content: string }>(
+      "aurora-chat",
+      { body: { messages: baseMessages } },
+    );
+    if (error || !data?.content) {
+      console.error("aurora-chat error", error, data);
+      sendPrompt("Sorry, I had trouble responding. Please try again.");
+    } else {
       setMessages((m) => [...m, { role: "assistant", content: data.content }]);
     }
-    if (error) return;
+    if (validationError) return;
 
     if (phase === "question") {
       const updatedAnswers = answers.map((a) => [...a]);

--- a/supabase/functions/aurora-chat/index.ts
+++ b/supabase/functions/aurora-chat/index.ts
@@ -107,7 +107,17 @@ serve(async (req) => {
     }
 
     const data = await resp.json();
-    let content = data?.choices?.[0]?.message?.content ?? "Okay.";
+    let content = data?.choices?.[0]?.message?.content;
+    if (!content || !content.trim()) {
+      console.error("Empty model response", data);
+      return new Response(
+        JSON.stringify({ error: "Empty response from model" }),
+        {
+          status: 502,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
+    }
 
     for (const filter of brain.filters) {
       content = filter(content);


### PR DESCRIPTION
## Summary
- Return structured error when `aurora-chat` OpenAI call yields empty content
- Surface invocation failures in router and onboarding flow instead of silent fallbacks
- Emit errors through `AuroraAgent` rather than speaking generic messages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aab8d3f6088326a5cc1cc4e8c33dc5