### PR TITLE
Remove Fastify TON Connect manifest route

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,10 +1,6 @@
 // [AURORA-BEGIN:server-entry]
 import Fastify from 'fastify';
 import cookie from '@fastify/cookie';
-// [AURORA-BEGIN:ton-manifest-dev]
-import path from 'node:path';
-import fs from 'node:fs';
-// [AURORA-END:ton-manifest-dev]
 
 import authTon from './auth/ton';
 import replicate from './replicate';
@@ -20,18 +16,6 @@ async function build() {
 }
 
 build();
-
-// [AURORA-BEGIN:ton-manifest-dev]
-server.get('/tonconnect-manifest.json', async (req, reply) => {
-  const p = path.join(process.cwd(), 'public', 'tonconnect-manifest.json'); // read from public directory
-  if (!fs.existsSync(p)) return reply.code(404).send({ error: 'manifest not found' });
-  const json = fs.readFileSync(p, 'utf8');
-  reply
-    .header('Content-Type', 'application/json; charset=utf-8')
-    .header('Access-Control-Allow-Origin', '*')
-    .send(json);
-});
-// [AURORA-END:ton-manifest-dev]
 
 const port = Number(process.env.PORT) || 3000;
 server.listen({ port, host: '0.0.0.0' }).catch((err) => {


### PR DESCRIPTION
## Summary
- Remove Fastify `/tonconnect-manifest.json` endpoint to rely on Vite's static file

## Testing
- `curl -i http://localhost:3000/tonconnect-manifest.json`
- `npm run lint` *(fails: Unexpected any, no-empty)*
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68ac517593988326b506c18b9f163c21