### PR TITLE
chore: set tonconnect manifest origin

### DIFF
--- a/public/tonconnect-manifest.json
+++ b/public/tonconnect-manifest.json
@@ -1,5 +1,5 @@
 {
-  "url": "%VITE_ORIGIN%",
+  "url": "http://localhost:8080",
   "name": "Aurora (Dev)",
   "iconUrl": "/icon.png"
 }


### PR DESCRIPTION
## Summary
- replace `%VITE_ORIGIN%` placeholder with `http://localhost:8080` in TonConnect manifest

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `curl http://localhost:8081/tonconnect-manifest.json`

------
https://chatgpt.com/codex/tasks/task_e_68ac573142c08326a3fc5712ac4071fd