### PR TITLE
feat: allow children in AuroraBallR3F

### DIFF
--- a/src/components/avatar/AuroraBallR3F.tsx
+++ b/src/components/avatar/AuroraBallR3F.tsx
@@ -3,7 +3,7 @@ import * as THREE from 'three';
 import { useMemo, useRef, forwardRef, useEffect } from 'react';
 import { useFrame } from '@react-three/fiber';
 
-export type AuroraBallProps = Omit<JSX.IntrinsicElements['group'], 'children'> & {
+export type AuroraBallProps = JSX.IntrinsicElements['group'] & {
   size?: number;
 };
 
@@ -31,19 +31,14 @@ const isAllowedGroupProp = (
 const AuroraBallR3F = forwardRef<THREE.Group, AuroraBallProps>(
   (props, ref) => {
     const { size = 1, children, ...restProps } = props;
-    const { lov, ...safeProps } = restProps;
     const matRef = useRef<THREE.ShaderMaterial>(null!);
 
     const groupProps = useMemo(() => {
-
-      const entries = Object.entries(safeProps as Record<string, unknown>).filter(
+      const entries = Object.entries(restProps as Record<string, unknown>).filter(
         ([key]) => !key.startsWith('data-') && !key.startsWith('aria-')
       );
-      return Object.fromEntries(entries) as Omit<
-        JSX.IntrinsicElements['group'],
-        'children'
-      >;
-    }, [safeProps]);
+      return Object.fromEntries(entries) as JSX.IntrinsicElements['group'];
+    }, [restProps]);
 
 
     const uniforms = useMemo(


### PR DESCRIPTION
## Summary
- allow children in AuroraBallR3F by using intrinsic group props
- simplify prop handling by removing unused lov destructuring

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export' from jose)*
- `npm run lint` *(fails: Unexpected any and react-hooks rules)*

------
https://chatgpt.com/codex/tasks/task_e_68ac69fc6fc48326bf257ac67060d49a