### PR TITLE
Require TON testnet wallet for authentication

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,3 +5,4 @@ Key guides and references:
 - [Data Backup](./backup.md)
 - [Deploying Supabase Functions](./deploy-supabase-functions.md)
 - [Offline Mode](./offline-mode.md)
+- TON wallet authentication requires connecting to the TON testnet.

--- a/src/hooks/useTonAuth.ts
+++ b/src/hooks/useTonAuth.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { CHAIN, TonConnectUI } from "@tonconnect/ui";
 
-// Create a single TonConnectUI instance for the app
+// Create a single TonConnectUI instance for the app. All connections must use the TON testnet.
 export const connector = new TonConnectUI({
   manifestUrl: "/tonconnect-manifest.json",
 });
@@ -62,10 +62,11 @@ export function useTonAuth() {
     setLoading(true);
     try {
       if (!connector.wallet) {
-        await connector.connectWallet();
+        await connector.tonConnect.connectWallet({ chain: CHAIN.TESTNET });
       }
       if (connector.wallet?.account.chain !== CHAIN.TESTNET) {
         console.warn("Wallet is not on TON testnet");
+        throw new Error("Only TON testnet is supported");
       }
       await signAndVerify(scopes);
       if (refreshTimer.current) clearInterval(refreshTimer.current);


### PR DESCRIPTION
## Summary
- enforce TON testnet connection when logging in
- note testnet requirement in developer docs

## Testing
- `npm test server/auth/__tests__/ton.spec.ts` *(fails: Unexpected token 'export' from jose)*
- `npm run lint` *(fails: 287 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68abee3a410c8326b59a5b133db93741