### PR TITLE
feat: add server NFT asset pinning and CID registry

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,25 @@
+// [AURORA-BEGIN:server-entry]
+import Fastify from 'fastify';
+import cookie from '@fastify/cookie';
+
+import authTon from './auth/ton';
+import replicate from './replicate';
+import nftAssets from './nft/assets';
+
+const server = Fastify({ logger: true });
+
+async function build() {
+  await server.register(cookie);
+  await server.register(authTon);
+  await server.register(replicate);
+  await server.register(nftAssets);
+}
+
+build();
+
+const port = Number(process.env.PORT) || 3000;
+server.listen({ port, host: '0.0.0.0' }).catch((err) => {
+  server.log.error(err);
+  process.exit(1);
+});
+// [AURORA-END:server-entry]

--- a/server/nft/assets.ts
+++ b/server/nft/assets.ts
@@ -1,0 +1,100 @@
+// [AURORA-BEGIN:asset-routes]
+import type { FastifyPluginAsync } from 'fastify';
+import multipart from '@fastify/multipart';
+import { z } from 'zod';
+import { RateLimiterMemory } from 'rate-limiter-flexible';
+import { jwtVerify } from 'jose';
+
+import { pinFile, pinJSON, ipfsUri } from '../utils/pinata';
+import { setCidForKey, listAllAssets, AssetKey } from '../utils/cid-registry';
+
+const plugin: FastifyPluginAsync = async (fastify) => {
+  await fastify.register(multipart, { limits: { fileSize: 1.5 * 1024 * 1024 } });
+
+  // [AURORA-BEGIN:asset-security]
+  const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+  const JWT_SECRET_BYTES = new TextEncoder().encode(JWT_SECRET);
+  const rateLimiter = new RateLimiterMemory({ points: 10, duration: 60 });
+
+  async function requireAdmin(req: any, reply: any) {
+    const token = req.cookies?.sid;
+    if (!token) {
+      reply.code(401).send({ error: 'missing_token' });
+      return null;
+    }
+    try {
+      const { payload }: any = await jwtVerify(token, JWT_SECRET_BYTES);
+      if (!Array.isArray(payload.scopes) || !payload.scopes.includes('nft:admin')) {
+        reply.code(403).send({ error: 'insufficient_scope' });
+        return null;
+      }
+      try {
+        await rateLimiter.consume(payload.sub);
+      } catch {
+        reply.code(429).send({ error: 'rate_limited' });
+        return null;
+      }
+      return payload;
+    } catch {
+      reply.code(401).send({ error: 'invalid_token' });
+      return null;
+    }
+  }
+  // [AURORA-END:asset-security]
+
+  function isValidKey(key: string): key is AssetKey {
+    return key === 'auroraid/base' || key === 'seasonpass/base' || key.startsWith('badge/');
+  }
+
+  fastify.get('/nft/assets', async (req, reply) => {
+    const auth = await requireAdmin(req, reply);
+    if (!auth) return;
+    const list = await listAllAssets();
+    return reply.send(list.map((a) => ({ ...a, uri: ipfsUri(a.cid) })));
+  });
+
+  fastify.post('/nft/assets/pin-file', async (req, reply) => {
+    const auth = await requireAdmin(req, reply);
+    if (!auth) return;
+
+    const parts = req.parts();
+    let file: any = null;
+    let key: string | undefined;
+    for await (const part of parts) {
+      if (part.type === 'file' && part.fieldname === 'file') file = part;
+      if (part.type === 'field' && part.fieldname === 'key') key = part.value;
+    }
+    if (!file || !key || !isValidKey(key)) {
+      return reply.code(400).send({ error: 'invalid_payload' });
+    }
+    if (!['image/png', 'image/svg+xml'].includes(file.mimetype)) {
+      return reply.code(400).send({ error: 'invalid_mime' });
+    }
+    const buf = await file.toBuffer();
+    if (buf.byteLength > 1.5 * 1024 * 1024) {
+      return reply.code(400).send({ error: 'file_too_large' });
+    }
+    const cid = await pinFile(key, buf, file.mimetype);
+    await setCidForKey(key as AssetKey, cid);
+    return reply.send({ key, cid, uri: ipfsUri(cid) });
+  });
+
+  fastify.post('/nft/assets/pin-svg', async (req, reply) => {
+    const auth = await requireAdmin(req, reply);
+    if (!auth) return;
+    const body = z.object({ key: z.string(), svg: z.string() }).safeParse(req.body);
+    if (!body.success || !isValidKey(body.data.key)) {
+      return reply.code(400).send({ error: 'invalid_payload' });
+    }
+    const { key, svg } = body.data;
+    if (svg.toLowerCase().includes('<script') || Buffer.byteLength(svg, 'utf8') > 200 * 1024) {
+      return reply.code(400).send({ error: 'invalid_svg' });
+    }
+    const cid = await pinJSON(key, { svg });
+    await setCidForKey(key as AssetKey, cid);
+    return reply.send({ key, cid, uri: ipfsUri(cid) });
+  });
+};
+
+export default plugin;
+// [AURORA-END:asset-routes]

