### PR TITLE
Handle chat send errors with retry and voice sync

### DIFF
--- a/src/state/chat.ts
+++ b/src/state/chat.ts
@@ -12,7 +12,11 @@ import { mergeAndExplainMemories, formatMemoryContext } from "@/memory/relevance
 import { bus } from "@/utils/bus";
 import { runAgentCommand } from "@/services/aiBridge";
 
-export type ChatEntry = ChatMessage & { id: string };
+export type ChatEntry = ChatMessage & {
+  id: string;
+  /** Optional retry handler for failed responses */
+  retry?: () => Promise<void>;
+};
 
 type ChatState = {
   messages: ChatEntry[];
@@ -115,17 +119,23 @@ export const useChatStore = create<ChatState>((set, get) => ({
       memoryStore.add("episodic", "assistant", finalText).catch(() => {});
       saveMemory(finalText, { role: "assistant" }).catch(() => {});
     } catch (error) {
+      const errorMessage =
+        error instanceof Error && error.message
+          ? `${error.message}. Tap to retry.`
+          : "Something went wrong. Tap to retry.";
       set(state => ({
         messages: state.messages.map(m =>
           m.id === responseId
-            ? { ...m, content: "Sorry, I couldn't respond." }
+            ? { ...m, content: errorMessage, retry: () => get().send(text) }
             : m
         ),
         sending: false,
       }));
       bus.emit('chat/stream:error', { id: responseId, error });
+      voiceService.cancel();
       bus.emit('sphere/state:set', { state: 'thinking' });
       bus.emit('voice/state:set', { state: 'thinking' });
+      void voiceService.speak(errorMessage);
     }
   },
 }));


### PR DESCRIPTION
## Summary
- provide retry-capable error message when chat send fails
- sync text and TTS by canceling speech and voicing the error

## Testing
- `npm run lint` *(fails: Unexpected any, 247 problems)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aab8e127c083268ca1de302031f888