### PR TITLE
chore: replace jsonwebtoken with jose

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "html-to-image": "^1.11.13",
     "input-otp": "^1.4.2",
     "jose": "^6.0.13",
-    "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.462.0",
     "nanoid": "^3.3.11",
     "next": "14.2.31",

--- a/server/auth/__tests__/ton.spec.ts
+++ b/server/auth/__tests__/ton.spec.ts
@@ -1,7 +1,8 @@
 import fastify from 'fastify';
 import cookie from '@fastify/cookie';
 import tonAuth, { composeMessage } from '../ton';
-import * as nacl from 'tweetnacl';
+import nacl from 'tweetnacl';
+import { jwtVerify } from 'jose';
 
 function toHex(buf: Uint8Array): string {
   return Buffer.from(buf).toString('hex');
@@ -10,6 +11,7 @@ function toHex(buf: Uint8Array): string {
 describe('TON auth', () => {
   let app: any;
   let keypair: nacl.SignKeyPair;
+  const secretBytes = new TextEncoder().encode('secret');
 
   beforeEach(async () => {
     app = fastify();
@@ -37,7 +39,11 @@ describe('TON auth', () => {
     };
     const first = await app.inject({ method: 'POST', url: '/auth/ton/verify', payload });
     expect(first.statusCode).toBe(200);
-    expect(first.cookies.find((c: any) => c.name === 'sid')).toBeDefined();
+    const tokenCookie = first.cookies.find((c: any) => c.name === 'sid');
+    expect(tokenCookie).toBeDefined();
+    const { payload: tokenPayload } = await jwtVerify(tokenCookie.value, secretBytes);
+    expect(tokenPayload.sub).toBe(toHex(keypair.publicKey));
+    expect(tokenPayload.scopes).toEqual(scopes);
     const second = await app.inject({ method: 'POST', url: '/auth/ton/verify', payload });
     expect(second.statusCode).toBe(400);
   });

--- a/server/auth/ton.ts
+++ b/server/auth/ton.ts
@@ -1,10 +1,11 @@
 import type { FastifyPluginAsync } from 'fastify';
-import * as jwt from 'jsonwebtoken';
+import { SignJWT } from 'jose';
 import { nanoid } from 'nanoid';
-import * as nacl from 'tweetnacl';
+import nacl from 'tweetnacl';
 
 const CHALLENGE_TTL = 300; // seconds
 const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+const JWT_SECRET_BYTES = new TextEncoder().encode(JWT_SECRET);
 
 export function composeMessage(
   challenge: string,
@@ -68,7 +69,10 @@ const plugin: FastifyPluginAsync = async (fastify) => {
       tokenExp = Math.min(Math.floor(exp / 1000), now + 60 * 60);
     }
 
-    const token = jwt.sign(payload, JWT_SECRET, { expiresIn: tokenExp - now });
+    const token = await new SignJWT(payload)
+      .setProtectedHeader({ alg: 'HS256' })
+      .setExpirationTime(tokenExp)
+      .sign(JWT_SECRET_BYTES);
     reply.setCookie('sid', token, {
       httpOnly: true,
       sameSite: 'lax',

--- a/server/replicate.ts
+++ b/server/replicate.ts
@@ -2,7 +2,7 @@ import type { FastifyPluginAsync } from 'fastify';
 import cors from '@fastify/cors';
 import helmet from '@fastify/helmet';
 import { RateLimiterMemory } from 'rate-limiter-flexible';
-import * as jwt from 'jsonwebtoken';
+import { jwtVerify } from 'jose';
 import { z } from 'zod';
 
 const paramsSchema = z.object({
@@ -12,6 +12,7 @@ const paramsSchema = z.object({
 const plugin: FastifyPluginAsync = async (fastify) => {
   const rateLimiter = new RateLimiterMemory({ points: 100, duration: 60 });
   const jwtSecret = process.env.JWT_SECRET || 'secret';
+  const jwtSecretBytes = new TextEncoder().encode(jwtSecret);
 
   await fastify.register(cors, { origin: false });
   await fastify.register(helmet, {
@@ -37,7 +38,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
       return null;
     }
     try {
-      const payload: any = jwt.verify(auth.slice(7), jwtSecret);
+      const { payload }: any = await jwtVerify(auth.slice(7), jwtSecretBytes);
       if (!Array.isArray(payload.scopes) || !payload.scopes.includes('replicate')) {
         reply.code(401).send({ error: 'invalid_scope' });
         return null;

--- a/server/replicate/__tests__/replicate.spec.ts
+++ b/server/replicate/__tests__/replicate.spec.ts
@@ -1,12 +1,16 @@
 import fastify from 'fastify';
 import replicatePlugin from '../../replicate';
 import cookie from '@fastify/cookie';
-import * as jwt from 'jsonwebtoken';
+import { SignJWT } from 'jose';
 
 const secret = 'secret';
+const secretBytes = new TextEncoder().encode(secret);
 
-function sign(scopes: string[]) {
-  return jwt.sign({ sub: 'user1', scopes }, secret, { expiresIn: '1h' });
+async function sign(scopes: string[]) {
+  return new SignJWT({ sub: 'user1', scopes })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setExpirationTime('1h')
+    .sign(secretBytes);
 }
 
 describe('replicate plugin', () => {
@@ -50,7 +54,7 @@ describe('replicate plugin', () => {
   });
 
   test('proxies changes feed', async () => {
-    const token = sign(['replicate']);
+    const token = await sign(['replicate']);
     const res = await app.inject({
       method: 'GET',
       url: '/replicate/tasks/_changes?since=0',
@@ -63,7 +67,7 @@ describe('replicate plugin', () => {
   });
 
   test('proxies bulk docs', async () => {
-    const token = sign(['replicate']);
+    const token = await sign(['replicate']);
     const payload = { docs: [{ _id: 'a' }] };
     const res = await app.inject({
       method: 'POST',
@@ -78,7 +82,7 @@ describe('replicate plugin', () => {
   });
 
   test('rejects missing scope', async () => {
-    const token = sign([]);
+    const token = await sign([]);
     const res = await app.inject({
       method: 'GET',
       url: '/replicate/tasks/_changes',


### PR DESCRIPTION
## Summary
- use `jose` for signing TON auth tokens
- verify replication JWTs with `jose`
- remove `jsonwebtoken` dependency

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npm test -- server/auth/__tests__/ton.spec.ts`
- `NODE_OPTIONS=--experimental-vm-modules npm test -- server/replicate/__tests__/replicate.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aae03de4e88326819c21cc752a6c42