### PR TITLE
feat(auth): validate TON verify payload

### DIFF
--- a/server/auth/__tests__/ton.spec.ts
+++ b/server/auth/__tests__/ton.spec.ts
@@ -1,4 +1,5 @@
 import fastify from 'fastify';
+import type { FastifyInstance } from 'fastify';
 import cookie from '@fastify/cookie';
 import tonAuth, { composeMessage } from '../ton';
 import * as nacl from 'tweetnacl';
@@ -8,7 +9,7 @@ function toHex(buf: Uint8Array): string {
 }
 
 describe('TON auth', () => {
-  let app: any;
+  let app: FastifyInstance;
   let keypair: nacl.SignKeyPair;
 
   beforeEach(async () => {
@@ -25,7 +26,8 @@ describe('TON auth', () => {
 
   test('rejects replayed challenges', async () => {
     const start = await app.inject({ method: 'POST', url: '/auth/ton/start' });
-    const { challenge } = start.json();
+    const { challenge, ttl } = start.json();
+    expect(ttl).toBe(120);
     const scopes = ['read'];
     const msg = composeMessage(challenge, scopes);
     const sig = toHex(nacl.sign.detached(Buffer.from(msg), keypair.secretKey));
@@ -37,18 +39,28 @@ describe('TON auth', () => {
     };
     const first = await app.inject({ method: 'POST', url: '/auth/ton/verify', payload });
     expect(first.statusCode).toBe(200);
-    expect(first.cookies.find((c: any) => c.name === 'sid')).toBeDefined();
+    expect(first.cookies.find((c) => c.name === 'sid')).toBeDefined();
     const second = await app.inject({ method: 'POST', url: '/auth/ton/verify', payload });
     expect(second.statusCode).toBe(400);
+  });
+
+  test('rejects invalid payload', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/ton/verify',
+      payload: { address: 'bad' },
+    });
+    expect(res.statusCode).toBe(400);
   });
 
   test('rejects expired challenge', async () => {
     const start = await app.inject({ method: 'POST', url: '/auth/ton/start' });
     const { challenge, ttl } = start.json();
+    expect(ttl).toBe(120);
     const originalNow = Date.now;
     const now = originalNow();
     // simulate expiration
-    // @ts-ignore
+    // @ts-expect-error: override Date.now for test
     Date.now = () => now + (ttl + 1) * 1000;
     const msg = composeMessage(challenge, []);
     const sig = toHex(nacl.sign.detached(Buffer.from(msg), keypair.secretKey));

--- a/server/auth/ton.ts
+++ b/server/auth/ton.ts
@@ -2,8 +2,9 @@ import type { FastifyPluginAsync } from 'fastify';
 import * as jwt from 'jsonwebtoken';
 import { nanoid } from 'nanoid';
 import * as nacl from 'tweetnacl';
+import { z } from 'zod';
 
-const CHALLENGE_TTL = 300; // seconds
+const CHALLENGE_TTL = 120; // seconds
 const JWT_SECRET = process.env.JWT_SECRET || 'secret';
 
 export function composeMessage(
@@ -14,6 +15,15 @@ export function composeMessage(
 ): string {
   return [challenge, sessionPubKey || '', exp ? String(exp) : '', scopes.join(',')].join('|');
 }
+
+const verifySchema = z.object({
+  address: z.string(),
+  signature: z.string(),
+  challenge: z.string(),
+  sessionPubKey: z.string().optional(),
+  exp: z.number().optional(),
+  scopes: z.array(z.string()).default([]),
+});
 
 const plugin: FastifyPluginAsync = async (fastify) => {
   const challenges = new Map<string, number>();
@@ -26,15 +36,11 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   });
 
   fastify.post('/auth/ton/verify', async (req, reply) => {
-    const { address, signature, challenge, sessionPubKey, scopes = [], exp } =
-      req.body as {
-        address: string;
-        signature: string;
-        challenge: string;
-        sessionPubKey?: string;
-        scopes?: string[];
-        exp?: number;
-      };
+    const body = verifySchema.safeParse(req.body);
+    if (!body.success) {
+      return reply.code(400).send({ error: 'invalid_payload' });
+    }
+    const { address, signature, challenge, sessionPubKey, scopes, exp } = body.data;
 
     const expiresAt = challenges.get(challenge);
     if (!expiresAt) {
@@ -58,7 +64,10 @@ const plugin: FastifyPluginAsync = async (fastify) => {
 
     const now = Math.floor(Date.now() / 1000);
     let tokenExp = now + 24 * 60 * 60; // default 24h
-    const payload: any = { sub: address, scopes };
+    const payload: { sub: string; scopes: string[]; session?: string } = {
+      sub: address,
+      scopes,
+    };
 
     if (sessionPubKey) {
       if (!exp || exp > Date.now() + 60 * 60 * 1000) {


### PR DESCRIPTION
## Summary
- shorten TON auth challenge TTL to 120 seconds
- validate TON verify payload with zod and reject invalid bodies
- test TON auth for TTL, invalid payloads, and replay protection

## Testing
- `npx eslint server/auth/ton.ts server/auth/__tests__/ton.spec.ts`
- `npm test server/auth/__tests__/ton.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aae04418a4832696eaed6e7105d85e