### PR TITLE
Set secure flag on sid cookie

### DIFF
--- a/server/auth/__tests__/ton.spec.ts
+++ b/server/auth/__tests__/ton.spec.ts
@@ -1,9 +1,10 @@
 import fastify from 'fastify';
 import type { FastifyInstance } from 'fastify';
 import cookie from '@fastify/cookie';
+import { jwtVerify } from 'jose';
 import tonAuth, { composeMessage } from '../ton';
-// TonWeb is CommonJS; require to access utils in Jest environment
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
 const TonWeb = require('tonweb');
 const { nacl, bytesToHex, stringToBytes } = TonWeb.utils;
 
@@ -18,7 +19,7 @@ describe('TON auth', () => {
   const secretBytes = new TextEncoder().encode('secret');
 
   beforeEach(async () => {
-    app = fastify();
+    app = fastify({ trustProxy: true });
     await app.register(cookie);
     await app.register(tonAuth);
     await app.ready();
@@ -27,6 +28,57 @@ describe('TON auth', () => {
 
   afterEach(async () => {
     await app.close();
+  });
+
+  test('sets cookie attributes over HTTP', async () => {
+    const start = await app.inject({ method: 'POST', url: '/auth/ton/start' });
+    const { challenge } = start.json();
+    const scopes = ['read'];
+    const msg = composeMessage(challenge, scopes);
+    const sig = toHex(nacl.sign.detached(stringToBytes(msg), keypair.secretKey));
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/ton/verify',
+      payload: {
+        address: toHex(keypair.publicKey),
+        challenge,
+        scopes,
+        signature: sig,
+      },
+      protocol: 'http',
+    });
+    expect(res.statusCode).toBe(200);
+    const cookie = res.cookies.find((c: any) => c.name === 'sid');
+    expect(cookie).toBeDefined();
+    expect(cookie.httpOnly).toBe(true);
+    expect(cookie.sameSite).toBe('Lax');
+    expect(cookie.secure).toBeUndefined();
+  });
+
+  test('sets secure cookie over HTTPS', async () => {
+    const start = await app.inject({ method: 'POST', url: '/auth/ton/start' });
+    const { challenge } = start.json();
+    const scopes = ['read'];
+    const msg = composeMessage(challenge, scopes);
+    const sig = toHex(nacl.sign.detached(stringToBytes(msg), keypair.secretKey));
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/ton/verify',
+      payload: {
+        address: toHex(keypair.publicKey),
+        challenge,
+        scopes,
+        signature: sig,
+      },
+      protocol: 'https',
+      headers: { 'x-forwarded-proto': 'https' },
+    });
+    expect(res.statusCode).toBe(200);
+    const cookie = res.cookies.find((c: any) => c.name === 'sid');
+    expect(cookie).toBeDefined();
+    expect(cookie.httpOnly).toBe(true);
+    expect(cookie.sameSite).toBe('Lax');
+    expect(cookie.secure).toBe(true);
   });
 
   test('rejects replayed challenges', async () => {

--- a/server/auth/ton.ts
+++ b/server/auth/ton.ts
@@ -1,8 +1,11 @@
 import type { FastifyPluginAsync } from 'fastify';
 import { SignJWT } from 'jose';
 import { nanoid } from 'nanoid';
+import { z } from 'zod';
 
-import * as TonWeb from 'tonweb';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const TonWeb = require('tonweb');
 
 
 const CHALLENGE_TTL = 120; // seconds
@@ -87,6 +90,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     reply.setCookie('sid', token, {
       httpOnly: true,
       sameSite: 'lax',
+      secure: req.protocol === 'https',
       path: '/',
     });
     return reply.send({ ok: true });


### PR DESCRIPTION
## Summary
- set `sid` cookie `secure` flag based on request protocol
- test cookie attributes for HTTP vs HTTPS authentication flows

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npm test server/auth/__tests__/ton.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aae402b4188326bc060cb65bfb721d