--- a/server/utils/cid-registry.ts
+++ b/server/utils/cid-registry.ts
@@ -1,0 +1,51 @@
+// [AURORA-BEGIN:cid-registry]
+import fetch from 'node-fetch';
+
+const couchUrl = process.env.COUCH_URL || 'http://localhost:5984';
+const dbName = process.env.COUCH_DB_ASSETS || 'assets';
+const dbUrl = `${couchUrl}/${dbName}`;
+
+async function ensureDb() {
+  const res = await fetch(dbUrl, { method: 'HEAD' });
+  if (res.status === 404) {
+    await fetch(dbUrl, { method: 'PUT' });
+  }
+}
+ensureDb();
+
+export type AssetKey = 'auroraid/base' | 'seasonpass/base' | `badge/${string}`;
+
+export async function getCidForKey(key: AssetKey): Promise<string | undefined> {
+  const res = await fetch(`${dbUrl}/${encodeURIComponent(key)}`);
+  if (res.status === 200) {
+    const json: any = await res.json();
+    return json.cid as string;
+  }
+  return undefined;
+}
+
+export async function setCidForKey(key: AssetKey, cid: string) {
+  const now = new Date().toISOString();
+  const docUrl = `${dbUrl}/${encodeURIComponent(key)}`;
+  const existing = await fetch(docUrl);
+  let rev: string | undefined;
+  if (existing.status === 200) {
+    const doc: any = await existing.json();
+    rev = doc._rev;
+  }
+  await fetch(docUrl, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ _id: key, cid, updatedAt: now, ...(rev ? { _rev: rev } : {}) }),
+  });
+}
+
+export async function listAllAssets(): Promise<Array<{ key: string; cid: string; updatedAt: string }>> {
+  const res = await fetch(`${dbUrl}/_all_docs?include_docs=true`);
+  if (!res.ok) return [];
+  const json: any = await res.json();
+  return json.rows
+    .filter((r: any) => r.doc)
+    .map((r: any) => ({ key: r.doc._id, cid: r.doc.cid, updatedAt: r.doc.updatedAt }));
+}
+// [AURORA-END:cid-registry]

--- a/server/utils/pinata.ts
+++ b/server/utils/pinata.ts
@@ -1,0 +1,40 @@
+// [AURORA-BEGIN:pinata-util]
+import fetch from 'node-fetch';
+import FormData from 'form-data';
+
+const PINATA_JWT = process.env.PINATA_JWT!;
+
+export async function pinFile(name: string, data: Buffer, mime: string) {
+  const form = new FormData();
+  form.append('file', data, { filename: name, contentType: mime });
+  const res = await fetch('https://api.pinata.cloud/pinning/pinFileToIPFS', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${PINATA_JWT}` },
+    body: form as any,
+  });
+  if (!res.ok) {
+    throw new Error('pinFile failed');
+  }
+  const json: any = await res.json();
+  return json.IpfsHash as string;
+}
+
+export async function pinJSON(name: string, json: any) {
+  const res = await fetch('https://api.pinata.cloud/pinning/pinJSONToIPFS', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      Authorization: `Bearer ${PINATA_JWT}`,
+    },
+    body: JSON.stringify({ pinataMetadata: { name }, pinataContent: json }),
+  });
+  if (!res.ok) {
+    throw new Error('pinJSON failed');
+  }
+  const body = await res.json();
+  return body.IpfsHash as string;
+}
+
+export const ipfsUri = (cid: string) => `ipfs://${cid}`;
+export const ipfsGateway = (cid: string) => `${process.env.IPFS_GATEWAY || 'https://gateway.pinata.cloud/ipfs'}/${cid}`;
+// [AURORA-END:pinata-util]


### PR DESCRIPTION
## Summary
- add Pinata helpers for pinning files/JSON to IPFS and building ipfs:// URIs
- introduce CouchDB-based CID registry to store asset mappings
- implement admin-only NFT asset routes with scope checks and rate limiting
- register new NFT asset plugin in Fastify server entry

## Testing
- `npm test` *(fails: Jest encountered unexpected token in server tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ab00817944832695e8d9e52e675295