### PR TITLE
feat: add sql.js type declarations

### DIFF
--- a/src/memory/brainBackup.ts
+++ b/src/memory/brainBackup.ts
@@ -1,4 +1,4 @@
-import { openBrainDb, __setMemoryDb } from './brainDb';
+import { openBrainDb, __setMemoryDb, type BrainDatabase } from './brainDb';
 import { toast } from '@/hooks/use-toast';
 
 const DB_FILE = 'brain.db';
@@ -16,7 +16,7 @@ async function deriveKey(passphrase: string, salt: Uint8Array) {
 }
 
 export async function exportEncryptedBrain(passphrase: string): Promise<Blob> {
-  const db = await openBrainDb();
+  const db: BrainDatabase = await openBrainDb();
   await db.saveToDisk();
   const data = db.export();
   const salt = crypto.getRandomValues(new Uint8Array(16));

--- a/src/memory/brainDb.ts
+++ b/src/memory/brainDb.ts
@@ -1,4 +1,4 @@
-import initSqlJs, { Database } from "sql.js";
+import initSqlJs, { type Database } from "sql.js";
 import wasmUrl from "sql.js/dist/sql-wasm.wasm?url";
 import { toast } from "@/hooks/use-toast";
 

--- a/src/views/BrainView.tsx
+++ b/src/views/BrainView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { openBrainDb } from '@/memory/brainDb';
+import { openBrainDb, type BrainDatabase } from '@/memory/brainDb';
 import { exportEncryptedBrain, importEncryptedBrain } from '@/memory/brainBackup';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -46,7 +46,7 @@ export default function BrainView() {
   }, []);
 
   const load = async () => {
-    const db = await openBrainDb();
+    const db: BrainDatabase = await openBrainDb();
     db.run(
       "CREATE TABLE IF NOT EXISTS memories (id INTEGER PRIMARY KEY AUTOINCREMENT, content TEXT, tags TEXT, type TEXT, importance INTEGER DEFAULT 0, pinned INTEGER DEFAULT 0, ts INTEGER DEFAULT (strftime('%s','now')))"
     );
@@ -150,7 +150,7 @@ export default function BrainView() {
 
   const saveEdit = async () => {
     if (!editing) return;
-    const db = await openBrainDb();
+    const db: BrainDatabase = await openBrainDb();
     db.run(
       `UPDATE memories SET content='${editContent.replace(/'/g, "''")}', tags='${editTags.replace(/'/g, "''")}', type='${editType}', importance=${Number(editImportance)} WHERE id=${editing.id}`
     );
@@ -160,14 +160,14 @@ export default function BrainView() {
   };
 
   const togglePin = async (m: Memory) => {
-    const db = await openBrainDb();
+    const db: BrainDatabase = await openBrainDb();
     db.run(`UPDATE memories SET pinned=${m.pinned ? 0 : 1} WHERE id=${m.id}`);
     await db.saveToDisk();
     load();
   };
 
   const remove = async (id: number) => {
-    const db = await openBrainDb();
+    const db: BrainDatabase = await openBrainDb();
     db.run(`DELETE FROM memories WHERE id=${id}`);
     await db.saveToDisk();
     load();

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -8,5 +8,5 @@
     "strict": false,
     "noFallthroughCasesInSwitch": false
   },
-  "include": ["src", "server"]
+  "include": ["src", "server", "types"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,6 +17,7 @@
     },
     "typeRoots": [
       "./node_modules/@types",
+      "./types",
       "./src/types"
     ]
   }

--- a/types/sqljs.d.ts
+++ b/types/sqljs.d.ts
@@ -1,0 +1,24 @@
+declare module "sql.js" {
+  export interface Statement {
+    step(): boolean;
+    getAsObject(): unknown;
+    free(): void;
+  }
+
+  export interface Database {
+    run(sql: string): void;
+    prepare(sql: string): Statement;
+    export(): Uint8Array;
+    close(): void;
+  }
+
+  export interface SqlJsStatic {
+    Database: {
+      new (data?: Uint8Array): Database;
+    };
+  }
+
+  export default function initSqlJs(config?: {
+    locateFile?: (file: string, prefix?: string) => string;
+  }): Promise<SqlJsStatic>;
+}


### PR DESCRIPTION
## Summary
- add custom sql.js typings for the Database API
- include local type definitions in tsconfig
- annotate brain database usage with explicit types

## Testing
- `npm test` *(fails: Jest encountered unexpected token in jose ESM)*
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: Property 'id' missing in ToasterToast, voice service type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac62521904832690062b54c01d7181