### PR TITLE
feat: limit chat drawer height with CSS variable

### DIFF
--- a/src/components/chat/ChatDrawer.tsx
+++ b/src/components/chat/ChatDrawer.tsx
@@ -71,7 +71,11 @@ export function ChatDrawer() {
         className={cn('chat-drawer glass-maple', open && 'open')}
         style={{ zIndex: 75 }}
       >
-        <div ref={contentRef} className="p-4 space-y-2 overflow-y-auto max-h-[70vh]">
+        <div
+          ref={contentRef}
+          className="flex-1 p-4 space-y-2 overflow-y-auto"
+          style={{ maxHeight: 'var(--chat-drawer-max-h)' }}
+        >
           {messages.map((m) => (
             <div key={m.id} className={cn('flex', m.role === 'assistant' ? 'justify-start' : 'justify-end')}>
               <div

--- a/src/index.css
+++ b/src/index.css
@@ -564,7 +564,9 @@ All colors MUST be HSL.
   left: 12px;
   right: 12px;
   bottom: calc(var(--chatbar-h) + var(--gap-h) + var(--safe-area-bottom));
-  max-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  max-height: var(--chat-drawer-max-h);
   border-radius: 16px;
   overflow: hidden;
   transform: translateY(12px);

--- a/src/styles/vars.css
+++ b/src/styles/vars.css
@@ -40,6 +40,7 @@
   --hud-gap: var(--gap-h);
   --kb-offset: 0px; /* keyboard height offset */
   --compass-bottom: calc(var(--dock-h) + var(--chatbar-h) + var(--gap-h) + var(--safe-area-bottom));
+  --chat-drawer-max-h: calc(100vh - var(--dock-h) - var(--chatbar-h) - var(--gap-h) - var(--safe-area-bottom));
 }
 
 /* Ethereal dimension */


### PR DESCRIPTION
## Summary
- define `--chat-drawer-max-h` variable for layout calculations
- use variable to cap chat drawer height and switch drawer to flex column layout
- make ChatDrawer content flex and remove fixed max height

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68aab98097a88326bf859e08f92f9a36