### PR TITLE
refactor: remove ts-expect-error comment in passive orbit controls

### DIFF
--- a/src/components/controls/PassiveOrbitControls.tsx
+++ b/src/components/controls/PassiveOrbitControls.tsx
@@ -48,7 +48,6 @@ export default function PassiveOrbitControls({
   useEffect(() => {
     if (!makeDefault) return;
     const previous = get().controls;
-    // @ts-expect-error - the three fiber typings don't include our custom controls
     set({ controls: controlsRef.current });
     return () => set({ controls: previous });
   }, [makeDefault, set, get]);


### PR DESCRIPTION
## Summary
- remove obsolete `@ts-expect-error` comment in `PassiveOrbitControls`

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in server/auth and server/replicate tests)*
- `npm run lint` *(fails: numerous lint errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6256d23c83269cba3b4989262df9