### PR TITLE
feat: add speech recognition types

### DIFF
--- a/src/components/chat/AnchoredChatBar.tsx
+++ b/src/components/chat/AnchoredChatBar.tsx
@@ -54,15 +54,13 @@ export function AnchoredChatBar() {
   }, []);
 
   useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const SR = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+    const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
     if (!SR) return;
     const rec: SpeechRecognition = new SR();
     rec.continuous = false;
     rec.interimResults = false;
     rec.onresult = (e: SpeechRecognitionEvent) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const transcript = (e.results as any)?.[0]?.[0]?.transcript as string;
+      const transcript = e.results[0]?.[0]?.transcript;
       if (transcript) {
         setSuggestion(transcript);
       }

--- a/types/speech.d.ts
+++ b/types/speech.d.ts
@@ -1,0 +1,44 @@
+interface SpeechRecognitionEvent extends Event {
+  results: SpeechRecognitionResultList;
+}
+
+interface SpeechRecognitionResultList {
+  [index: number]: SpeechRecognitionResult;
+  length: number;
+}
+
+interface SpeechRecognitionResult {
+  [index: number]: SpeechRecognitionAlternative;
+  length: number;
+  isFinal?: boolean;
+}
+
+interface SpeechRecognitionAlternative {
+  transcript: string;
+  confidence?: number;
+}
+
+interface SpeechRecognition extends EventTarget {
+  continuous: boolean;
+  interimResults: boolean;
+  onresult: ((event: SpeechRecognitionEvent) => void) | null;
+  onstart: ((event: Event) => void) | null;
+  onend: ((event: Event) => void) | null;
+  start(): void;
+  stop(): void;
+}
+
+declare const SpeechRecognition: {
+  prototype: SpeechRecognition;
+  new (): SpeechRecognition;
+};
+
+declare const webkitSpeechRecognition: {
+  prototype: SpeechRecognition;
+  new (): SpeechRecognition;
+};
+
+interface Window {
+  SpeechRecognition?: typeof SpeechRecognition;
+  webkitSpeechRecognition?: typeof SpeechRecognition;
+}


### PR DESCRIPTION
## Summary
- add minimal SpeechRecognition interfaces and events
- use typed SpeechRecognition in AnchoredChatBar

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export' from jose)*
- `npm run lint` *(fails: 313 problems (289 errors, 24 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68ac6a04053883268f828d229a225bfe