### PR TITLE
feat(logger): allow variadic args

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,10 +1,23 @@
 import pino from "pino";
 
+// Allow string-first logging with additional args without requiring
+// placeholder parsing in the type system.
+interface LogFn {
+  (msg: string, ...args: unknown[]): void;
+  (obj: unknown, msg?: string, ...args: unknown[]): void;
+}
+
+export interface Logger extends pino.Logger {
+  debug: LogFn;
+  info: LogFn;
+  warn: LogFn;
+}
+
 const level = import.meta.env.VITE_LOG_LEVEL ?? (import.meta.env.PROD ? "error" : "debug");
 const enabled = import.meta.env.VITE_LOG_ENABLED !== "false";
 const endpoint = import.meta.env.VITE_LOG_ENDPOINT;
 
-const logger = pino({
+const baseLogger = pino({
   level,
   enabled,
   browser: {
@@ -21,4 +34,4 @@ const logger = pino({
   },
 });
 
-export default logger;
+export default baseLogger as Logger;


### PR DESCRIPTION
## Summary
- widen pino logger typings to permit variadic string-first logging

## Testing
- `npm test` *(fails: SyntaxError in jose module during server/auth and replicate tests)*
- `npm run lint` *(fails: multiple lint errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68ac605785808326ac1279997901e192