### PR TITLE
Ensure unsubscribes don't leak Set.delete return values

### DIFF
--- a/src/components/navigation/quickActions.ts
+++ b/src/components/navigation/quickActions.ts
@@ -17,7 +17,9 @@ export function registerQuickAction(action: QuickAction) {
 
 function subscribe(listener: () => void) {
   listeners.add(listener);
-  return () => listeners.delete(listener);
+  return () => {
+    listeners.delete(listener);
+  };
 }
 
 function getSnapshot() {

--- a/src/voice/voiceService.ts
+++ b/src/voice/voiceService.ts
@@ -39,12 +39,16 @@ class VoiceService {
 
   onTranscript(cb: (text: string) => void) {
     this.transcriptListeners.add(cb);
-    return () => this.transcriptListeners.delete(cb);
+    return () => {
+      this.transcriptListeners.delete(cb);
+    };
   }
 
   onPlaybackBlocked(cb: (callback: (() => void) | null) => void) {
     this.playbackBlockedListeners.add(cb);
-    return () => this.playbackBlockedListeners.delete(cb);
+    return () => {
+      this.playbackBlockedListeners.delete(cb);
+    };
   }
 
   private emitTranscript(text: string) {


### PR DESCRIPTION
## Summary
- Ensure VoiceService's onTranscript and onPlaybackBlocked return void by wrapping Set.delete in a closure
- Update quickActions.subscribe to use a void-returning listener removal function

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export' from jose in server tests)*
- `npm run lint` *(fails: multiple @typescript-eslint/no-explicit-any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac605bc4088326b11020a242e37d81