### PR TITLE
fix: limit chat drawer height

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -101,6 +101,7 @@ All colors MUST be HSL.
     /* Layout gap */
     --gap-h: 12px;           /* gap above dock/chat bar */
     --chat-drawer-h: 0px;
+    --chat-drawer-max-h: calc(100vh - var(--dock-h) - var(--chatbar-h) - var(--gap-h) - var(--safe-area-bottom));
   }
 
   .light {

--- a/src/styles/vars.css
+++ b/src/styles/vars.css
@@ -40,7 +40,6 @@
   --hud-gap: var(--gap-h);
   --kb-offset: 0px; /* keyboard height offset */
   --compass-bottom: calc(var(--dock-h) + var(--chatbar-h) + var(--gap-h) + var(--safe-area-bottom));
-  --chat-drawer-max-h: calc(100vh - var(--dock-h) - var(--chatbar-h) - var(--gap-h) - var(--safe-area-bottom));
 }
 
 /* Ethereal dimension */


### PR DESCRIPTION
## Summary
- define `--chat-drawer-max-h` variable for layout calculations
- ensure `.chat-drawer` respects `max-height: var(--chat-drawer-max-h)`

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any etc)*

------
https://chatgpt.com/codex/tasks/task_e_68aabaad5fac8326b4508a58ee9784ed