### PR TITLE
chore: remove duplicate listenMode definitions

### DIFF
--- a/src/state/voice.ts
+++ b/src/state/voice.ts
@@ -35,7 +35,6 @@ type VoiceState = {
   pitch: number;
   expression: number;
   emotion: string;
-  listenMode: ListenMode;
   setListening: (v: boolean) => void;
   setThinking: (v: boolean) => void;
   setSpeaking: (v: boolean) => void;
@@ -49,7 +48,6 @@ type VoiceState = {
   setPitch: (v: number) => void;
   setExpression: (v: number) => void;
   setEmotion: (v: string) => void;
-  setListenMode: (m: ListenMode) => void;
 };
 
 export const useVoiceStore = create<VoiceState>((set) => {
@@ -92,9 +90,6 @@ export const useVoiceStore = create<VoiceState>((set) => {
     emotion: hasWindow
       ? ls!.getItem(VOICE_EMOTION_KEY) || 'neutral'
       : 'neutral',
-    listenMode: hasWindow
-      ? ((ls!.getItem(VOICE_LISTEN_MODE_KEY) as ListenMode) || 'push-to-talk')
-      : 'push-to-talk',
 
     setListening: (v) => set({ isListening: v }),
     setThinking: (v) => set({ isThinking: v }),
@@ -179,15 +174,6 @@ export const useVoiceStore = create<VoiceState>((set) => {
         /* empty */
       }
       set({ emotion });
-    },
-
-    setListenMode: (listenMode) => {
-      try {
-        ls?.setItem(VOICE_LISTEN_MODE_KEY, listenMode);
-      } catch {
-        /* empty */
-      }
-      set({ listenMode });
-    }, // <- no extra comma after the last property
+    }
   };
 });


### PR DESCRIPTION
## Summary
- remove duplicate listenMode and setListenMode definitions in voice store

## Testing
- `npm test server/auth/__tests__/ton.spec.ts` *(fails: SyntaxError Unexpected token 'export')*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac606108ec8326a89fe302363a73b9