### PR TITLE
feat: compose identity scene

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,8 @@
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "three": "^0.179.1",
+    "@react-three/postprocessing": "^3.0.4",
+    "postprocessing": "^6.37.7",
     "tonweb": "^0.0.66",
     "ts-node": "^10.9.2",
     "tweetnacl": "^1.0.3",

--- a/src/three/ComposedIdentityScene.tsx
+++ b/src/three/ComposedIdentityScene.tsx
@@ -1,0 +1,47 @@
+// [AURORA-BEGIN:three-identity]
+import { useMemo } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { EffectComposer, Bloom, FXAA } from '@react-three/postprocessing';
+import { AuroraSphere, AuroraMood } from '@/components/avatar/AuroraSphere';
+import HoloBrain from './HoloBrain';
+import { makeSeed, paletteFromSeed } from '@/visual/seed';
+
+export interface ComposedIdentitySceneProps {
+  xp: number;
+  streak: number;
+  mood: AuroraMood;
+}
+
+export function ComposedIdentityScene({ xp, streak, mood }: ComposedIdentitySceneProps) {
+  const seedParams = useMemo(
+    () => ({ wallet: String(xp), personaTone: mood, createdAt: streak }),
+    [xp, streak, mood]
+  );
+  const seed = useMemo(() => makeSeed(seedParams), [seedParams]);
+  const palette = useMemo(() => paletteFromSeed(seedParams), [seedParams]);
+
+  const level = Math.floor(xp / 100) + 1;
+  const xpPct = xp % 100;
+  const pulse = 1 + streak * 0.1;
+  const particles = Math.min(500 + xp, 2000);
+  const color = palette[0];
+
+  return (
+    <div className="relative w-full h-full">
+      <Canvas className="absolute inset-0" camera={{ position: [0, 0, 4], fov: 60 }}>
+        <ambientLight intensity={0.4} />
+        <HoloBrain seed={seed} color={color} pulse={pulse} particles={particles} />
+        <EffectComposer disableNormalPass>
+          <Bloom luminanceThreshold={0.2} intensity={0.8} />
+          <FXAA />
+        </EffectComposer>
+      </Canvas>
+      <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+        <AuroraSphere level={level} xpPct={xpPct} mood={mood} size={220} />
+      </div>
+    </div>
+  );
+}
+
+export default ComposedIdentityScene;
+// [AURORA-END:three-identity]


### PR DESCRIPTION
## Summary
- add ComposedIdentityScene that blends AuroraSphere and HoloBrain with seed-based palette
- include Bloom and FXAA postprocessing
- depend on @react-three/postprocessing and postprocessing

## Testing
- `npm test` *(fails: SyntaxError in server/auth/__tests__/ton.spec.ts, SyntaxError in server/replicate/__tests__/replicate.spec.ts)*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9ac399088326a59700eeebb4dc24