### PR TITLE
feat: bypass app layout on auth route

### DIFF
--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -105,8 +105,10 @@ export default function AppShell() {
     );
   }
 
-  if (!user && loc.pathname !== '/auth') {
-    return <Navigate to="/auth" replace />;
+  if (!user) {
+    return loc.pathname === '/auth'
+      ? <Outlet />           // render login form alone
+      : <Navigate to="/auth" replace />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- allow unauthenticated users to access `/auth` without rendering full app shell

## Testing
- `npm test` *(fails: Unexpected token in `server/auth/__tests__/ton.spec.ts`)*
- `npm run lint` *(fails: 293 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68abf849d7b48326be0062bd53be5ea8