### PR TITLE
feat: add server NFT asset pinning and metadata endpoint

### DIFF
--- a/app/studio/nft/page.tsx
+++ b/app/studio/nft/page.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { useToast } from '@/components/ui/use-toast';
+import { useTonAuth } from '@/hooks/useTonAuth';
+
+const adminWallets = (process.env.NEXT_PUBLIC_ADMIN_WALLETS || process.env.ADMIN_WALLETS || '')
+  .split(',')
+  .map(w => w.trim().toLowerCase())
+  .filter(Boolean);
+const ipfsGateway = (cid: string) => `${process.env.NEXT_PUBLIC_IPFS_GATEWAY || 'https://gateway.pinata.cloud/ipfs'}/${cid}`;
+
+interface Asset { key: string; cid: string; updatedAt: string }
+// [AURORA-BEGIN:studio-ui]
+interface AssetCardProps {
+  label: string;
+  assetKey: string;
+  cid?: string;
+  onFile: (key: string, file: File | null) => void;
+  onSvg: (key: string, svg: string) => void;
+}
+
+function AssetCard({ label, assetKey, cid, onFile, onSvg }: AssetCardProps) {
+  const [svg, setSvg] = useState('');
+  const fileRef = useRef<HTMLInputElement>(null);
+  return (
+    <Card className="mb-4">
+      <CardHeader>
+        <CardTitle>{label}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {cid && <img src={ipfsGateway(cid)} alt={assetKey} className="h-32 w-32 object-contain" />}
+        <div className="text-xs break-all">{cid || 'No CID'}</div>
+        <Input
+          ref={fileRef}
+          type="file"
+          accept="image/png,image/svg+xml"
+          className="hidden"
+          onChange={e => onFile(assetKey, e.target.files?.[0] || null)}
+        />
+        <Button onClick={() => fileRef.current?.click()}>Upload PNG/SVG</Button>
+        <Textarea
+          placeholder="<svg ... />"
+          value={svg}
+          onChange={e => setSvg(e.target.value)}
+        />
+        <Button onClick={() => onSvg(assetKey, svg)}>Pin SVG</Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function NFTAssetStudioPage() {
+  const { address, login } = useTonAuth();
+  const { toast } = useToast();
+  const [assets, setAssets] = useState<Asset[]>([]);
+  const [authorized, setAuthorized] = useState(false);
+  const [badgeKeys, setBadgeKeys] = useState<string[]>(['first_journal', 'streak_7', 'focus_5']);
+  const [newBadge, setNewBadge] = useState('');
+
+  const refreshAssets = async () => {
+    const res = await fetch('/nft/assets', { credentials: 'include' });
+    if (!res.ok) throw new Error('unauthorized');
+    const data = await res.json();
+    setAssets(data);
+  };
+
+  useEffect(() => {
+    if (!address) return;
+    const isAdmin = adminWallets.includes(address.toLowerCase());
+    if (isAdmin) {
+      setAuthorized(true);
+      refreshAssets().catch(() => {});
+    } else {
+      refreshAssets()
+        .then(() => setAuthorized(true))
+        .catch(() => setAuthorized(false));
+    }
+  }, [address]);
+
+  const handleFile = async (key: string, file: File | null) => {
+    if (!file) return;
+    const form = new FormData();
+    form.append('key', key);
+    form.append('file', file);
+    const res = await fetch('/nft/assets/pin-file', { method: 'POST', body: form });
+    if (res.ok) {
+      toast({ title: 'Pinned', description: key });
+      await refreshAssets();
+    } else {
+      toast({ title: 'Pin failed', description: key, variant: 'destructive' });
+    }
+  };
+
+  const handleSvg = async (key: string, svg: string) => {
+    const res = await fetch('/nft/assets/pin-svg', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key, svg }),
+    });
+    if (res.ok) {
+      toast({ title: 'Pinned', description: key });
+      await refreshAssets();
+    } else {
+      toast({ title: 'Pin failed', description: key, variant: 'destructive' });
+    }
+  };
+
+  const addBadge = () => {
+    const k = newBadge.trim();
+    if (k && !badgeKeys.includes(k)) setBadgeKeys([...badgeKeys, k]);
+    setNewBadge('');
+  };
+
+  if (!address) {
+    return (
+      <div className="p-4">
+        <Button onClick={() => login(['nft:admin'])}>Connect Admin Wallet</Button>
+      </div>
+    );
+  }
+  if (!authorized) {
+    return <div className="p-4">Not authorized</div>;
+  }
+
+  const getCid = (key: string) => assets.find(a => a.key === key)?.cid;
+
+  return (
+    <div className="p-4 space-y-6">
+      <AssetCard label="AuroraID" assetKey="auroraid/base" cid={getCid('auroraid/base')} onFile={handleFile} onSvg={handleSvg} />
+      <AssetCard label="Season Pass" assetKey="seasonpass/base" cid={getCid('seasonpass/base')} onFile={handleFile} onSvg={handleSvg} />
+      <Card>
+        <CardHeader>
+          <CardTitle>Badges</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {badgeKeys.map(bk => (
+            <AssetCard key={bk} label={bk} assetKey={`badge/${bk}`} cid={getCid(`badge/${bk}`)} onFile={handleFile} onSvg={handleSvg} />
+          ))}
+          <div className="flex space-x-2">
+            <Input value={newBadge} onChange={e => setNewBadge(e.target.value)} placeholder="new badge key" />
+            <Button onClick={addBadge}>Add badge key</Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+// [AURORA-END:studio-ui]
+

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,27 @@
+// [AURORA-BEGIN:server-entry]
+import Fastify from 'fastify';
+import cookie from '@fastify/cookie';
+
+import authTon from './auth/ton';
+import replicate from './replicate';
+import nftAssets from './nft/assets';
+import nftMetadata from './nft/metadata';
+
+const server = Fastify({ logger: true });
+
+async function build() {
+  await server.register(cookie);
+  await server.register(authTon);
+  await server.register(replicate);
+  await server.register(nftAssets);
+  await server.register(nftMetadata);
+}
+
+build();
+
+const port = Number(process.env.PORT) || 3000;
+server.listen({ port, host: '0.0.0.0' }).catch((err) => {
+  server.log.error(err);
+  process.exit(1);
+});
+// [AURORA-END:server-entry]

--- a/server/nft/assets.ts
+++ b/server/nft/assets.ts
@@ -1,0 +1,100 @@
+// [AURORA-BEGIN:asset-routes]
+import type { FastifyPluginAsync } from 'fastify';
+import multipart from '@fastify/multipart';
+import { z } from 'zod';
+import { RateLimiterMemory } from 'rate-limiter-flexible';
+import { jwtVerify } from 'jose';
+
+import { pinFile, pinJSON, ipfsUri } from '../utils/pinata';
+import { setCidForKey, listAllAssets, AssetKey } from '../utils/cid-registry';
+
+const plugin: FastifyPluginAsync = async (fastify) => {
+  await fastify.register(multipart, { limits: { fileSize: 1.5 * 1024 * 1024 } });
+
+  // [AURORA-BEGIN:asset-security]
+  const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+  const JWT_SECRET_BYTES = new TextEncoder().encode(JWT_SECRET);
+  const rateLimiter = new RateLimiterMemory({ points: 10, duration: 60 });
+
+  async function requireAdmin(req: any, reply: any) {
+    const token = req.cookies?.sid;
+    if (!token) {
+      reply.code(401).send({ error: 'missing_token' });
+      return null;
+    }
+    try {
+      const { payload }: any = await jwtVerify(token, JWT_SECRET_BYTES);
+      if (!Array.isArray(payload.scopes) || !payload.scopes.includes('nft:admin')) {
+        reply.code(403).send({ error: 'insufficient_scope' });
+        return null;
+      }
+      try {
+        await rateLimiter.consume(payload.sub);
+      } catch {
+        reply.code(429).send({ error: 'rate_limited' });
+        return null;
+      }
+      return payload;
+    } catch {
+      reply.code(401).send({ error: 'invalid_token' });
+      return null;
+    }
+  }
+  // [AURORA-END:asset-security]
+
+  function isValidKey(key: string): key is AssetKey {
+    return key === 'auroraid/base' || key === 'seasonpass/base' || key.startsWith('badge/');
+  }
+
+  fastify.get('/nft/assets', async (req, reply) => {
+    const auth = await requireAdmin(req, reply);
+    if (!auth) return;
+    const list = await listAllAssets();
+    return reply.send(list.map((a) => ({ ...a, uri: ipfsUri(a.cid) })));
+  });
+
+  fastify.post('/nft/assets/pin-file', async (req, reply) => {
+    const auth = await requireAdmin(req, reply);
+    if (!auth) return;
+
+    const parts = req.parts();
+    let file: any = null;
+    let key: string | undefined;
+    for await (const part of parts) {
+      if (part.type === 'file' && part.fieldname === 'file') file = part;
+      if (part.type === 'field' && part.fieldname === 'key') key = part.value;
+    }
+    if (!file || !key || !isValidKey(key)) {
+      return reply.code(400).send({ error: 'invalid_payload' });
+    }
+    if (!['image/png', 'image/svg+xml'].includes(file.mimetype)) {
+      return reply.code(400).send({ error: 'invalid_mime' });
+    }
+    const buf = await file.toBuffer();
+    if (buf.byteLength > 1.5 * 1024 * 1024) {
+      return reply.code(400).send({ error: 'file_too_large' });
+    }
+    const cid = await pinFile(key, buf, file.mimetype);
+    await setCidForKey(key as AssetKey, cid);
+    return reply.send({ key, cid, uri: ipfsUri(cid) });
+  });
+
+  fastify.post('/nft/assets/pin-svg', async (req, reply) => {
+    const auth = await requireAdmin(req, reply);
+    if (!auth) return;
+    const body = z.object({ key: z.string(), svg: z.string() }).safeParse(req.body);
+    if (!body.success || !isValidKey(body.data.key)) {
+      return reply.code(400).send({ error: 'invalid_payload' });
+    }
+    const { key, svg } = body.data;
+    if (svg.toLowerCase().includes('<script') || Buffer.byteLength(svg, 'utf8') > 200 * 1024) {
+      return reply.code(400).send({ error: 'invalid_svg' });
+    }
+    const cid = await pinJSON(key, { svg });
+    await setCidForKey(key as AssetKey, cid);
+    return reply.send({ key, cid, uri: ipfsUri(cid) });
+  });
+};
+
+export default plugin;
+// [AURORA-END:asset-routes]

--- a/server/nft/metadata.ts
+++ b/server/nft/metadata.ts
@@ -1,0 +1,85 @@
+// [AURORA-BEGIN:metadata-hybrid]
+import type { FastifyPluginAsync } from 'fastify';
+import { z } from 'zod';
+import { createHash } from 'crypto';
+import fetch from 'node-fetch';
+
+import { getCidForKey, AssetKey } from '../utils/cid-registry';
+import { ipfsUri } from '../utils/pinata';
+
+async function fetchStats(wallet: string) {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const apiKey = process.env.SUPABASE_SERVICE_KEY || process.env.SUPABASE_ANON_KEY;
+  let xp = 0;
+  let streakDays = 0;
+  let goalsCompleted = 0;
+  let updatedAt = new Date().toISOString();
+  if (supabaseUrl && apiKey) {
+    try {
+      const res = await fetch(`${supabaseUrl}/rest/v1/user_stats?user_id=eq.${wallet}`, {
+        headers: {
+          apikey: apiKey,
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+      });
+      if (res.ok) {
+        const json: any = await res.json();
+        const row = json[0];
+        if (row) {
+          xp = row.total_xp ?? 0;
+          streakDays = row.streak_count ?? 0;
+          goalsCompleted = row.goals_completed ?? 0;
+          updatedAt = row.updated_at || updatedAt;
+        }
+      }
+    } catch {}
+  }
+  return { xp, streakDays, goalsCompleted, updatedAt };
+}
+
+const plugin: FastifyPluginAsync = async (fastify) => {
+  fastify.get('/nft/metadata/:kind/:tokenId', async (req, reply) => {
+    const params = z
+      .object({ kind: z.enum(['auroraid', 'seasonpass', 'badge']), tokenId: z.string() })
+      .safeParse(req.params);
+    if (!params.success) {
+      return reply.code(400).send({ error: 'invalid_params' });
+    }
+    const { kind, tokenId } = params.data;
+    let key: AssetKey;
+    if (kind === 'auroraid') key = 'auroraid/base';
+    else if (kind === 'seasonpass') key = 'seasonpass/base';
+    else key = `badge/${tokenId}`;
+
+    const cid = await getCidForKey(key);
+    if (!cid) {
+      return reply.code(404).send({ error: 'asset_not_found' });
+    }
+
+    const stats = await fetchStats(tokenId);
+    const attributes = [
+      { trait_type: 'XP', value: stats.xp },
+      { trait_type: 'Streak Days', value: stats.streakDays },
+      { trait_type: 'Goals Completed', value: stats.goalsCompleted },
+    ];
+    const etag = createHash('sha1').update(JSON.stringify(attributes)).digest('hex');
+    reply.header('ETag', etag);
+    reply.header('Cache-Control', 'public, max-age=300');
+
+    const name =
+      kind === 'badge' ? `Badge ${tokenId}` : kind === 'seasonpass' ? 'Season Pass' : 'AuroraID';
+    const description = `Aurora ${kind}`;
+    return {
+      name,
+      description,
+      image: ipfsUri(cid),
+      external_url: process.env.APP_ORIGIN || '',
+      attributes,
+      updatedAt: stats.updatedAt,
+    };
+  });
+};
+
+export default plugin;
+// [AURORA-END:metadata-hybrid]

--- a/server/utils/cid-registry.ts
+++ b/server/utils/cid-registry.ts
@@ -1,0 +1,51 @@
+// [AURORA-BEGIN:cid-registry]
+import fetch from 'node-fetch';
+
+const couchUrl = process.env.COUCH_URL || 'http://localhost:5984';
+const dbName = process.env.COUCH_DB_ASSETS || 'assets';
+const dbUrl = `${couchUrl}/${dbName}`;
+
+async function ensureDb() {
+  const res = await fetch(dbUrl, { method: 'HEAD' });
+  if (res.status === 404) {
+    await fetch(dbUrl, { method: 'PUT' });
+  }
+}
+ensureDb();
+
+export type AssetKey = 'auroraid/base' | 'seasonpass/base' | `badge/${string}`;
+
+export async function getCidForKey(key: AssetKey): Promise<string | undefined> {
+  const res = await fetch(`${dbUrl}/${encodeURIComponent(key)}`);
+  if (res.status === 200) {
+    const json: any = await res.json();
+    return json.cid as string;
+  }
+  return undefined;
+}
+
+export async function setCidForKey(key: AssetKey, cid: string) {
+  const now = new Date().toISOString();
+  const docUrl = `${dbUrl}/${encodeURIComponent(key)}`;
+  const existing = await fetch(docUrl);
+  let rev: string | undefined;
+  if (existing.status === 200) {
+    const doc: any = await existing.json();
+    rev = doc._rev;
+  }
+  await fetch(docUrl, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ _id: key, cid, updatedAt: now, ...(rev ? { _rev: rev } : {}) }),
+  });
+}
+
+export async function listAllAssets(): Promise<Array<{ key: string; cid: string; updatedAt: string }>> {
+  const res = await fetch(`${dbUrl}/_all_docs?include_docs=true`);
+  if (!res.ok) return [];
+  const json: any = await res.json();
+  return json.rows
+    .filter((r: any) => r.doc)
+    .map((r: any) => ({ key: r.doc._id, cid: r.doc.cid, updatedAt: r.doc.updatedAt }));
+}
+// [AURORA-END:cid-registry]

