### PR TITLE
Validate TON signature and key lengths in verify handler

### DIFF
--- a/server/auth/__tests__/ton.spec.ts
+++ b/server/auth/__tests__/ton.spec.ts
@@ -219,6 +219,83 @@ describe('TON auth', () => {
     expect(res.statusCode).toBe(400);
   });
 
+  test('rejects short public key', async () => {
+    const start = await app.inject({ method: 'POST', url: '/auth/ton/start' });
+    const { challenge } = start.json();
+    const msg = composeMessage(challenge, []);
+    const sig = toHex(nacl.sign.detached(stringToBytes(msg), keypair.secretKey));
+    const shortPk = toHex(keypair.publicKey).slice(0, 60);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/ton/verify',
+      payload: {
+        publicKey: shortPk,
+        challenge,
+        scopes: [],
+        signature: sig,
+      },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('rejects long public key', async () => {
+    const start = await app.inject({ method: 'POST', url: '/auth/ton/start' });
+    const { challenge } = start.json();
+    const msg = composeMessage(challenge, []);
+    const sig = toHex(nacl.sign.detached(stringToBytes(msg), keypair.secretKey));
+    const longPk = toHex(keypair.publicKey) + 'aa';
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/ton/verify',
+      payload: {
+        publicKey: longPk,
+        challenge,
+        scopes: [],
+        signature: sig,
+      },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('rejects short signature', async () => {
+    const start = await app.inject({ method: 'POST', url: '/auth/ton/start' });
+    const { challenge } = start.json();
+    const msg = composeMessage(challenge, []);
+    const sig = toHex(
+      nacl.sign.detached(stringToBytes(msg), keypair.secretKey)
+    ).slice(0, 120);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/ton/verify',
+      payload: {
+        publicKey: toHex(keypair.publicKey),
+        challenge,
+        scopes: [],
+        signature: sig,
+      },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('rejects long signature', async () => {
+    const start = await app.inject({ method: 'POST', url: '/auth/ton/start' });
+    const { challenge } = start.json();
+    const msg = composeMessage(challenge, []);
+    const sig =
+      toHex(nacl.sign.detached(stringToBytes(msg), keypair.secretKey)) + 'aa';
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/ton/verify',
+      payload: {
+        publicKey: toHex(keypair.publicKey),
+        challenge,
+        scopes: [],
+        signature: sig,
+      },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
   test('rejects expired challenge', async () => {
     const start = await app.inject({ method: 'POST', url: '/auth/ton/start' });
     const { challenge, ttl } = start.json();
@@ -280,6 +357,9 @@ describe('TON auth', () => {
     });
     const t1 = first.cookies.find((c: { name: string }) => c.name === 'sid');
     const { payload: p1 } = await jwtVerify(t1.value, secretBytes);
+
+    // ensure a different expiration timestamp for the rotated token
+    await new Promise((r) => setTimeout(r, 1000));
 
     const start2 = await app.inject({ method: 'POST', url: '/auth/ton/start' });
     const { challenge: ch2 } = start2.json();

--- a/server/auth/ton.ts
+++ b/server/auth/ton.ts
@@ -69,6 +69,9 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     } catch {
       return reply.code(400).send({ error: "invalid_public_key" });
     }
+    if (pkBytes.length !== 32) {
+      return reply.code(400).send({ error: "invalid_public_key" });
+    }
 
     const message = composeMessage(challenge, scopes, sessionPubKey, exp);
 
@@ -82,12 +85,20 @@ const plugin: FastifyPluginAsync = async (fastify) => {
         return reply.code(400).send({ error: "invalid_signature" });
       }
     }
+    if (sigBytes.length !== 64) {
+      return reply.code(400).send({ error: "invalid_signature" });
+    }
 
-    const ok = nacl.sign.detached.verify(
-      stringToBytes(message),
-      sigBytes,
-      pkBytes,
-    );
+    let ok: boolean;
+    try {
+      ok = nacl.sign.detached.verify(
+        stringToBytes(message),
+        sigBytes,
+        pkBytes,
+      );
+    } catch {
+      return reply.code(401).send({ error: "invalid_signature" });
+    }
     if (!ok) {
       return reply.code(401).send({ error: "invalid_signature" });
     }


### PR DESCRIPTION
### Summary
- enforce 32-byte public keys and 64-byte signatures in `/auth/ton/verify`
- handle nacl verification errors with `401 invalid_signature`
- add tests for short/long keys and signatures

### Testing
- `NODE_OPTIONS=--experimental-vm-modules npm test server/auth/__tests__/ton.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68abee399a788326977b08e01bccacfd