### PR TITLE
feat: add identity viewer page

### DIFF
--- a/app/view/identity/page.tsx
+++ b/app/view/identity/page.tsx
@@ -1,0 +1,34 @@
+// [AURORA-BEGIN:identity-viewer]
+"use client";
+
+import { useEffect, useState } from "react";
+import ComposedIdentityScene from "@/components/identity/ComposedIdentityScene";
+import { supabase } from "@/integrations/supabase/client";
+import { useTonSession } from "@/hooks/useTonSession";
+
+export default function IdentityPage() {
+  const { user } = useTonSession();
+  const [stats, setStats] = useState<any | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      if (!user) return;
+      try {
+        const { data } = await supabase
+          .from("user_stats")
+          .select("*")
+          .eq("user_id", user.id)
+          .maybeSingle();
+        setStats(data ?? null);
+      } catch (e) {
+        console.error("[identity] failed to load stats", e);
+        setStats(null);
+      }
+    })();
+  }, [user]);
+
+  if (!stats) return null;
+
+  return <ComposedIdentityScene stats={stats} />;
+}
+// [AURORA-END:identity-viewer]


### PR DESCRIPTION
## Summary
- add identity viewer route loading user stats and rendering the composed scene

## Testing
- `npm test` *(fails: SyntaxError in server/auth/__tests__/ton.spec.ts and server/replicate/__tests__/replicate.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9bab6f0883268db62e1f67aa0ee7