### PR TITLE
chore: ensure TonConnect uses testnet

### DIFF
--- a/src/hooks/useTonAuth.ts
+++ b/src/hooks/useTonAuth.ts
@@ -65,8 +65,8 @@ export function useTonAuth() {
     try {
       if (!connector.wallet) {
         try {
-          // use TonConnectUI's connectWallet to prompt user connection
-          await connector.connectWallet();
+          // use TonConnectUI's connectWallet to prompt user connection on testnet
+          await connector.connectWallet({ network: CHAIN.TESTNET });
         } catch (err) {
           console.error("Wallet connection failed", err);
           throw err;


### PR DESCRIPTION
## Summary
- specify TON testnet when connecting wallet through TonConnect
- keep runtime check as a safety net

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export' for jose)*
- `npm run lint` *(fails: 291 problems, including no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0eccd5b083268462c2219c9b5074