### PR TITLE
fix tonconnect login helper

### DIFF
--- a/src/hooks/useTonAuth.ts
+++ b/src/hooks/useTonAuth.ts
@@ -65,7 +65,8 @@ export function useTonAuth() {
     try {
       if (!connector.wallet) {
         try {
-          await connector.tonConnect.connectWallet({ chain: CHAIN.TESTNET });
+          // use TonConnectUI's connectWallet to prompt user connection
+          await connector.connectWallet();
         } catch (err) {
           console.error("Wallet connection failed", err);
           throw err;


### PR DESCRIPTION
## Summary
- adjust TonConnect auth hook to use TonConnectUI.connectWallet instead of deprecated tonConnect property

## Testing
- `npm test` (fails: Jest encountered an unexpected token in server/auth/__tests__/ton.spec.ts)
- `npm run lint` (fails: Unexpected any. Specify a different type)


------
https://chatgpt.com/codex/tasks/task_e_68ac062ad2408326bd2948b80df4ad69