### PR TITLE
chore: update tonconnect manifest URLs

### DIFF
--- a/public/tonconnect-manifest.json
+++ b/public/tonconnect-manifest.json
@@ -1,5 +1,5 @@
 {
   "url": "http://localhost:8080",
   "name": "Aurora (Dev)",
-  "iconUrl": "/public/icon.png"
+  "iconUrl": "/icon.png"
 }

--- a/tonconnect-manifest.json
+++ b/tonconnect-manifest.json
@@ -1,5 +1,5 @@
 {
   "url": "http://localhost:8080",
   "name": "Aurora (Dev)",
-  "iconUrl": "/public/icon.png"
+  "iconUrl": "/icon.png"
 }


### PR DESCRIPTION
## Summary
- fix tonconnect manifest to point at dev server
- reference icon path directly under root

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export' in jose)*
- `curl http://localhost:8080/tonconnect-manifest.json`


------
https://chatgpt.com/codex/tasks/task_e_68ac367f73fc8326994e8ba6d53e0d35