### PR TITLE
feat: add visual seed helpers

### DIFF
--- a/src/visual/seed.ts
+++ b/src/visual/seed.ts
@@ -1,0 +1,36 @@
+// [AURORA-BEGIN:visual-seed]
+export type SeedParams = {
+  wallet: string;
+  personaTone: string;
+  createdAt: string | number | Date;
+};
+
+function hashString(str: string): number {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) {
+    h = Math.imul(31, h) + str.charCodeAt(i);
+  }
+  return h >>> 0;
+}
+
+export function makeSeed({ wallet, personaTone, createdAt }: SeedParams): number {
+  const ts = new Date(createdAt).toISOString();
+  return hashString(`${wallet}|${personaTone}|${ts}`);
+}
+
+function mulberry32(a: number) {
+  return function () {
+    let t = (a += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), 1 | t);
+    t ^= t + Math.imul(t ^ (t >>> 7), 61 | t);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function paletteFromSeed(params: SeedParams): string[] {
+  const seed = makeSeed(params);
+  const rand = mulberry32(seed);
+  const baseHue = Math.floor(rand() * 360);
+  return Array.from({ length: 5 }, (_, i) => `hsl(${(baseHue + i * 72) % 360} 70% 50%)`);
+}
+// [AURORA-END:visual-seed]


### PR DESCRIPTION
## Summary
- add visual seed utils to derive palette from wallet, personaTone, and createdAt

## Testing
- `npm test` (fails: Jest encountered an unexpected token in server tests)
- `npm run lint` (fails: 272 errors)

------
https://chatgpt.com/codex/tasks/task_e_68ab07b47e0083268a62c146d4890d9e