### PR TITLE
feat: add secret-sharing key recovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "recharts": "^2.15.4",
     "sonner": "^1.7.4",
     "sql.js": "^1.13.0",
+    "secrets.js-grempe": "^2.0.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "three": "^0.179.1",

--- a/src/components/settings/KeyRecoveryPanel.tsx
+++ b/src/components/settings/KeyRecoveryPanel.tsx
@@ -1,0 +1,149 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { toast } from '@/hooks/use-toast';
+import { generateKeyShards, restoreKeyFromShards } from '@/state/keyManager';
+
+async function encryptShare(share: string, passphrase: string, address: string): Promise<string> {
+  const enc = new TextEncoder();
+  const keyMaterial = await crypto.subtle.digest('SHA-256', enc.encode(passphrase + address));
+  const key = await crypto.subtle.importKey('raw', keyMaterial, 'AES-GCM', false, ['encrypt']);
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const data = enc.encode(share);
+  const encrypted = new Uint8Array(await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, data));
+  const out = new Uint8Array(iv.length + encrypted.length);
+  out.set(iv, 0);
+  out.set(encrypted, iv.length);
+  return btoa(String.fromCharCode(...out));
+}
+
+async function decryptShare(payload: string, passphrase: string, address: string): Promise<string> {
+  const raw = Uint8Array.from(atob(payload), c => c.charCodeAt(0));
+  const iv = raw.slice(0, 12);
+  const data = raw.slice(12);
+  const enc = new TextEncoder();
+  const keyMaterial = await crypto.subtle.digest('SHA-256', enc.encode(passphrase + address));
+  const key = await crypto.subtle.importKey('raw', keyMaterial, 'AES-GCM', false, ['decrypt']);
+  const decrypted = new Uint8Array(await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, data));
+  return new TextDecoder().decode(decrypted);
+}
+
+export default function KeyRecoveryPanel() {
+  const [guardianList, setGuardianList] = useState('');
+  const [threshold, setThreshold] = useState(2);
+  const [passphrase, setPassphrase] = useState('');
+  const [generated, setGenerated] = useState<string[] | null>(null);
+  const [restorePass, setRestorePass] = useState('');
+  const [restoreShares, setRestoreShares] = useState('');
+
+  const generate = async () => {
+    const guardians = guardianList.split('\n').map(s => s.trim()).filter(Boolean);
+    if (!guardians.length) {
+      toast({ title: 'No guardians', description: 'Enter guardian wallet addresses.' });
+      return;
+    }
+    if (!passphrase) {
+      toast({ title: 'Passphrase required', description: 'Set an encryption passphrase.' });
+      return;
+    }
+    try {
+      const shards = generateKeyShards(guardians.length, threshold);
+      const encrypted = await Promise.all(guardians.map((g, i) => encryptShare(shards[i], passphrase, g)));
+      localStorage.setItem('recovery.data', JSON.stringify({ threshold, guardians, shares: encrypted }));
+      setGenerated(shards);
+      toast({ title: 'Shards generated', description: 'Distribute the shards to guardians.' });
+    } catch (e) {
+      toast({ title: 'Generation failed', description: String(e) });
+    }
+  };
+
+  const loadSaved = async () => {
+    try {
+      const raw = localStorage.getItem('recovery.data');
+      if (!raw) {
+        toast({ title: 'No recovery data', description: 'Generate shards first.' });
+        return;
+      }
+      const { guardians, shares } = JSON.parse(raw) as { guardians: string[]; shares: string[] };
+      const dec = await Promise.all(guardians.map((g, i) => decryptShare(shares[i], restorePass, g)));
+      setRestoreShares(dec.join('\n'));
+    } catch (e) {
+      toast({ title: 'Load failed', description: String(e) });
+    }
+  };
+
+  const restore = () => {
+    const shards = restoreShares.split('\n').map(s => s.trim()).filter(Boolean);
+    const stored = localStorage.getItem('recovery.data');
+    const required = stored ? (JSON.parse(stored).threshold as number) : 2;
+    if (shards.length < required) {
+      toast({ title: 'Not enough shards', description: `Need at least ${required}.` });
+      return;
+    }
+    try {
+      const key = restoreKeyFromShards(shards);
+      if (key) {
+        toast({ title: 'Key restored', description: 'Data key has been reconstructed.' });
+      }
+    } catch (e) {
+      toast({ title: 'Restore failed', description: String(e) });
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-semibold">Key Recovery</h2>
+      <div className="space-y-2 max-w-sm">
+        <Label htmlFor="guardian-list">Guardian Wallets</Label>
+        <Textarea
+          id="guardian-list"
+          value={guardianList}
+          onChange={e => setGuardianList(e.target.value)}
+          placeholder="wallet1\nwallet2"
+        />
+        <Label htmlFor="threshold">Threshold</Label>
+        <Input
+          id="threshold"
+          type="number"
+          min={1}
+          value={threshold}
+          onChange={e => setThreshold(parseInt(e.target.value, 10))}
+        />
+        <Label htmlFor="passphrase">Encryption Passphrase</Label>
+        <Input
+          id="passphrase"
+          type="password"
+          value={passphrase}
+          onChange={e => setPassphrase(e.target.value)}
+        />
+        <Button variant="outline" onClick={generate}>Generate Shards</Button>
+      </div>
+      {generated && (
+        <div className="space-y-2 max-w-sm">
+          <Label>Generated Shares</Label>
+          <Textarea readOnly value={generated.join('\n')} />
+        </div>
+      )}
+      <div className="space-y-2 max-w-sm pt-4">
+        <Label htmlFor="restore-pass">Restore Passphrase</Label>
+        <Input
+          id="restore-pass"
+          type="password"
+          value={restorePass}
+          onChange={e => setRestorePass(e.target.value)}
+        />
+        <Button variant="outline" onClick={loadSaved}>Load Encrypted Shares</Button>
+        <Label htmlFor="restore-shares">Shares</Label>
+        <Textarea
+          id="restore-shares"
+          value={restoreShares}
+          onChange={e => setRestoreShares(e.target.value)}
+          placeholder="Paste shares here"
+        />
+        <Button onClick={restore}>Restore Key</Button>
+      </div>
+    </div>
+  );
+}

--- a/src/state/keyManager.ts
+++ b/src/state/keyManager.ts
@@ -1,3 +1,5 @@
+import secrets from 'secrets.js-grempe';
+
 let dataKey: Uint8Array | undefined;
 let resolveKey: ((key: Uint8Array) => void) | undefined;
 const dataKeyPromise = new Promise<Uint8Array>((resolve) => {
@@ -26,6 +28,20 @@ function decodeSignedMessage(message: string): Uint8Array {
   } catch {
     throw new Error('Invalid signed message format');
   }
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16);
+  }
+  return bytes;
 }
 
 export function setDataKey(key: Uint8Array) {
@@ -71,5 +87,20 @@ export function waitForDataKey(): Promise<Uint8Array> {
     return Promise.resolve(dataKey);
   }
   return dataKeyPromise;
+}
+
+export function generateKeyShards(total: number, threshold: number): string[] {
+  if (!dataKey) {
+    throw new Error('No data key set');
+  }
+  const hex = bytesToHex(dataKey);
+  return secrets.share(hex, total, threshold);
+}
+
+export function restoreKeyFromShards(shards: string[]): Uint8Array {
+  const hex = secrets.combine(shards);
+  const key = hexToBytes(hex);
+  setDataKey(key);
+  return key;
 }
 

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -18,6 +18,7 @@ import ModelPanel from "@/components/settings/ModelPanel";
 import DataSourcesPanel from "@/components/settings/DataSourcesPanel";
 import MemoryPanel from "@/components/settings/MemoryPanel";
 import BrainBackupPanel from "@/components/settings/BrainBackupPanel";
+import KeyRecoveryPanel from "@/components/settings/KeyRecoveryPanel";
 import ApiCallLogPanel from "@/components/settings/ApiCallLogPanel";
 import FeatureFlagsPanel from "@/components/settings/FeatureFlagsPanel";
 import DeviceManagerPanel from "@/components/settings/DeviceManagerPanel";
@@ -115,6 +116,7 @@ export default function SettingsView() {
             <TriggersPanel />
             <ModelPanel />
             <BrainBackupPanel />
+            <KeyRecoveryPanel />
             <MemoryPanel />
             <DeviceManagerPanel />
             <ApiCallLogPanel />


### PR DESCRIPTION
## Summary
- support secret sharing for data key in key manager
- allow generating encrypted key shards and restoring key from settings
- add dependency for secret sharing library

## Testing
- `npm test` *(fails: SyntaxError in server tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aafadd6c9483269194c73b27029dec