### PR TITLE
Use ArrayBuffer for encrypted brain backups

### DIFF
--- a/src/components/settings/BrainBackupPanel.tsx
+++ b/src/components/settings/BrainBackupPanel.tsx
@@ -21,7 +21,8 @@ export default function BrainBackupPanel() {
     }
     setBusy(true);
     try {
-      const blob = await exportEncryptedBrain(passphrase);
+      const data = await exportEncryptedBrain(passphrase);
+      const blob = new Blob([data], { type: 'application/x-aurora' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
@@ -50,7 +51,8 @@ export default function BrainBackupPanel() {
       if (!file) return;
       setBusy(true);
       try {
-        await importEncryptedBrain(file, passphrase);
+        const buffer = await file.arrayBuffer();
+        await importEncryptedBrain(buffer, passphrase);
         toast({ title: 'Brain restored', description: 'Reloading…' });
         location.reload();
       } catch (e) {

--- a/src/hooks/useWeeklyBrainBackup.ts
+++ b/src/hooks/useWeeklyBrainBackup.ts
@@ -20,7 +20,8 @@ export default function useWeeklyBrainBackup() {
     }
     const run = async () => {
       try {
-        const blob = await exportEncryptedBrain(passphrase);
+        const data = await exportEncryptedBrain(passphrase);
+        const blob = new Blob([data], { type: 'application/x-aurora' });
         const path = `${user.id}/${now.toISOString()}.bin`;
         await uploadToStorage('brain-backups', path, blob);
 

--- a/src/memory/brainBackup.test.ts
+++ b/src/memory/brainBackup.test.ts
@@ -8,10 +8,10 @@ describe('brain backup round trip', () => {
     db.run("CREATE TABLE IF NOT EXISTS memories (id INTEGER PRIMARY KEY AUTOINCREMENT, content TEXT)");
     db.run("INSERT INTO memories (content) VALUES ('hello')");
     await db.saveToDisk();
-    const blob = await exportEncryptedBrain('pass');
+    const data = await exportEncryptedBrain('pass');
     await closeBrainDb();
     __setMemoryDb(null);
-    await importEncryptedBrain(blob, 'pass');
+    await importEncryptedBrain(data, 'pass');
     const db2 = await openBrainDb();
     const stmt = db2.prepare("SELECT content FROM memories");
     let content = '';

--- a/src/memory/brainBackup.ts
+++ b/src/memory/brainBackup.ts
@@ -5,9 +5,15 @@ const DB_FILE = 'brain.db';
 
 async function deriveKey(passphrase: string, salt: Uint8Array) {
   const enc = new TextEncoder();
-  const keyMaterial = await crypto.subtle.importKey('raw', enc.encode(passphrase), 'PBKDF2', false, ['deriveKey']);
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(passphrase),
+    'PBKDF2',
+    false,
+    ['deriveKey']
+  );
   return crypto.subtle.deriveKey(
-    { name: 'PBKDF2', salt, iterations: 100000, hash: 'SHA-256' },
+    { name: 'PBKDF2', salt: salt.buffer, iterations: 100000, hash: 'SHA-256' },
     keyMaterial,
     { name: 'AES-GCM', length: 256 },
     false,
@@ -15,7 +21,7 @@ async function deriveKey(passphrase: string, salt: Uint8Array) {
   );
 }
 
-export async function exportEncryptedBrain(passphrase: string): Promise<Blob> {
+export async function exportEncryptedBrain(passphrase: string): Promise<ArrayBuffer> {
   const db: BrainDatabase = await openBrainDb();
   await db.saveToDisk();
   const data = db.export();
@@ -23,13 +29,13 @@ export async function exportEncryptedBrain(passphrase: string): Promise<Blob> {
   const iv = crypto.getRandomValues(new Uint8Array(12));
   const key = await deriveKey(passphrase, salt);
   const encrypted = new Uint8Array(
-    await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, data)
+    await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, data.buffer)
   );
   const out = new Uint8Array(salt.length + iv.length + encrypted.length);
   out.set(salt, 0);
   out.set(iv, salt.length);
   out.set(encrypted, salt.length + iv.length);
-  return new Blob([out], { type: 'application/x-aurora' });
+  return out.buffer;
 }
 
 async function writeBrain(bytes: Uint8Array) {
@@ -72,14 +78,14 @@ async function writeBrain(bytes: Uint8Array) {
   __setMemoryDb(bytes);
 }
 
-export async function importEncryptedBrain(blob: Blob, passphrase: string) {
-  const buf = new Uint8Array(await blob.arrayBuffer());
+export async function importEncryptedBrain(buffer: ArrayBuffer, passphrase: string) {
+  const buf = new Uint8Array(buffer);
   const salt = buf.slice(0, 16);
   const iv = buf.slice(16, 28);
   const data = buf.slice(28);
   const key = await deriveKey(passphrase, salt);
   const decrypted = new Uint8Array(
-    await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, data)
+    await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, data.buffer)
   );
   await writeBrain(decrypted);
 }

--- a/src/views/BrainView.tsx
+++ b/src/views/BrainView.tsx
@@ -176,7 +176,8 @@ export default function BrainView() {
   const handleExport = async () => {
     const pass = prompt('Passphrase to encrypt backup') || '';
     if (!pass) return;
-    const blob = await exportEncryptedBrain(pass);
+    const data = await exportEncryptedBrain(pass);
+    const blob = new Blob([data], { type: 'application/x-aurora' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
@@ -188,7 +189,8 @@ export default function BrainView() {
   const handleImport = async (file: File) => {
     const pass = prompt('Passphrase to decrypt backup') || '';
     if (!pass) return;
-    await importEncryptedBrain(file, pass);
+    const buffer = await file.arrayBuffer();
+    await importEncryptedBrain(buffer, pass);
     window.location.reload();
   };
 


### PR DESCRIPTION
## Summary
- Use `ArrayBuffer` for encrypted brain backup export/import
- Pass `salt.buffer` and `data.buffer` to WebCrypto operations
- Adjust backup consumers and tests for new interfaces

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export' in node_modules/jose)*
- `npm test -- src/memory/brainBackup.test.ts`
- `npm run lint` *(fails: 314 problems (290 errors, 24 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68ac6d92c3fc8326b106bba7a237f8d3