### PR TITLE
Type model preference store

### DIFF
--- a/src/state/modelPreference.ts
+++ b/src/state/modelPreference.ts
@@ -11,17 +11,18 @@ interface ModelState {
 
 const STORAGE_KEY = 'modelPreference';
 
-export const useModelPreference = create<ModelState>((set) => {
+export const useModelPreference = create<ModelState>((set): ModelState => {
   const raw =
     typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null;
-  const initial = raw
-    ? (JSON.parse(raw) as { preference: ModelPreference; fallbackToCloud: boolean })
+  const initial: Pick<ModelState, 'preference' | 'fallbackToCloud'> = raw
+    ? (JSON.parse(raw) as Pick<ModelState, 'preference' | 'fallbackToCloud'>)
     : { preference: 'auto', fallbackToCloud: true };
+
   return {
     ...initial,
-    setPreference: (p) =>
+    setPreference: (p: ModelPreference) =>
       set((state) => {
-        const next = { ...state, preference: p } as ModelState;
+        const next: ModelState = { ...state, preference: p };
         try {
           const { preference, fallbackToCloud } = next;
           localStorage.setItem(
@@ -31,9 +32,9 @@ export const useModelPreference = create<ModelState>((set) => {
         } catch {}
         return next;
       }),
-    setFallback: (f) =>
+    setFallback: (f: boolean) =>
       set((state) => {
-        const next = { ...state, fallbackToCloud: f } as ModelState;
+        const next: ModelState = { ...state, fallbackToCloud: f };
         try {
           const { preference, fallbackToCloud } = next;
           localStorage.setItem(


### PR DESCRIPTION
## Summary
- type model preference store initial state and setter
- ensure create<ModelState> returns a complete ModelState

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export')*

------
https://chatgpt.com/codex/tasks/task_e_68ac625156988326a3f558573c5ed8c1