### PR TITLE
Handle tonconnect manifest errors and copy in build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "preinstall": "node scripts/check-peer-deps.cjs",
     "dev": "vite",
-    "build": "tsc -p tsconfig.node.json && tsc -p tsconfig.app.json && vite build",
-    "build:dev": "tsc -p tsconfig.node.json && tsc -p tsconfig.app.json && vite build --mode development",
+    "build": "tsc -p tsconfig.node.json && tsc -p tsconfig.app.json && vite build && mkdir -p dist/public && cp public/tonconnect-manifest.json dist/public/tonconnect-manifest.json",
+    "build:dev": "tsc -p tsconfig.node.json && tsc -p tsconfig.app.json && vite build --mode development && mkdir -p dist/public && cp public/tonconnect-manifest.json dist/public/tonconnect-manifest.json",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "jest",

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,14 +3,12 @@ import Fastify from 'fastify';
 import cookie from '@fastify/cookie';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import authTon from './auth/ton';
 import replicate from './replicate';
 
 const server = Fastify({ logger: true });
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const manifestPath = path.resolve(__dirname, '../public/tonconnect-manifest.json');
+const manifestPath = path.resolve(process.cwd(), 'public/tonconnect-manifest.json');
 
 async function build() {
   await server.register(cookie);
@@ -21,9 +19,17 @@ async function build() {
     await server.register(nftAssets);
   }
   server.get('/tonconnect-manifest.json', async (req, reply) => {
-    const raw = await fs.readFile(manifestPath, 'utf-8');
-    const origin = process.env.VITE_ORIGIN || `${req.protocol}://${req.headers.host}`;
-    reply.header('Content-Type', 'application/json').send(raw.replace('%VITE_ORIGIN%', origin));
+    try {
+      const raw = await fs.readFile(manifestPath, 'utf-8');
+      const origin =
+        process.env.VITE_ORIGIN || `${req.protocol}://${req.headers.host}`;
+      reply
+        .header('Content-Type', 'application/json')
+        .send(raw.replace('%VITE_ORIGIN%', origin));
+    } catch (err) {
+      server.log.error(err);
+      reply.code(404).send({ error: 'tonconnect-manifest.json not found' });
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- wrap `/tonconnect-manifest.json` handler with try/catch and return 404 JSON on failure
- resolve manifest path from `process.cwd()`
- copy `tonconnect-manifest.json` into `dist/public` during build

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export' in jose)*
- `npm run build` *(fails: TypeScript errors in vite.config.ts)*
- `node --loader ts-node/esm server/index.ts` *(fails: Cannot find module './auth/ton')*

------
https://chatgpt.com/codex/tasks/task_e_68ac5aa348dc832693e51d62a40133e3