### PR TITLE
Consolidate TonConnect manifest for dev server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ memory/*.db
 memory/chroma_db/
 __pycache__/
 *.env
+
+# Local development icons
+public/icon.png

--- a/public/tonconnect-manifest.json
+++ b/public/tonconnect-manifest.json
@@ -1,5 +1,5 @@
 {
-  "url": "<YOUR_APP_ORIGIN>",
-  "name": "Aurora",
-  "iconUrl": "/icons/aurora.png"
+  "url": "http://localhost:8080",
+  "name": "Aurora (Dev)",
+  "iconUrl": "/icon.png"
 }

--- a/tonconnect-manifest.json
+++ b/tonconnect-manifest.json
@@ -1,5 +1,0 @@
-{
-  "url": "http://localhost:8080",
-  "name": "Aurora (Dev)",
-  "iconUrl": "https://via.placeholder.com/256.png"
-}


### PR DESCRIPTION
## Summary
- remove duplicate TonConnect manifest from repo root
- use port 8080 dev settings in public/tonconnect-manifest.json
- drop placeholder icon from repository and ignore local icon assets

## Testing
- `npm test` (fails: SyntaxError in server auth and replicate tests)
- `npm run lint` (fails: Unexpected any and Empty block statement errors)
- `curl http://localhost:8080/tonconnect-manifest.json`


------
https://chatgpt.com/codex/tasks/task_e_68ac0ebea6e48326b1a95c43649f6707