### PR TITLE
refactor: use public tonconnect manifest

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -23,7 +23,7 @@ build();
 
 // [AURORA-BEGIN:ton-manifest-dev]
 server.get('/tonconnect-manifest.json', async (req, reply) => {
-  const p = path.join(process.cwd(), 'tonconnect-manifest.json'); // drop file in project root
+  const p = path.join(process.cwd(), 'public', 'tonconnect-manifest.json'); // read from public directory
   if (!fs.existsSync(p)) return reply.code(404).send({ error: 'manifest not found' });
   const json = fs.readFileSync(p, 'utf8');
   reply

--- a/tonconnect-manifest.json
+++ b/tonconnect-manifest.json
@@ -1,5 +1,0 @@
-{
-  "url": "http://localhost:8080",
-  "name": "Aurora (Dev)",
-  "iconUrl": "/public/icon.png"
-}

--- a/tonconnect-manifest.json
+++ b/tonconnect-manifest.json
@@ -1,0 +1,5 @@
+{
+  "url": "http://localhost:8080",
+  "name": "Aurora (Dev)",
+  "iconUrl": "/public/icon.png"
+}


### PR DESCRIPTION
## Summary
- remove duplicate tonconnect manifest from project root
- serve TonConnect manifest from public directory in server

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export' in node_modules/jose/dist/webapi/index.js)*
- `npm run lint` *(fails: no-explicit-any, no-empty, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68ac36807d64832694e633f202d98c6e