### PR TITLE
chore: update tonconnect manifest

### DIFF
--- a/public/tonconnect-manifest.json
+++ b/public/tonconnect-manifest.json
@@ -1,5 +1,5 @@
 {
-  "url": "http://localhost:8080",
+  "url": "%VITE_ORIGIN%",
   "name": "Aurora (Dev)",
   "iconUrl": "/icon.png"
 }

--- a/tonconnect-manifest.json
+++ b/tonconnect-manifest.json
@@ -1,5 +1,0 @@
-{
-  "url": "http://localhost:8080",
-  "name": "Aurora (Dev)",
-  "iconUrl": "/icon.png"
-}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,10 +2,30 @@ import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { VitePWA } from "vite-plugin-pwa";
+import fs from "fs";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), 'VITE_');
+  const tonConnectManifest = () => {
+    const manifestPath = path.resolve(__dirname, "public/tonconnect-manifest.json");
+    return {
+      name: "tonconnect-manifest",
+      apply: "serve",
+      configureServer(server) {
+        server.middlewares.use((req, res, next) => {
+          if (req.url === "/tonconnect-manifest.json") {
+            const raw = fs.readFileSync(manifestPath, "utf-8");
+            const origin = env.VITE_ORIGIN || `http://${req.headers.host}`;
+            res.setHeader("Content-Type", "application/json");
+            res.end(raw.replace("%VITE_ORIGIN%", origin));
+            return;
+          }
+          next();
+        });
+      },
+    };
+  };
   return {
     server: {
       host: "::",
@@ -18,6 +38,7 @@ export default defineConfig(({ mode }) => {
         manifest: false,
         workbox: { globPatterns: ['**/*.{js,css,html,ico,png,svg}'] }
       }),
+      tonConnectManifest(),
     ],
     resolve: {
       alias: {
@@ -25,9 +46,9 @@ export default defineConfig(({ mode }) => {
       },
       dedupe: ["react", "react-dom"],
     },
-      define: {
-        'process.env.VITE_API_BASE_URL': JSON.stringify(env.VITE_API_BASE_URL),
-      },
+    define: {
+      'process.env.VITE_API_BASE_URL': JSON.stringify(env.VITE_API_BASE_URL),
+    },
     optimizeDeps: {
       exclude: ["@mlc-ai/web-llm"],
     },


### PR DESCRIPTION
## Summary
- remove duplicate root tonconnect manifest
- serve tonconnect manifest from public with dynamic origin injection

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in jose module)*
- `npm run lint` *(fails: numerous @typescript-eslint/no-explicit-any errors)*
- `npm run dev` followed by `curl http://localhost:8080/tonconnect-manifest.json`

------
https://chatgpt.com/codex/tasks/task_e_68ac4bf28490832686651054ab5977f8