### PR TITLE
feat(server): add dev tonconnect manifest route

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,10 @@
 // [AURORA-BEGIN:server-entry]
 import Fastify from 'fastify';
 import cookie from '@fastify/cookie';
+// [AURORA-BEGIN:ton-manifest-dev]
+import path from 'node:path';
+import fs from 'node:fs';
+// [AURORA-END:ton-manifest-dev]
 
 import authTon from './auth/ton';
 import replicate from './replicate';
@@ -16,6 +20,20 @@ async function build() {
 }
 
 build();
+
+// [AURORA-BEGIN:ton-manifest-dev]
+if (process.env.NODE_ENV === 'development') {
+  server.get('/tonconnect-manifest.json', async (req, reply) => {
+    const p = path.join(process.cwd(), 'tonconnect-manifest.json'); // drop file in project root
+    if (!fs.existsSync(p)) return reply.code(404).send({ error: 'manifest not found' });
+    const json = fs.readFileSync(p, 'utf8');
+    reply
+      .header('Content-Type', 'application/json; charset=utf-8')
+      .header('Access-Control-Allow-Origin', '*')
+      .send(json);
+  });
+}
+// [AURORA-END:ton-manifest-dev]
 
 const port = Number(process.env.PORT) || 3000;
 server.listen({ port, host: '0.0.0.0' }).catch((err) => {

--- a/tonconnect-manifest.json
+++ b/tonconnect-manifest.json
@@ -1,0 +1,5 @@
+{
+  "url": "http://localhost:8080",
+  "name": "Aurora (Dev)",
+  "iconUrl": "https://via.placeholder.com/256.png"
+}


### PR DESCRIPTION
## Summary
- serve dev manifest at `/tonconnect-manifest.json`
- include local `tonconnect-manifest.json`

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export')*
- `npm run lint` *(fails: 265 errors, 22 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68abcd8617a08326be5185ec1f03dd3c