### PR TITLE
Export createDatabase alias in database module

### DIFF
--- a/src/data/db.ts
+++ b/src/data/db.ts
@@ -225,6 +225,8 @@ async function getDatabase(): Promise<RxDatabase<Collections>> {
   return dbPromise;
 }
 
+export { getDatabase as createDatabase };
+
 export const db = {
   open: async () => {
     await getDatabase();


### PR DESCRIPTION
## Summary
- re-export `getDatabase` as `createDatabase` in db helper

## Testing
- `npm test` *(fails: jest not found)*
- `npx jest --version` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68abb1e163c083269c1180e4fbec12bd