### PR TITLE
refactor: use async/await for session insertion

### DIFF
--- a/src/components/hypno/HypnoPanel.tsx
+++ b/src/components/hypno/HypnoPanel.tsx
@@ -36,13 +36,16 @@ export default function HypnoPanel({ onClose }: Props) {
     const user = await getTonUser();
     const uid = user?.id;
     if (uid) {
-      db.from("sessions").insert({
-        user_id: uid,
-        type: "hypno",
-        mood_before: mood,
-      })
-      .then(() => logEvent("session_start", { type: "hypno" }))
-      .catch((e) => console.error("[HypnoPanel] session insert failed", e));
+      try {
+        await db.from("sessions").insert({
+          user_id: uid,
+          type: "hypno",
+          mood_before: mood,
+        });
+        await logEvent("session_start", { type: "hypno" });
+      } catch (e) {
+        console.error("[HypnoPanel] session insert failed", e);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- replace promise chain with async/await and try/catch when starting a hypno session

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in jose)*
- `npm run lint` *(fails: multiple lint errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6a058d808326bd7d57077a5cf3f4