### PR TITLE
fix: close TonDbClient class

### DIFF
--- a/src/integrations/db.ts
+++ b/src/integrations/db.ts
@@ -17,6 +17,7 @@ class TonDbClient {
     invoke: async (_fn: string, _args?: any): Promise<QueryResult<any>> => ({ data: null, error: null }),
   };
 
+}
 
 export const db = new TonDbClient();
 


### PR DESCRIPTION
## Summary
- properly terminate TonDbClient class by adding missing closing brace after the functions field

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in server/auth/__tests__/ton.spec.ts and server/replicate/__tests__/replicate.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0c5eb3bc8326836a19bc36a468c8