### PR TITLE
Send hex public key for TON login

### DIFF
--- a/server/auth/__tests__/ton.spec.ts
+++ b/server/auth/__tests__/ton.spec.ts
@@ -50,7 +50,7 @@ describe('TON auth', () => {
       method: 'POST',
       url: '/auth/ton/verify',
       payload: {
-        address: toHex(keypair.publicKey),
+        publicKey: toHex(keypair.publicKey),
         challenge,
         scopes,
         signature: sig,
@@ -75,7 +75,7 @@ describe('TON auth', () => {
       method: 'POST',
       url: '/auth/ton/verify',
       payload: {
-        address: toHex(keypair.publicKey),
+        publicKey: toHex(keypair.publicKey),
         challenge,
         scopes,
         signature: sig,
@@ -100,7 +100,7 @@ describe('TON auth', () => {
       method: 'POST',
       url: '/auth/ton/verify',
       payload: {
-        address: toHex(keypair.publicKey),
+        publicKey: toHex(keypair.publicKey),
         challenge,
         scopes: [],
         signature: sig,
@@ -139,7 +139,7 @@ describe('TON auth', () => {
       method: 'POST',
       url: '/auth/ton/verify',
       payload: {
-        address: toHex(keypair.publicKey),
+        publicKey: toHex(keypair.publicKey),
         challenge,
         scopes,
         signature: sig,
@@ -164,7 +164,7 @@ describe('TON auth', () => {
       method: 'POST',
       url: '/auth/ton/verify',
       payload: {
-        address: toHex(keypair.publicKey),
+        publicKey: toHex(keypair.publicKey),
         challenge,
         scopes: [],
         signature: wrongSig,
@@ -180,7 +180,7 @@ describe('TON auth', () => {
     const msg = composeMessage(challenge, []);
     const sig = toHex(nacl.sign.detached(stringToBytes(msg), keypair.secretKey));
     const payload = {
-      address: toHex(keypair.publicKey),
+      publicKey: toHex(keypair.publicKey),
       challenge,
       scopes: [],
       signature: sig,
@@ -196,7 +196,25 @@ describe('TON auth', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/auth/ton/verify',
-      payload: { address: 'bad' },
+      payload: { publicKey: 'bad' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('rejects non-hex public key', async () => {
+    const start = await app.inject({ method: 'POST', url: '/auth/ton/start' });
+    const { challenge } = start.json();
+    const msg = composeMessage(challenge, []);
+    const sig = toHex(nacl.sign.detached(stringToBytes(msg), keypair.secretKey));
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/ton/verify',
+      payload: {
+        publicKey: 'zz',
+        challenge,
+        scopes: [],
+        signature: sig,
+      },
     });
     expect(res.statusCode).toBe(400);
   });
@@ -216,7 +234,7 @@ describe('TON auth', () => {
       method: 'POST',
       url: '/auth/ton/verify',
       payload: {
-        address: toHex(keypair.publicKey),
+        publicKey: toHex(keypair.publicKey),
         challenge,
         scopes: [],
         signature: sig,
@@ -236,7 +254,7 @@ describe('TON auth', () => {
       method: 'POST',
       url: '/auth/ton/verify',
       payload: {
-        address: toHex(keypair.publicKey),
+        publicKey: toHex(keypair.publicKey),
         challenge,
         scopes: ['read', 'write'],
         signature: sig,
@@ -254,7 +272,7 @@ describe('TON auth', () => {
       method: 'POST',
       url: '/auth/ton/verify',
       payload: {
-        address: toHex(keypair.publicKey),
+        publicKey: toHex(keypair.publicKey),
         challenge: ch1,
         scopes: [],
         signature: sig1,
@@ -271,7 +289,7 @@ describe('TON auth', () => {
       method: 'POST',
       url: '/auth/ton/verify',
       payload: {
-        address: toHex(keypair.publicKey),
+        publicKey: toHex(keypair.publicKey),
         challenge: ch2,
         scopes: [],
         signature: sig2,
@@ -295,7 +313,7 @@ describe('TON auth', () => {
       method: 'POST',
       url: '/auth/ton/verify',
       payload: {
-        address: toHex(keypair.publicKey),
+        publicKey: toHex(keypair.publicKey),
         challenge,
         sessionPubKey: session,
         exp,
@@ -322,7 +340,7 @@ describe('TON auth', () => {
       method: 'POST',
       url: '/auth/ton/verify',
       payload: {
-        address: toHex(keypair.publicKey),
+        publicKey: toHex(keypair.publicKey),
         challenge,
         sessionPubKey: session,
         exp,

--- a/server/auth/ton.ts
+++ b/server/auth/ton.ts
@@ -22,7 +22,7 @@ export function composeMessage(
 }
 
 const verifySchema = z.object({
-  address: z.string(),
+  publicKey: z.string(),
   signature: z.string(),
   challenge: z.string(),
   sessionPubKey: z.string().optional(),
@@ -45,7 +45,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     if (!body.success) {
       return reply.code(400).send({ error: 'invalid_payload' });
     }
-    const { address, signature, challenge, sessionPubKey, scopes, exp } = body.data;
+    const { publicKey, signature, challenge, sessionPubKey, scopes, exp } = body.data;
 
     const expiresAt = challenges.get(challenge);
     if (!expiresAt) {
@@ -57,11 +57,18 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     }
     challenges.delete(challenge);
 
+    let pkBytes: Uint8Array;
+    try {
+      pkBytes = hexToBytes(publicKey);
+    } catch {
+      return reply.code(400).send({ error: 'invalid_public_key' });
+    }
+
     const message = composeMessage(challenge, scopes, sessionPubKey, exp);
     const ok = nacl.sign.detached.verify(
       stringToBytes(message),
       hexToBytes(signature),
-      hexToBytes(address)
+      pkBytes
     );
     if (!ok) {
       return reply.code(401).send({ error: 'invalid_signature' });
@@ -75,7 +82,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
       session?: string;
       sessionExp?: number;
     } = {
-      sub: address,
+      sub: publicKey,
       scopes,
     };
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,10 @@
 // [AURORA-BEGIN:server-entry]
 import Fastify from 'fastify';
 import cookie from '@fastify/cookie';
+// [AURORA-BEGIN:ton-manifest-dev]
+import path from 'node:path';
+import fs from 'node:fs';
+// [AURORA-END:ton-manifest-dev]
 
 import authTon from './auth/ton';
 import replicate from './replicate';
@@ -16,6 +20,20 @@ async function build() {
 }
 
 build();
+
+// [AURORA-BEGIN:ton-manifest-dev]
+if (process.env.NODE_ENV === 'development') {
+  server.get('/tonconnect-manifest.json', async (req, reply) => {
+    const p = path.join(process.cwd(), 'tonconnect-manifest.json'); // drop file in project root
+    if (!fs.existsSync(p)) return reply.code(404).send({ error: 'manifest not found' });
+    const json = fs.readFileSync(p, 'utf8');
+    reply
+      .header('Content-Type', 'application/json; charset=utf-8')
+      .header('Access-Control-Allow-Origin', '*')
+      .send(json);
+  });
+}
+// [AURORA-END:ton-manifest-dev]
 
 const port = Number(process.env.PORT) || 3000;
 server.listen({ port, host: '0.0.0.0' }).catch((err) => {

--- a/src/hooks/useTonAuth.ts
+++ b/src/hooks/useTonAuth.ts
@@ -31,16 +31,19 @@ export function useTonAuth() {
     const res = await fetch("/auth/ton/start", { method: "POST" });
     const { challenge } = await res.json();
     const message = composeMessage(challenge, scopes);
-    const { signature, address: addr } = await connector.signData({
+    const { signature } = await connector.signData({
       type: "text",
       text: message,
     });
+    const publicKey = connector.wallet?.account.publicKey;
+    if (!publicKey) throw new Error("missing_public_key");
     await fetch("/auth/ton/verify", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ address: addr, signature, challenge, scopes }),
+      body: JSON.stringify({ publicKey, signature, challenge, scopes }),
     });
-    setAddress(addr);
+    const addr = connector.wallet?.account.address;
+    setAddress(addr || null);
   };
 
   const login = async (scopes: string[] = []) => {

--- a/tonconnect-manifest.json
+++ b/tonconnect-manifest.json
@@ -1,0 +1,5 @@
+{
+  "url": "http://localhost:8080",
+  "name": "Aurora (Dev)",
+  "iconUrl": "https://via.placeholder.com/256.png"
+}


### PR DESCRIPTION
## Summary
- send wallet public key from client hook during TON login
- validate decoded public key on the server and reject invalid hex
- update TON auth tests for public key payload

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in jose ESM modules)*
- `npm run lint` *(fails: 265 errors, 22 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68abcd8617a08326be5185ec1f03dd3c