--- a/server/utils/pinata.ts
+++ b/server/utils/pinata.ts
@@ -1,0 +1,40 @@
+// [AURORA-BEGIN:pinata-util]
+import fetch from 'node-fetch';
+import FormData from 'form-data';
+
+const PINATA_JWT = process.env.PINATA_JWT!;
+
+export async function pinFile(name: string, data: Buffer, mime: string) {
+  const form = new FormData();
+  form.append('file', data, { filename: name, contentType: mime });
+  const res = await fetch('https://api.pinata.cloud/pinning/pinFileToIPFS', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${PINATA_JWT}` },
+    body: form as any,
+  });
+  if (!res.ok) {
+    throw new Error('pinFile failed');
+  }
+  const json: any = await res.json();
+  return json.IpfsHash as string;
+}
+
+export async function pinJSON(name: string, json: any) {
+  const res = await fetch('https://api.pinata.cloud/pinning/pinJSONToIPFS', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      Authorization: `Bearer ${PINATA_JWT}`,
+    },
+    body: JSON.stringify({ pinataMetadata: { name }, pinataContent: json }),
+  });
+  if (!res.ok) {
+    throw new Error('pinJSON failed');
+  }
+  const body = await res.json();
+  return body.IpfsHash as string;
+}
+
+export const ipfsUri = (cid: string) => `ipfs://${cid}`;
+export const ipfsGateway = (cid: string) => `${process.env.IPFS_GATEWAY || 'https://gateway.pinata.cloud/ipfs'}/${cid}`;
+// [AURORA-END:pinata-util]


### PR DESCRIPTION
## Summary
- add Pinata helpers for pinning files/JSON to IPFS and building ipfs:// URIs
- introduce CouchDB-based CID registry to store asset mappings
- implement admin-only NFT asset routes with scope checks and rate limiting
- register new NFT asset plugin in Fastify server entry
- add NFT Asset Studio admin page for uploading and managing IPFS asset CIDs
- expose /nft/metadata/:kind/:tokenId for IPFS image links and live attributes with ETag caching

## Testing
- `npm test` *(fails: Jest encountered unexpected token in server/auth/__tests__/ton.spec.ts and server/replicate/__tests__/replicate.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ab00817944832695e8d9e52e675295