### PR TITLE
feat: add visual xp and streak events

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -573,3 +573,21 @@ All colors MUST be HSL.
   right: 0;
   bottom: auto;
 }
+
+/* // [AURORA-BEGIN:visual-css] */
+.xp-pulse {
+  animation: xp-pulse 1s var(--ease-standard) forwards;
+}
+@keyframes xp-pulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.15); }
+}
+
+.streak-flash {
+  animation: streak-flash 0.8s var(--ease-standard) forwards;
+}
+@keyframes streak-flash {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+/* // [AURORA-END:visual-css] */

--- a/src/integrations/supabase/gameSync.ts
+++ b/src/integrations/supabase/gameSync.ts
@@ -33,6 +33,14 @@ export async function awardXPRemote(activity: string, amount: number, metadata: 
     const streak = first?.streak_count;
     if (typeof total === "number") {
       window.dispatchEvent(new CustomEvent("xp-total-update", { detail: { total_xp: total, streak } }));
+      window.dispatchEvent(
+        new CustomEvent("xp-awarded", { detail: { activity, amount, total } })
+      );
+    }
+    if (typeof streak === "number") {
+      window.dispatchEvent(
+        new CustomEvent("streak-progress", { detail: { streak } })
+      );
     }
   } catch (e) {
     logger.warn("[gameSync] xp-total-update event failed", e);

--- a/src/visual/events.ts
+++ b/src/visual/events.ts
@@ -1,0 +1,21 @@
+// [AURORA-BEGIN:visual-events]
+export type XpAwardedDetail = {
+  activity?: string;
+  amount: number;
+  total?: number;
+};
+
+export function onXpAwarded(handler: (detail: XpAwardedDetail) => void) {
+  window.addEventListener("xp-awarded", (e: Event) => {
+    const detail = (e as CustomEvent<XpAwardedDetail>).detail;
+    handler(detail);
+  });
+}
+
+export function onStreakProgress(handler: (streak: number) => void) {
+  window.addEventListener("streak-progress", (e: Event) => {
+    const detail = (e as CustomEvent<{ streak: number }>).detail;
+    handler(detail.streak);
+  });
+}
+// [AURORA-END:visual-events]


### PR DESCRIPTION
## Summary
- add visual-events utility with onXpAwarded and onStreakProgress helpers
- dispatch xp-awarded and streak-progress events from Supabase game sync
- style xp and streak updates with xp-pulse and streak-flash animations

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm test` *(fails: server auth and replicate suites parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9cf847ec8326838e5857ea9d9c51