### PR TITLE
test(auth): cover TON signature verification

### DIFF
--- a/server/auth/__tests__/ton.spec.ts
+++ b/server/auth/__tests__/ton.spec.ts
@@ -1,11 +1,11 @@
 import fastify from 'fastify';
 import type { FastifyInstance } from 'fastify';
 import cookie from '@fastify/cookie';
+import { jwtVerify } from 'jose';
 import tonAuth, { composeMessage } from '../ton';
-// TonWeb is CommonJS; require to access utils in Jest environment
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const TonWeb = require('tonweb');
-const { nacl, bytesToHex, stringToBytes } = TonWeb.utils;
+let nacl: any;
+let bytesToHex: any;
+let stringToBytes: any;
 
 
 function toHex(buf: Uint8Array): string {
@@ -14,8 +14,14 @@ function toHex(buf: Uint8Array): string {
 
 describe('TON auth', () => {
   let app: FastifyInstance;
-  let keypair: nacl.SignKeyPair;
+  let keypair: any;
   const secretBytes = new TextEncoder().encode('secret');
+
+  beforeAll(async () => {
+    const TonWeb = await import('tonweb');
+    const utils = (TonWeb as any).utils || (TonWeb as any).default.utils;
+    ({ nacl, bytesToHex, stringToBytes } = utils);
+  });
 
   beforeEach(async () => {
     app = fastify();
@@ -29,27 +35,65 @@ describe('TON auth', () => {
     await app.close();
   });
 
-  test('rejects replayed challenges', async () => {
+  test('accepts valid signature and sets cookie', async () => {
     const start = await app.inject({ method: 'POST', url: '/auth/ton/start' });
     const { challenge, ttl } = start.json();
     expect(ttl).toBe(120);
     const scopes = ['read'];
     const msg = composeMessage(challenge, scopes);
     const sig = toHex(nacl.sign.detached(stringToBytes(msg), keypair.secretKey));
-    const payload = {
-      address: toHex(keypair.publicKey),
-      challenge,
-      scopes,
-      signature: sig,
-    };
-    const first = await app.inject({ method: 'POST', url: '/auth/ton/verify', payload });
-    expect(first.statusCode).toBe(200);
-
-    const tokenCookie = first.cookies.find((c: any) => c.name === 'sid');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/ton/verify',
+      payload: {
+        address: toHex(keypair.publicKey),
+        challenge,
+        scopes,
+        signature: sig,
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const tokenCookie = res.cookies.find((c: any) => c.name === 'sid');
     expect(tokenCookie).toBeDefined();
     const { payload: tokenPayload } = await jwtVerify(tokenCookie.value, secretBytes);
     expect(tokenPayload.sub).toBe(toHex(keypair.publicKey));
     expect(tokenPayload.scopes).toEqual(scopes);
+  });
+
+  test('rejects invalid signature', async () => {
+    const start = await app.inject({ method: 'POST', url: '/auth/ton/start' });
+    const { challenge } = start.json();
+    const wrongMsg = composeMessage('wrong', []);
+    const wrongSig = toHex(
+      nacl.sign.detached(stringToBytes(wrongMsg), keypair.secretKey)
+    );
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/ton/verify',
+      payload: {
+        address: toHex(keypair.publicKey),
+        challenge,
+        scopes: [],
+        signature: wrongSig,
+      },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('rejects replayed challenges', async () => {
+    const start = await app.inject({ method: 'POST', url: '/auth/ton/start' });
+    const { challenge, ttl } = start.json();
+    expect(ttl).toBe(120);
+    const msg = composeMessage(challenge, []);
+    const sig = toHex(nacl.sign.detached(stringToBytes(msg), keypair.secretKey));
+    const payload = {
+      address: toHex(keypair.publicKey),
+      challenge,
+      scopes: [],
+      signature: sig,
+    };
+    const first = await app.inject({ method: 'POST', url: '/auth/ton/verify', payload });
+    expect(first.statusCode).toBe(200);
     const second = await app.inject({ method: 'POST', url: '/auth/ton/verify', payload });
     expect(second.statusCode).toBe(400);
   });

--- a/server/auth/ton.ts
+++ b/server/auth/ton.ts
@@ -1,8 +1,9 @@
 import type { FastifyPluginAsync } from 'fastify';
 import { SignJWT } from 'jose';
 import { nanoid } from 'nanoid';
+import { z } from 'zod';
 
-import * as TonWeb from 'tonweb';
+import TonWeb from 'tonweb';
 
 
 const CHALLENGE_TTL = 120; // seconds


### PR DESCRIPTION
## Summary
- test TON auth happy path sets cookie and validates JWT
- test invalid signature returns 401
- fix TON auth plugin imports for zod and TonWeb

## Testing
- `node --experimental-vm-modules node_modules/jest/bin/jest.js server/auth/__tests__/ton.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aae406b8a88326ab8d765c815c740e