### PR TITLE
refactor: replace HUD arrow with chevron

### DIFF
--- a/src/components/chat/ChatDrawer.tsx
+++ b/src/components/chat/ChatDrawer.tsx
@@ -58,14 +58,20 @@ export function ChatDrawer() {
 
   return (
     <>
-      <button
-        aria-label={open ? 'Collapse chat' : 'Expand chat'}
-        aria-expanded={open}
-        onClick={() => setOpen((v) => !v)}
-        className={cn('drawer-grabber', open && 'open')}
+      <div
+        className="pointer-events-none fixed right-3 bottom-[calc(var(--chatbar-h)+var(--gap-h)+var(--safe-area-bottom)+var(--chat-drawer-h))] z-[var(--z-hud)]"
       >
-        <ChevronUp className="drawer-grabber-icon" />
-      </button>
+        <button
+          aria-label={open ? 'Collapse chat' : 'Expand chat'}
+          aria-expanded={open}
+          onClick={() => setOpen((v) => !v)}
+          className="absolute-center pointer-events-auto p-2 rounded-full bg-gray-800 focus-visible:ring transition duration-200"
+        >
+          <ChevronUp
+            className={cn('transition-transform duration-200', open && 'rotate-180')}
+          />
+        </button>
+      </div>
       <div
         ref={drawerRef}
         className={cn('chat-drawer glass-maple', open && 'open')}

--- a/src/game/hud/HUDBar.tsx
+++ b/src/game/hud/HUDBar.tsx
@@ -36,16 +36,18 @@ export default function HUDBar() {
     <div className="pointer-events-auto fixed inset-x-0 bottom-0 z-[var(--z-hud)]">
       {/* HUD shelf with divider line */}
       <div className="relative w-full" style={{ height: 'var(--hud-h)' }}>
-        <button
-          type="button"
-          aria-label="Toggle HUD"
-          aria-expanded={expanded}
-          onClick={toggle}
-          onKeyDown={onKeyToggle}
-          className="hud-toggle absolute right-0 top-1/2 -translate-y-1/2 rounded-full p-2 bg-white/10 hover:bg-white/20 transition-transform duration-200"
-        >
-          <ChevronDown className={`transition-transform duration-200 ${expanded ? '' : 'rotate-180'}`} />
-        </button>
+        <div className="pointer-events-none absolute right-0 top-1/2 -translate-y-1/2 translate-x-full z-10">
+          <button
+            type="button"
+            aria-label="Toggle HUD"
+            aria-expanded={expanded}
+            onClick={toggle}
+            onKeyDown={onKeyToggle}
+            className="hud-toggle absolute-center pointer-events-auto p-2 rounded-full bg-gray-800 focus-visible:ring transition duration-200"
+          >
+            <ChevronDown className={`transition-transform duration-200 ${expanded ? '' : 'rotate-180'}`} />
+          </button>
+        </div>
         <div className="absolute top-0 left-0 right-0 h-px bg-border/80" role="separator" aria-hidden />
         <div className={`absolute inset-x-0 bottom-2 flex justify-center pb-safe transition-transform duration-200 ${expanded ? 'translate-y-0' : 'translate-y-full'}`}
         >

--- a/src/index.css
+++ b/src/index.css
@@ -227,6 +227,13 @@ All colors MUST be HSL.
     pointer-events: none;
     background-color: hsl(var(--background));
   }
+
+  .absolute-center {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
 }
 
 /* Subtle animated glow for active focus card */
@@ -539,27 +546,6 @@ All colors MUST be HSL.
 .room-agent { --primary: 290 70% 60%; --accent: 290 70% 60%; }
 
 /* Chat drawer and HUD grabbers */
-.drawer-grabber {
-  position: fixed;
-  left: 0;
-  right: 0;
-  bottom: calc(var(--chatbar-h) + var(--gap-h) + var(--safe-area-bottom));
-  height: 24px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  pointer-events: auto;
-  z-index: var(--z-hud);
-}
-.drawer-grabber-icon {
-  width: 20px;
-  height: 20px;
-  color: hsl(var(--foreground) / 0.6);
-  transition: transform 0.2s ease;
-}
-.drawer-grabber.open .drawer-grabber-icon {
-  transform: rotate(180deg);
-}
 .chat-drawer {
   position: fixed;
   left: 12px;


### PR DESCRIPTION
## Summary
- anchor HUD toggle chevron on panel edge with pointer-event-safe wrapper
- add `absolute-center` utility and apply new Tailwind styling
- anchor chat drawer chevron outside quick-action hitboxes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aae0863efc8326b9b1874c30bcf8b4