### PR TITLE
feat: add stopPlayback to halt voice output

### DIFF
--- a/src/voice/__tests__/voiceService.test.ts
+++ b/src/voice/__tests__/voiceService.test.ts
@@ -193,5 +193,27 @@ describe('voiceService', () => {
     expect(blocked).toBeNull();
     off();
   });
+
+  it('stopPlayback stops audio and resets speaking state', () => {
+    let blocked: (() => void) | null = () => {};
+    const off = voiceService.onPlaybackBlocked((cb) => {
+      blocked = cb;
+    });
+    const audio = new MockAudio();
+    voiceService['audio'] = audio as any;
+    voiceService['audios'].add(audio as any);
+    const utter = new (SpeechSynthesisUtterance as any)('hi');
+    voiceService['utter'] = utter as any;
+    useVoiceStore.getState().setSpeaking(true);
+    const cancelSpy = jest.spyOn(window.speechSynthesis, 'cancel');
+
+    voiceService.stopPlayback();
+
+    expect(audio.pause).toHaveBeenCalled();
+    expect(cancelSpy).toHaveBeenCalled();
+    expect(useVoiceStore.getState().isSpeaking).toBe(false);
+    expect(blocked).toBeNull();
+    off();
+  });
 });
 

--- a/src/voice/voiceService.ts
+++ b/src/voice/voiceService.ts
@@ -170,10 +170,31 @@ class VoiceService {
     useVoiceStore.getState().setThinking(true);
   }
 
-  async speak(text: string) {
-    if (!text?.trim()) return;
+  stopPlayback() {
+    this.audios.forEach((a) => {
+      a.pause();
+      a.srcObject = null;
+    });
+    this.audios.clear();
+    this.audio = null;
+    if (this.utter) {
+      try {
+        window.speechSynthesis.cancel();
+      } catch {
+        /* ignore */
+      }
+      this.utter = null;
+    }
     this.blocked = null;
     this.emitPlaybackBlocked(null);
+    useVoiceStore.getState().setSpeaking(false);
+    bus.emit('sphere/state:set', { state: 'thinking' });
+    bus.emit('voice/state:set', { state: 'thinking' });
+  }
+
+  async speak(text: string) {
+    if (!text?.trim()) return;
+    this.stopPlayback();
     if (!this.enabled) {
       const resume = () => {
         window.removeEventListener('pointerdown', resume);


### PR DESCRIPTION
## Summary
- add `stopPlayback` to cancel active audio or speech synthesis and reset voice state
- ensure `speak` stops prior playback before starting new speech
- cover `stopPlayback` with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aab9dff08083269457716311a6151d