### PR TITLE
Use Web Crypto RNG for secrets

### DIFF
--- a/src/state/keyManager.ts
+++ b/src/state/keyManager.ts
@@ -1,4 +1,4 @@
-import secrets from 'secrets.js-grempe';
+import secrets from 'secrets.js-grempe/lib/secrets.js';
 
 let dataKey: Uint8Array | undefined;
 let resolveKey: ((key: Uint8Array) => void) | undefined;
@@ -93,6 +93,15 @@ export function generateKeyShards(total: number, threshold: number): string[] {
   if (!dataKey) {
     throw new Error('No data key set');
   }
+  secrets.setRNG((bits: number) => {
+    const bytes = new Uint8Array(Math.ceil(bits / 8));
+    globalThis.crypto.getRandomValues(bytes);
+    let out = '';
+    for (let i = 0; i < bytes.length; i++) {
+      out += bytes[i].toString(2).padStart(8, '0');
+    }
+    return out.slice(0, bits);
+  });
   const hex = bytesToHex(dataKey);
   return secrets.share(hex, total, threshold);
 }


### PR DESCRIPTION
## Summary
- use browser build of secrets.js-grempe
- seed secrets.js with Web Crypto RNG before sharing key shards

## Testing
- `node keyManagerTest.js` (local script)
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68abbdefa2ec8326a05fcdb08976e7c7