### PR TITLE
feat(auth): enforce hourly token rotation

### DIFF
--- a/server/auth/__tests__/ton.spec.ts
+++ b/server/auth/__tests__/ton.spec.ts
@@ -1,10 +1,9 @@
 import fastify from 'fastify';
 import type { FastifyInstance } from 'fastify';
 import cookie from '@fastify/cookie';
+import { jwtVerify } from 'jose';
 import tonAuth, { composeMessage } from '../ton';
-// TonWeb is CommonJS; require to access utils in Jest environment
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const TonWeb = require('tonweb');
+import TonWeb from 'tonweb';
 const { nacl, bytesToHex, stringToBytes } = TonWeb.utils;
 
 
@@ -50,6 +49,10 @@ describe('TON auth', () => {
     const { payload: tokenPayload } = await jwtVerify(tokenCookie.value, secretBytes);
     expect(tokenPayload.sub).toBe(toHex(keypair.publicKey));
     expect(tokenPayload.scopes).toEqual(scopes);
+    // token expiration is capped at one hour
+    expect(tokenPayload.exp).toBeLessThanOrEqual(
+      Math.floor(Date.now() / 1000) + 60 * 60
+    );
     const second = await app.inject({ method: 'POST', url: '/auth/ton/verify', payload });
     expect(second.statusCode).toBe(400);
   });
@@ -105,5 +108,93 @@ describe('TON auth', () => {
       },
     });
     expect(res.statusCode).toBe(401);
+  });
+
+  test('rotates short-lived tokens', async () => {
+    const start1 = await app.inject({ method: 'POST', url: '/auth/ton/start' });
+    const { challenge: ch1 } = start1.json();
+    const msg1 = composeMessage(ch1, []);
+    const sig1 = toHex(nacl.sign.detached(stringToBytes(msg1), keypair.secretKey));
+    const first = await app.inject({
+      method: 'POST',
+      url: '/auth/ton/verify',
+      payload: {
+        address: toHex(keypair.publicKey),
+        challenge: ch1,
+        scopes: [],
+        signature: sig1,
+      },
+    });
+    const t1 = first.cookies.find((c: any) => c.name === 'sid');
+    const { payload: p1 } = await jwtVerify(t1.value, secretBytes);
+
+    const start2 = await app.inject({ method: 'POST', url: '/auth/ton/start' });
+    const { challenge: ch2 } = start2.json();
+    const msg2 = composeMessage(ch2, []);
+    const sig2 = toHex(nacl.sign.detached(stringToBytes(msg2), keypair.secretKey));
+    const second = await app.inject({
+      method: 'POST',
+      url: '/auth/ton/verify',
+      payload: {
+        address: toHex(keypair.publicKey),
+        challenge: ch2,
+        scopes: [],
+        signature: sig2,
+      },
+    });
+    const t2 = second.cookies.find((c: any) => c.name === 'sid');
+    const { payload: p2 } = await jwtVerify(t2.value, secretBytes);
+    // second token should have a later expiry, proving rotation
+    expect(p2.exp).toBeGreaterThan(p1.exp);
+    expect(p2.exp).toBeLessThanOrEqual(Math.floor(Date.now() / 1000) + 60 * 60);
+  });
+
+  test('includes session key expiration in token', async () => {
+    const start = await app.inject({ method: 'POST', url: '/auth/ton/start' });
+    const { challenge } = start.json();
+    const session = toHex(nacl.sign.keyPair().publicKey);
+    const exp = Date.now() + 10 * 60 * 1000; // 10 minutes
+    const msg = composeMessage(challenge, [], session, exp);
+    const sig = toHex(nacl.sign.detached(stringToBytes(msg), keypair.secretKey));
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/ton/verify',
+      payload: {
+        address: toHex(keypair.publicKey),
+        challenge,
+        sessionPubKey: session,
+        exp,
+        scopes: [],
+        signature: sig,
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const tokenCookie = res.cookies.find((c: any) => c.name === 'sid');
+    const { payload } = await jwtVerify(tokenCookie.value, secretBytes);
+    expect(payload.session).toBe(session);
+    expect(payload.sessionExp).toBe(Math.floor(exp / 1000));
+    expect(payload.exp).toBeLessThanOrEqual(payload.sessionExp);
+  });
+
+  test('rejects session key exp over one hour', async () => {
+    const start = await app.inject({ method: 'POST', url: '/auth/ton/start' });
+    const { challenge } = start.json();
+    const session = toHex(nacl.sign.keyPair().publicKey);
+    const exp = Date.now() + 2 * 60 * 60 * 1000; // 2 hours
+    const msg = composeMessage(challenge, [], session, exp);
+    const sig = toHex(nacl.sign.detached(stringToBytes(msg), keypair.secretKey));
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/ton/verify',
+      payload: {
+        address: toHex(keypair.publicKey),
+        challenge,
+        sessionPubKey: session,
+        exp,
+        scopes: [],
+        signature: sig,
+      },
+    });
+    expect(res.statusCode).toBe(400);
   });
 });

--- a/server/auth/ton.ts
+++ b/server/auth/ton.ts
@@ -1,6 +1,7 @@
 import type { FastifyPluginAsync } from 'fastify';
 import { SignJWT } from 'jose';
 import { nanoid } from 'nanoid';
+import { z } from 'zod';
 
 import * as TonWeb from 'tonweb';
 
@@ -66,20 +67,29 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     }
 
     const now = Math.floor(Date.now() / 1000);
-    let tokenExp = now + 24 * 60 * 60; // default 24h
-    const payload: { sub: string; scopes: string[]; session?: string } = {
+    let tokenExp = now + 60 * 60; // rotate tokens every hour
+    const payload: {
+      sub: string;
+      scopes: string[];
+      session?: string;
+      sessionExp?: number;
+    } = {
       sub: address,
       scopes,
     };
 
     if (sessionPubKey) {
+      // session key must expire within one hour
       if (!exp || exp > Date.now() + 60 * 60 * 1000) {
         return reply.code(400).send({ error: 'invalid_grant_exp' });
       }
       payload.session = sessionPubKey;
-      tokenExp = Math.min(Math.floor(exp / 1000), now + 60 * 60);
+      payload.sessionExp = Math.floor(exp / 1000);
+      // token cannot outlive the session key
+      tokenExp = Math.min(tokenExp, payload.sessionExp);
     }
 
+    // a fresh JWT is issued for every verification to force rotation
     const token = await new SignJWT(payload)
       .setProtectedHeader({ alg: 'HS256' })
       .setExpirationTime(tokenExp)


### PR DESCRIPTION
## Summary
- ensure JWTs always expire within one hour
- embed session public key expiry and rotate token each verification
- document token rotation logic in tests

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npm test server/auth/__tests__/ton.spec.ts` *(fails: status 500 during tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aae32eae208326b894382a429b18fb