### PR TITLE
refactor: update rxdb encryption plugin and tailwind duration

### DIFF
--- a/src/components/navigation/BottomDock.tsx
+++ b/src/components/navigation/BottomDock.tsx
@@ -55,7 +55,7 @@ export default function BottomDock() {
       ref={ref}
       className={cn(
         "fixed left-0 right-0 mx-3 select-none",
-        "transition-[transform,opacity] duration-[250ms] ease-in-out",
+        "transition-[transform,opacity] duration-300 ease-in-out",
         expanded ? "pb-3" : "pb-2"
       )}
       style={{
@@ -86,7 +86,7 @@ export default function BottomDock() {
 
           <div
             className={cn(
-              "grid overflow-hidden transition-[max-height,opacity] duration-[250ms] ease-in-out",
+              "grid overflow-hidden transition-[max-height,opacity] duration-300 ease-in-out",
               expanded ? "max-h-40 opacity-100 mb-2" : "max-h-0 opacity-0 mb-0"
             )}
           >

--- a/src/data/db.ts
+++ b/src/data/db.ts
@@ -6,7 +6,7 @@ import {
   type RxJsonSchema,
 } from "rxdb";
 import { RxDBAttachmentsPlugin } from "rxdb/plugins/attachments";
-import { RxDBEncryptionPlugin } from "rxdb/plugins/encryption-crypto-js";
+import { wrappedKeyEncryptionCryptoJsStorage } from "rxdb/plugins/encryption-crypto-js";
 import { getRxStorageDexie } from "rxdb/plugins/storage-dexie";
 import type { Observable } from "rxjs";
 import { getDataKey } from "@/state/keyManager";
@@ -194,7 +194,6 @@ export type Collections = {
 };
 
 addRxPlugin(RxDBAttachmentsPlugin);
-addRxPlugin(RxDBEncryptionPlugin);
 
 let dbPromise: Promise<RxDatabase<Collections>> | null = null;
 
@@ -203,9 +202,12 @@ async function getDatabase(): Promise<RxDatabase<Collections>> {
     const key = getDataKey();
     if (!key) throw new Error("Data key not set");
     const password = btoa(String.fromCharCode(...key));
+    const storage = wrappedKeyEncryptionCryptoJsStorage({
+      storage: getRxStorageDexie(),
+    });
     dbPromise = createRxDatabase<Collections>({
       name: "brain",
-      storage: getRxStorageDexie(),
+      storage,
       password,
     }).then(async (db) => {
       await db.addCollections({


### PR DESCRIPTION
## Summary
- wrap Dexie storage with RxDB crypto-js encryption
- standardize Tailwind transition duration to 300ms

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68aaea5a618083268b57fb9921b02f45