### PR TITLE
feat: compose identity scene

### DIFF
--- a/app/view/identity/page.tsx
+++ b/app/view/identity/page.tsx
@@ -1,0 +1,10 @@
+'use client';
+import { IdentityVisualizer } from '@/three/export';
+
+export default function IdentityPage() {
+  return (
+    <div className="identity-page">
+      <IdentityVisualizer />
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -90,6 +90,8 @@
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "three": "^0.179.1",
+    "@react-three/postprocessing": "^2.15.0",
+    "postprocessing": "^6.37.7",
     "tonweb": "^0.0.66",
     "ts-node": "^10.9.2",
     "tweetnacl": "^1.0.3",

--- a/src/index.css
+++ b/src/index.css
@@ -573,3 +573,21 @@ All colors MUST be HSL.
   right: 0;
   bottom: auto;
 }
+
+/* Identity scene container */
+.identity-page {
+  position: fixed;
+  inset: 0;
+  background:
+    radial-gradient(600px 400px at 50% 0%, hsl(var(--primary) / 0.1), transparent 70%),
+    hsl(var(--background));
+  overflow: hidden;
+}
+.identity-page canvas {
+  touch-action: none;
+}
+.identity-page .overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}

--- a/src/integrations/supabase/gameSync.ts
+++ b/src/integrations/supabase/gameSync.ts
@@ -1,6 +1,7 @@
 
 import { supabase } from "@/integrations/supabase/client";
 import logger from "@/lib/logger";
+import { dispatchVisualEvent } from "@/visual/events";
 
 /**
  * Lightweight helpers to sync game actions with Supabase.
@@ -32,7 +33,7 @@ export async function awardXPRemote(activity: string, amount: number, metadata: 
     const total = first?.total_xp ?? null;
     const streak = first?.streak_count;
     if (typeof total === "number") {
-      window.dispatchEvent(new CustomEvent("xp-total-update", { detail: { total_xp: total, streak } }));
+      dispatchVisualEvent("xp-total-update", { total_xp: total, streak });
     }
   } catch (e) {
     logger.warn("[gameSync] xp-total-update event failed", e);

--- a/src/three/ComposedIdentityScene.tsx
+++ b/src/three/ComposedIdentityScene.tsx
@@ -1,0 +1,47 @@
+// [AURORA-BEGIN:three-identity]
+import { useMemo } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { EffectComposer, Bloom, FXAA } from '@react-three/postprocessing';
+import { AuroraSphere, AuroraMood } from '@/components/avatar/AuroraSphere';
+import HoloBrain from './HoloBrain';
+import { makeSeed, paletteFromSeed } from '@/visual/seed';
+
+export interface ComposedIdentitySceneProps {
+  xp: number;
+  streak: number;
+  mood: AuroraMood;
+}
+
+export function ComposedIdentityScene({ xp, streak, mood }: ComposedIdentitySceneProps) {
+  const seedParams = useMemo(
+    () => ({ wallet: String(xp), personaTone: mood, createdAt: streak }),
+    [xp, streak, mood]
+  );
+  const seed = useMemo(() => makeSeed(seedParams), [seedParams]);
+  const palette = useMemo(() => paletteFromSeed(seedParams), [seedParams]);
+
+  const level = Math.floor(xp / 100) + 1;
+  const xpPct = xp % 100;
+  const pulse = 1 + streak * 0.1;
+  const particles = Math.min(500 + xp, 2000);
+  const color = palette[0];
+
+  return (
+    <div className="relative w-full h-full">
+      <Canvas className="absolute inset-0" camera={{ position: [0, 0, 4], fov: 60 }}>
+        <ambientLight intensity={0.4} />
+        <HoloBrain seed={seed} color={color} pulse={pulse} particles={particles} />
+        <EffectComposer disableNormalPass>
+          <Bloom luminanceThreshold={0.2} intensity={0.8} />
+          <FXAA />
+        </EffectComposer>
+      </Canvas>
+      <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+        <AuroraSphere level={level} xpPct={xpPct} mood={mood} size={220} />
+      </div>
+    </div>
+  );
+}
+
+export default ComposedIdentityScene;
+// [AURORA-END:three-identity]

--- a/src/three/export.ts
+++ b/src/three/export.ts
@@ -1,0 +1,26 @@
+// [AURORA-BEGIN:three-export]
+import { useEffect, useState } from 'react';
+import { ComposedIdentityScene, ComposedIdentitySceneProps } from './ComposedIdentityScene';
+import { onVisualEvent } from '@/visual/events';
+import { useProgressStore } from '@/state/progress';
+import { useAvatarStore } from '@/state/avatar';
+import HoloBrain from './HoloBrain';
+
+export function IdentityVisualizer() {
+  const { xp, streak } = useProgressStore((s) => ({ xp: s.xp, streak: s.streak }));
+  const mood = useAvatarStore((s) => s.mood);
+  const [props, setProps] = useState<ComposedIdentitySceneProps>({ xp, streak, mood });
+
+  useEffect(() => setProps({ xp, streak, mood }), [xp, streak, mood]);
+
+  useEffect(() =>
+    onVisualEvent('xp-total-update', (e) =>
+      setProps((p) => ({ ...p, xp: e.detail.total_xp, streak: e.detail.streak ?? p.streak })),
+    ), []);
+
+  return <ComposedIdentityScene {...props} />;
+}
+
+export { ComposedIdentityScene } from './ComposedIdentityScene';
+export { default as HoloBrain } from './HoloBrain';
+// [AURORA-END:three-export]

--- a/src/visual/events.ts
+++ b/src/visual/events.ts
@@ -1,0 +1,20 @@
+export type VisualEventMap = {
+  'xp-total-update': { total_xp: number; streak?: number };
+};
+
+export type VisualEventType = keyof VisualEventMap;
+
+export function dispatchVisualEvent<K extends VisualEventType>(type: K, detail: VisualEventMap[K]) {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(type, { detail }));
+  }
+}
+
+export function onVisualEvent<K extends VisualEventType>(
+  type: K,
+  handler: (ev: CustomEvent<VisualEventMap[K]>) => void,
+) {
+  const listener = handler as EventListener;
+  window.addEventListener(type, listener);
+  return () => window.removeEventListener(type, listener);
+}


### PR DESCRIPTION
## Summary
- add visual event helpers and identity visualizer wrapper
- expose identity scene via new Next.js route and styles
- pin @react-three/postprocessing to fiber 8-compatible version

## Testing
- `npm install`
- `npm test` *(fails: Jest unexpected token in server/auth/__tests__/ton.spec.ts and server/replicate/__tests__/replicate.spec.ts)*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9ac399088326a59700eeebb4dc24