### PR TITLE
fix: use absolute URL for TonConnect manifest

### DIFF
--- a/src/hooks/useTonAuth.ts
+++ b/src/hooks/useTonAuth.ts
@@ -5,7 +5,10 @@ import { db as localDb } from "@/data/db";
 
 // Create a single TonConnectUI instance for the app. All connections must use the TON testnet.
 export const connector = new TonConnectUI({
-  manifestUrl: "/tonconnect-manifest.json",
+  manifestUrl: new URL(
+    "/tonconnect-manifest.json",
+    window.location.origin,
+  ).toString(),
 });
 
 function composeMessage(


### PR DESCRIPTION
## Summary
- ensure TonConnect manifest URL resolves against current origin

## Testing
- `curl -I http://localhost:8080/tonconnect-manifest.json`
- `node -e "(async () => { const url=new URL('/tonconnect-manifest.json','http://localhost:8080').toString(); console.log('url', url); const res=await fetch(url); console.log('status', res.status);})();"`
- `npm test` *(fails: SyntaxError: Unexpected token 'export')*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5174b91c83268167cd1596030641