### PR TITLE
Cast stmt.getAsObject result

### DIFF
--- a/src/memory/brainBackup.test.ts
+++ b/src/memory/brainBackup.test.ts
@@ -16,7 +16,8 @@ describe('brain backup round trip', () => {
     const stmt = db2.prepare("SELECT content FROM memories");
     let content = '';
     if (stmt.step()) {
-      content = String(stmt.getAsObject().content || '');
+      const row = stmt.getAsObject() as { content?: string };
+      content = String(row.content || '');
     }
     stmt.free();
     expect(content).toBe('hello');


### PR DESCRIPTION
## Summary
- Cast SQLite query result to `{ content?: string }` before reading `.content` in `brainBackup` test.

## Testing
- `npm test` *(fails: Jest encountered ESM syntax in `jose` for server/auth/__tests__/ton.spec.ts and server/replicate/__tests__/replicate.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6a07670c832691d42d941e90bb77