### PR TITLE
Fix Ton auth and Vite plugin typing

### DIFF
--- a/src/hooks/useTonAuth.ts
+++ b/src/hooks/useTonAuth.ts
@@ -68,8 +68,8 @@ export function useTonAuth() {
     try {
       if (!connector.wallet) {
         try {
-          // use TonConnectUI's connectWallet to prompt user connection on testnet
-          await connector.connectWallet({ network: CHAIN.TESTNET });
+          // use TonConnectUI's connectWallet to prompt user connection
+          await connector.connectWallet();
         } catch (err) {
           console.error("Wallet connection failed", err);
           throw err;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,28 +1,39 @@
 import { defineConfig, loadEnv } from "vite";
+import type { Plugin, ViteDevServer } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { VitePWA } from "vite-plugin-pwa";
 import fs from "fs";
+import type { IncomingMessage, ServerResponse } from "http";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), 'VITE_');
-  const tonConnectManifest = () => {
-    const manifestPath = path.resolve(__dirname, "public/tonconnect-manifest.json");
+  const tonConnectManifest = (): Plugin => {
+    const manifestPath = path.resolve(
+      __dirname,
+      "public/tonconnect-manifest.json",
+    );
     return {
       name: "tonconnect-manifest",
       apply: "serve",
-      configureServer(server) {
-        server.middlewares.use((req, res, next) => {
-          if (req.url === "/tonconnect-manifest.json") {
-            const raw = fs.readFileSync(manifestPath, "utf-8");
-            const origin = env.VITE_ORIGIN || `http://${req.headers.host}`;
-            res.setHeader("Content-Type", "application/json");
-            res.end(raw.replace("%VITE_ORIGIN%", origin));
-            return;
-          }
-          next();
-        });
+      configureServer(server: ViteDevServer) {
+        server.middlewares.use(
+          (
+            req: IncomingMessage,
+            res: ServerResponse,
+            next: () => void,
+          ) => {
+            if (req.url === "/tonconnect-manifest.json") {
+              const raw = fs.readFileSync(manifestPath, "utf-8");
+              const origin = env.VITE_ORIGIN || `http://${req.headers.host}`;
+              res.setHeader("Content-Type", "application/json");
+              res.end(raw.replace("%VITE_ORIGIN%", origin));
+              return;
+            }
+            next();
+          },
+        );
       },
     };
   };


### PR DESCRIPTION
## Summary
- Remove unsupported `connectWallet` argument and keep testnet check
- Type custom TonConnect manifest plugin for Vite

## Testing
- `npm test` (fails: Jest encountered an unexpected token in jose ESM modules)
- `npm run lint` (fails: @typescript-eslint/no-explicit-any errors across repo)
- `npx tsc --noEmit -p tsconfig.app.json` (fails: TS1005 in src/three/export.ts)


------
https://chatgpt.com/codex/tasks/task_e_68ac5c386d848326805326ed4f5e382c