### PR TITLE
Implement TON wallet auth helper with session refresh

### DIFF
--- a/src/components/auth/AuthMenu.tsx
+++ b/src/components/auth/AuthMenu.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { useTonAuth } from "@/hooks/useTonAuth";
 
 export function AuthMenu() {
-  const { address, disconnect } = useTonAuth();
+  const { address, logout } = useTonAuth();
 
   if (!address) {
     return (
@@ -21,7 +21,7 @@ export function AuthMenu() {
   return (
     <div className="flex items-center gap-2">
       <span className="text-xs text-muted-foreground max-w-[160px] truncate">{short}</span>
-      <Button variant="softPrimary" size="sm" onClick={disconnect}>Disconnect</Button>
+      <Button variant="softPrimary" size="sm" onClick={logout}>Disconnect</Button>
     </div>
   );
 }

--- a/src/hooks/useTonAuth.ts
+++ b/src/hooks/useTonAuth.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { TonConnectUI } from "@tonconnect/ui";
 
 // Create a single TonConnectUI instance for the app
@@ -6,8 +6,19 @@ export const connector = new TonConnectUI({
   manifestUrl: "/tonconnect-manifest.json",
 });
 
+function composeMessage(
+  challenge: string,
+  scopes: string[] = [],
+  sessionPubKey?: string,
+  exp?: number
+): string {
+  return [challenge, sessionPubKey || "", exp ? String(exp) : "", scopes.join(",")].join("|");
+}
+
 export function useTonAuth() {
   const [address, setAddress] = useState<string | null>(null);
+  const refreshTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     const unsubscribe = connector.onStatusChange((wallet) => {
@@ -16,9 +27,50 @@ export function useTonAuth() {
     return unsubscribe;
   }, []);
 
-  const disconnect = async () => {
-    await connector.disconnect();
+  const signAndVerify = async (scopes: string[] = []) => {
+    const res = await fetch("/auth/ton/start", { method: "POST" });
+    const { challenge } = await res.json();
+    const message = composeMessage(challenge, scopes);
+    const { signature, address: addr } = await connector.signData({
+      type: "text",
+      text: message,
+    });
+    await fetch("/auth/ton/verify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ address: addr, signature, challenge, scopes }),
+    });
+    setAddress(addr);
   };
 
-  return { address, disconnect };
+  const login = async (scopes: string[] = []) => {
+    setLoading(true);
+    try {
+      if (!connector.wallet) {
+        await connector.connectWallet();
+      }
+      await signAndVerify(scopes);
+      if (refreshTimer.current) clearInterval(refreshTimer.current);
+      refreshTimer.current = setInterval(() => {
+        signAndVerify(scopes).catch(() => {
+          /* ignore refresh errors */
+        });
+      }, 50 * 60 * 1000); // refresh roughly every 50 minutes
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const logout = async () => {
+    try {
+      await fetch("/auth/logout", { method: "POST" });
+    } finally {
+      if (refreshTimer.current) clearInterval(refreshTimer.current);
+      await connector.disconnect();
+      setAddress(null);
+    }
+  };
+
+  return { address, login, logout, loading };
 }
+

--- a/src/hooks/useTonSession.ts
+++ b/src/hooks/useTonSession.ts
@@ -2,44 +2,15 @@ import { useEffect, useState } from "react";
 import { useTonAuth } from "./useTonAuth";
 
 export function useTonSession() {
-  const { address, disconnect } = useTonAuth();
-  const [token, setToken] = useState<string | null>(null);
+  const { address, logout } = useTonAuth();
   const [initializing, setInitializing] = useState(true);
 
   useEffect(() => {
-    const init = async () => {
-      if (!address) {
-        setToken(null);
-        setInitializing(false);
-        return;
-      }
-      try {
-        const res = await fetch("/auth/session");
-        if (res.ok) {
-          const data = await res.json().catch(() => ({ token: null }));
-          setToken(data.token ?? null);
-        } else {
-          setToken(null);
-        }
-      } catch {
-        setToken(null);
-      } finally {
-        setInitializing(false);
-      }
-    };
-    init();
+    setInitializing(false);
   }, [address]);
 
-  const logout = async () => {
-    try {
-      await fetch("/auth/logout", { method: "POST" });
-    } finally {
-      await disconnect();
-      setToken(null);
-    }
-  };
-
   const user = address ? { id: address, email: address } : null;
-  return { user, token, initializing, logout };
+  return { user, token: null, initializing, logout };
 }
+
 

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,13 +1,12 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { useTonAuth, connector } from "@/hooks/useTonAuth";
+import { useTonAuth } from "@/hooks/useTonAuth";
 
 const AuthPage = () => {
-  const { address } = useTonAuth();
+  const { address, login, loading } = useTonAuth();
   const navigate = useNavigate();
-  const [isConnecting, setIsConnecting] = useState(false);
 
   useEffect(() => {
     if (address) {
@@ -16,12 +15,7 @@ const AuthPage = () => {
   }, [address, navigate]);
 
   const connect = async () => {
-    setIsConnecting(true);
-    try {
-      await connector.connectWallet();
-    } finally {
-      setIsConnecting(false);
-    }
+    await login();
   };
 
   return (
@@ -33,7 +27,7 @@ const AuthPage = () => {
           <p className="text-sm text-muted-foreground">Use your TON wallet to sign in.</p>
         </div>
         <div className="flex justify-center">
-          {isConnecting ? (
+          {loading ? (
             <p className="text-sm text-muted-foreground">Connecting...</p>
           ) : (
             <Button onClick={connect}>Connect TON Wallet</Button>


### PR DESCRIPTION
## Summary
- add `useTonAuth` hook to sign TON challenges, verify with backend, and refresh session tokens
- update auth page and menu to login/logout with server session
- simplify session hook to rely on server-issued cookie

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export' in jose)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf322bcd48326ad29ac7423d72fc7