### PR TITLE
feat: guard secrets import

### DIFF
--- a/src/components/settings/KeyRecoveryPanel.tsx
+++ b/src/components/settings/KeyRecoveryPanel.tsx
@@ -49,7 +49,7 @@ export default function KeyRecoveryPanel() {
       return;
     }
     try {
-      const shards = generateKeyShards(guardians.length, threshold);
+      const shards = await generateKeyShards(guardians.length, threshold);
       const encrypted = await Promise.all(guardians.map((g, i) => encryptShare(shards[i], passphrase, g)));
       localStorage.setItem('recovery.data', JSON.stringify({ threshold, guardians, shares: encrypted }));
       setGenerated(shards);
@@ -74,7 +74,7 @@ export default function KeyRecoveryPanel() {
     }
   };
 
-  const restore = () => {
+  const restore = async () => {
     const shards = restoreShares.split('\n').map(s => s.trim()).filter(Boolean);
     const stored = localStorage.getItem('recovery.data');
     const required = stored ? (JSON.parse(stored).threshold as number) : 2;
@@ -83,7 +83,7 @@ export default function KeyRecoveryPanel() {
       return;
     }
     try {
-      const key = restoreKeyFromShards(shards);
+      const key = await restoreKeyFromShards(shards);
       if (key) {
         toast({ title: 'Key restored', description: 'Data key has been reconstructed.' });
       }

--- a/src/state/README.md
+++ b/src/state/README.md
@@ -6,15 +6,16 @@ preferences and UI state.
 ## RNG requirement
 
 `keyManager.ts` uses [`secrets.js-grempe`](https://www.npmjs.com/package/secrets.js-grempe)
-for secret sharing. The library does not automatically use a
-cryptographically secure random number generator, so it must be
-initialized before generating key shards:
+for secret sharing. The library is loaded dynamically only in browser
+environments that expose `crypto.getRandomValues`:
 
 ```ts
-import secrets from 'secrets.js-grempe';
-secrets.init();
-secrets.setRNG('browserCryptoGetRandomValues');
+if (typeof window !== 'undefined' && globalThis.crypto?.getRandomValues) {
+  const { default: secrets } = await import('secrets.js-grempe/lib/secrets.js');
+  secrets.init();
+  secrets.setRNG('browserCryptoGetRandomValues');
+}
 ```
 
-If the RNG is not configured, shard generation will throw an error to
-avoid silently falling back to an insecure source.
+If a secure random number generator is unavailable, shard generation will
+throw an error instead of silently falling back to an insecure source.

--- a/src/state/keyManager.ts
+++ b/src/state/keyManager.ts
@@ -1,13 +1,25 @@
-import secrets from 'secrets.js-grempe/lib/secrets.js';
+let secrets: typeof import('secrets.js-grempe/lib/secrets.js').default | undefined;
 
-// secrets.js does not automatically use a CSPRNG. Initialize the library and
-// explicitly set the RNG so shard generation relies on `crypto.getRandomValues`.
-try {
-  secrets.init();
-  secrets.setRNG('browserCryptoGetRandomValues');
-} catch (err) {
-  // eslint-disable-next-line no-console
-  console.error('Failed to initialize secrets.js RNG', err);
+async function loadSecrets() {
+  if (secrets) {
+    return secrets;
+  }
+  if (typeof window !== 'undefined' && globalThis.crypto) {
+    if (typeof globalThis.crypto.getRandomValues !== 'function') {
+      throw new Error('Secure random number generator not available');
+    }
+    const module = await import('secrets.js-grempe/lib/secrets.js');
+    secrets = module.default;
+    try {
+      secrets.init();
+      secrets.setRNG('browserCryptoGetRandomValues');
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to initialize secrets.js RNG', err);
+    }
+    return secrets;
+  }
+  throw new Error('Secure random number generator not available');
 }
 
 let dataKey: Uint8Array | undefined;
@@ -99,16 +111,20 @@ export function waitForDataKey(): Promise<Uint8Array> {
   return dataKeyPromise;
 }
 
-export function generateKeyShards(total: number, threshold: number): string[] {
+export async function generateKeyShards(
+  total: number,
+  threshold: number
+): Promise<string[]> {
   if (!dataKey) {
     throw new Error('No data key set');
   }
-  if (!secrets.getConfig().hasCSPRNG) {
+  const s = await loadSecrets();
+  if (!s.getConfig().hasCSPRNG) {
     throw new Error('RNG not initialized');
   }
   try {
     const hex = bytesToHex(dataKey);
-    return secrets.share(hex, total, threshold);
+    return s.share(hex, total, threshold);
   } catch (err) {
     throw new Error(
       `Failed to generate key shards: ${(err as Error).message}`
@@ -116,8 +132,11 @@ export function generateKeyShards(total: number, threshold: number): string[] {
   }
 }
 
-export function restoreKeyFromShards(shards: string[]): Uint8Array {
-  const hex = secrets.combine(shards);
+export async function restoreKeyFromShards(
+  shards: string[]
+): Promise<Uint8Array> {
+  const s = await loadSecrets();
+  const hex = s.combine(shards);
   const key = hexToBytes(hex);
   setDataKey(key);
   return key;


### PR DESCRIPTION
## Summary
- load `secrets.js-grempe` only when running in a browser with `crypto.getRandomValues`
- throw helpful errors when secure randomness is missing
- await secret-sharing helpers in key recovery panel

## Testing
- `npm test` *(fails: Jest encountered an unexpected token from jose ESM modules)*
- `npm run lint` *(fails: multiple @typescript-eslint/no-explicit-any errors)*

------
https://chatgpt.com/codex/tasks/task_e_68abc154df908326853a507247b9b3d8