### PR TITLE
feat: add generic visual event dispatcher

### DIFF
--- a/src/visual/events.ts
+++ b/src/visual/events.ts
@@ -6,17 +6,31 @@ export type XpAwardedDetail = {
   total?: number;
 };
 
+type VisualEvents = {
+  "xp-awarded": XpAwardedDetail;
+  "streak-progress": { streak: number };
+  "xp-total-update": { total_xp: number; streak?: number };
+};
+
+export function dispatchVisualEvent<K extends keyof VisualEvents>(
+  type: K,
+  detail: VisualEvents[K],
+) {
+  window.dispatchEvent(new CustomEvent(type, { detail }));
+}
+
+export function onVisualEvent<K extends keyof VisualEvents>(
+  type: K,
+  handler: (event: CustomEvent<VisualEvents[K]>) => void,
+) {
+  window.addEventListener(type, handler as EventListener);
+}
+
 export function onXpAwarded(handler: (detail: XpAwardedDetail) => void) {
-  window.addEventListener("xp-awarded", (e: Event) => {
-    const detail = (e as CustomEvent<XpAwardedDetail>).detail;
-    handler(detail);
-  });
+  onVisualEvent("xp-awarded", (e) => handler(e.detail));
 }
 
 export function onStreakProgress(handler: (streak: number) => void) {
-  window.addEventListener("streak-progress", (e: Event) => {
-    const detail = (e as CustomEvent<{ streak: number }>).detail;
-    handler(detail.streak);
-  });
+  onVisualEvent("streak-progress", (e) => handler(e.detail.streak));
 }
 // [AURORA-END:visual-events]


### PR DESCRIPTION
## Summary
- add typed visual event map with generic dispatch and listener utilities
- use helpers to emit and handle xp and streak events

## Testing
- `npm test` *(fails: SyntaxError in jose for server/auth and server/replicate tests)*
- `npm run lint` *(fails: multiple eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68abb1374f408326bec61c9ddc16296b