### PR TITLE
Encrypt collections using derived data key

### DIFF
--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -3,7 +3,7 @@ import { RxDBAttachmentsPlugin } from 'rxdb/plugins/attachments';
 import { RxDBEncryptionPlugin } from 'rxdb/plugins/encryption';
 import { getRxStorageDexie } from 'rxdb/plugins/storage-dexie';
 import type { Observable } from 'rxjs';
-import { getDataKey } from './keyManager';
+import { getDataKey, waitForDataKey } from './keyManager';
 
 addRxPlugin(RxDBAttachmentsPlugin);
 addRxPlugin(RxDBEncryptionPlugin);
@@ -97,19 +97,19 @@ let dbPromise: Promise<RxDatabase<Collections>> | null = null;
 
 export async function createDatabase(): Promise<RxDatabase<Collections>> {
   if (!dbPromise) {
+    await waitForDataKey();
     const key = getDataKey();
     if (!key) throw new Error('Data key not set');
     const password = btoa(String.fromCharCode(...key));
     dbPromise = createRxDatabase<Collections>({
       name: 'brain',
       storage: getRxStorageDexie(),
-      password
     }).then(async (db) => {
       await db.addCollections({
-        journal: { schema: journalSchema },
-        focus_sessions: { schema: focusSessionSchema },
-        tasks: { schema: taskSchema },
-        goals: { schema: goalSchema }
+        journal: { schema: journalSchema, password },
+        focus_sessions: { schema: focusSessionSchema, password },
+        tasks: { schema: taskSchema, password },
+        goals: { schema: goalSchema, password }
       });
       return db;
     });

--- a/src/state/keyManager.ts
+++ b/src/state/keyManager.ts
@@ -1,4 +1,8 @@
 let dataKey: Uint8Array | undefined;
+let resolveKey: ((key: Uint8Array) => void) | undefined;
+const dataKeyPromise = new Promise<Uint8Array>((resolve) => {
+  resolveKey = resolve;
+});
 
 export async function deriveDataKey(signedMessage: string, passcode: string) {
   const enc = new TextEncoder();
@@ -19,9 +23,17 @@ export async function deriveDataKey(signedMessage: string, passcode: string) {
   );
   const raw = await crypto.subtle.exportKey('raw', key);
   dataKey = new Uint8Array(raw);
+  resolveKey?.(dataKey);
   return dataKey;
 }
 
 export function getDataKey() {
   return dataKey;
+}
+
+export function waitForDataKey(): Promise<Uint8Array> {
+  if (dataKey) {
+    return Promise.resolve(dataKey);
+  }
+  return dataKeyPromise;
 }


### PR DESCRIPTION
## Summary
- wait for derived data key before creating the database
- encrypt each RxDB collection using the derived data key
- expose a helper to await data key derivation

## Testing
- `npm run lint` *(fails: Unexpected any, no-empty)*
- `npm test` *(fails: Cannot find module '@fastify/cors')*

------
https://chatgpt.com/codex/tasks/task_e_68aad85f87b083269ed43bb3411d9174