### PR TITLE
refactor: use TonWeb for TON auth

### DIFF
--- a/server/auth/__tests__/ton.spec.ts
+++ b/server/auth/__tests__/ton.spec.ts
@@ -1,10 +1,13 @@
 import fastify from 'fastify';
 import cookie from '@fastify/cookie';
 import tonAuth, { composeMessage } from '../ton';
-import * as nacl from 'tweetnacl';
+// TonWeb is CommonJS; require to access utils in Jest environment
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const TonWeb = require('tonweb');
+const { nacl, bytesToHex, stringToBytes } = TonWeb.utils;
 
 function toHex(buf: Uint8Array): string {
-  return Buffer.from(buf).toString('hex');
+  return bytesToHex(buf);
 }
 
 describe('TON auth', () => {
@@ -28,7 +31,7 @@ describe('TON auth', () => {
     const { challenge } = start.json();
     const scopes = ['read'];
     const msg = composeMessage(challenge, scopes);
-    const sig = toHex(nacl.sign.detached(Buffer.from(msg), keypair.secretKey));
+    const sig = toHex(nacl.sign.detached(stringToBytes(msg), keypair.secretKey));
     const payload = {
       address: toHex(keypair.publicKey),
       challenge,
@@ -51,7 +54,7 @@ describe('TON auth', () => {
     // @ts-ignore
     Date.now = () => now + (ttl + 1) * 1000;
     const msg = composeMessage(challenge, []);
-    const sig = toHex(nacl.sign.detached(Buffer.from(msg), keypair.secretKey));
+    const sig = toHex(nacl.sign.detached(stringToBytes(msg), keypair.secretKey));
     const res = await app.inject({
       method: 'POST',
       url: '/auth/ton/verify',
@@ -71,7 +74,7 @@ describe('TON auth', () => {
     const { challenge } = start.json();
     const signedScopes = ['read'];
     const msg = composeMessage(challenge, signedScopes);
-    const sig = toHex(nacl.sign.detached(Buffer.from(msg), keypair.secretKey));
+    const sig = toHex(nacl.sign.detached(stringToBytes(msg), keypair.secretKey));
     const res = await app.inject({
       method: 'POST',
       url: '/auth/ton/verify',

--- a/server/auth/ton.ts
+++ b/server/auth/ton.ts
@@ -1,7 +1,7 @@
 import type { FastifyPluginAsync } from 'fastify';
 import * as jwt from 'jsonwebtoken';
 import { nanoid } from 'nanoid';
-import * as nacl from 'tweetnacl';
+import * as TonWeb from 'tonweb';
 
 const CHALLENGE_TTL = 300; // seconds
 const JWT_SECRET = process.env.JWT_SECRET || 'secret';
@@ -46,11 +46,12 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     }
     challenges.delete(challenge);
 
+    const { stringToBytes, hexToBytes, nacl } = TonWeb.utils;
     const message = composeMessage(challenge, scopes, sessionPubKey, exp);
     const ok = nacl.sign.detached.verify(
-      Buffer.from(message),
-      Buffer.from(signature, 'hex'),
-      Buffer.from(address, 'hex')
+      stringToBytes(message),
+      hexToBytes(signature),
+      hexToBytes(address)
     );
     if (!ok) {
       return reply.code(401).send({ error: 'invalid_signature' });


### PR DESCRIPTION
## Summary
- use TonWeb for TON authentication verification and hex conversions
- generate test signatures via TonWeb utils for consistency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aae040f9788326bb1494f5255c1a67