### PR TITLE
test: add explicit jest mock types

### DIFF
--- a/src/modules/payments/__tests__/guard.test.ts
+++ b/src/modules/payments/__tests__/guard.test.ts
@@ -3,7 +3,7 @@ import { guardPremiumAction } from '../guard';
 import { logEvent } from '@/integrations/db';
 
 jest.mock('@/integrations/db', () => ({
-  logEvent: jest.fn().mockResolvedValue(undefined),
+  logEvent: jest.fn<Promise<void>, any[]>().mockResolvedValue(undefined),
 }));
 
 describe('guardPremiumAction', () => {
@@ -20,23 +20,23 @@ describe('guardPremiumAction', () => {
   });
 
   it('prompts and logs when feature is unavailable', async () => {
-    global.confirm = jest.fn(() => true);
+    global.confirm = jest.fn<boolean, any[]>(() => true);
     const result = await guardPremiumAction(() => false, 'voice_features', 'voice_clone', 'use default voice');
     expect(result).toBe('free');
     expect(logEvent).toHaveBeenCalledWith('pro_action_upsell', { action: 'voice_clone' });
   });
 
   it('returns null when user cancels', async () => {
-    global.confirm = jest.fn(() => false);
+    global.confirm = jest.fn<boolean, any[]>(() => false);
     const result = await guardPremiumAction(() => false, 'voice_features', 'voice_clone', 'use default voice');
     expect(result).toBeNull();
     expect(logEvent).toHaveBeenCalledWith('pro_action_upsell', { action: 'voice_clone' });
   });
 
   it('executes free alternative after confirmation', async () => {
-    global.confirm = jest.fn(() => true);
+    global.confirm = jest.fn<boolean, any[]>(() => true);
     const result = await guardPremiumAction(() => false, 'voice_features', 'voice_clone', 'use default voice');
-    const alternative = jest.fn();
+    const alternative = jest.fn<void, any[]>();
     if (result === 'free') {
       alternative();
     }

--- a/src/modules/payments/__tests__/pricingPage.test.tsx
+++ b/src/modules/payments/__tests__/pricingPage.test.tsx
@@ -15,14 +15,18 @@ jest.mock('framer-motion', () => {
   };
 });
 
-jest.mock('@/hooks/use-toast', () => ({ toast: jest.fn() }));
+jest.mock('@/hooks/use-toast', () => ({ toast: jest.fn<void, any[]>() }));
 
 jest.mock('@/modules/payments/api/subscription', () => ({
-  createCheckoutSession: jest.fn().mockResolvedValue({ url: 'https://example.com' }),
+  createCheckoutSession: jest
+    .fn<Promise<{ sessionId: string; url: string }>, any[]>()
+    .mockResolvedValue({ sessionId: 'session123', url: 'https://example.com' }),
 }));
 
 jest.mock('@/modules/payments/hooks/useSubscription', () => ({
-  useSubscription: jest.fn().mockReturnValue({ subscription: null }),
+  useSubscription: jest
+    .fn<{ subscription: null; refetch: jest.Mock }, any[]>()
+    .mockReturnValue({ subscription: null, refetch: jest.fn<void, any[]>() }),
 }));
 
 import { createCheckoutSession } from '@/modules/payments/api/subscription';

--- a/src/modules/payments/__tests__/subscription.test.ts
+++ b/src/modules/payments/__tests__/subscription.test.ts
@@ -1,7 +1,7 @@
 import { jest } from '@jest/globals';
 
 // Mock loggedFetch to avoid real network calls and side effects
-const mockLoggedFetch = jest.fn();
+const mockLoggedFetch = jest.fn<Promise<Response>, any[]>();
 jest.mock('@/lib/loggedFetch', () => ({ loggedFetch: mockLoggedFetch }));
 
 let getSubscription: any;
@@ -30,7 +30,7 @@ beforeEach(() => {
   mockLoggedFetch.mockReset();
   // minimal localStorage stub
   (global as any).localStorage = {
-    getItem: jest.fn(() => null),
+    getItem: jest.fn<string | null, any[]>(() => null),
   };
 });
 

--- a/src/voice/__tests__/voiceService.test.ts
+++ b/src/voice/__tests__/voiceService.test.ts
@@ -10,10 +10,10 @@ import * as ts from 'typescript';
 let voiceService: typeof import('../voiceService').voiceService;
 
 jest.mock('@/modules/payments/guard', () => ({
-  guardPremiumAction: jest.fn(),
+  guardPremiumAction: jest.fn<Promise<'pro' | 'free' | null>, any[]>(),
 }));
 jest.mock('@/voice/voiceClone', () => ({
-  playClonedVoice: jest.fn(),
+  playClonedVoice: jest.fn<Promise<{ audio: any; error?: unknown }>, any[]>(),
 }));
 jest.mock('@/state/voice', () => {
   const { create } = require('zustand');
@@ -36,7 +36,7 @@ jest.mock('@/state/featureFlags', () => ({
 }));
 
 class MockTrack {
-  stop = jest.fn();
+  stop = jest.fn<void, any[]>();
 }
 class MockMediaStream {
   private tracks = [new MockTrack()];
@@ -45,19 +45,22 @@ class MockMediaStream {
   }
 }
 class MockAudio {
-  play = jest.fn().mockResolvedValue(undefined);
-  pause = jest.fn();
+  play = jest.fn<Promise<void>, any[]>().mockResolvedValue(undefined);
+  pause = jest.fn<void, any[]>();
   srcObject: any = null;
 }
 class MockRTCPeerConnection {
   ondatachannel: any;
   ontrack: any;
-  addTrack = jest.fn();
-  getSenders = jest.fn(() => [{ track: new MockTrack() }]);
-  createOffer = jest.fn().mockResolvedValue({ sdp: 'offer', type: 'offer' });
-  setLocalDescription = jest.fn();
-  setRemoteDescription = jest.fn();
-  close = jest.fn();
+  addTrack = jest.fn<void, any[]>();
+  getSenders = jest.fn<{ track: MockTrack }[], any[]>(() => [{ track: new MockTrack() }]);
+  createOffer = jest.fn<Promise<{ sdp: string; type: string }>, any[]>().mockResolvedValue({
+    sdp: 'offer',
+    type: 'offer',
+  });
+  setLocalDescription = jest.fn<void, any[]>();
+  setRemoteDescription = jest.fn<void, any[]>();
+  close = jest.fn<void, any[]>();
 }
 
 beforeAll(() => {
@@ -76,22 +79,22 @@ beforeAll(() => {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  (global as any).Audio = jest.fn(() => new MockAudio());
+  (global as any).Audio = jest.fn<MockAudio, any[]>(() => new MockAudio());
   (global as any).RTCPeerConnection = MockRTCPeerConnection as any;
   Object.defineProperty(global.navigator, 'mediaDevices', {
-    value: { getUserMedia: jest.fn().mockResolvedValue(new MockMediaStream()) },
+    value: { getUserMedia: jest.fn<Promise<MockMediaStream>, any[]>().mockResolvedValue(new MockMediaStream()) },
     configurable: true,
   });
-  (global as any).fetch = jest.fn().mockResolvedValue({
+  (global as any).fetch = jest.fn<Promise<any>, any[]>().mockResolvedValue({
     ok: true,
     json: async () => ({ sdp: 'answer', type: 'answer' }),
   });
 
   (window as any).speechSynthesis = {
-    cancel: jest.fn(),
-    speak: jest.fn(),
-    getVoices: jest.fn(() => [{ lang: 'en-US' }]),
-    resume: jest.fn(),
+    cancel: jest.fn<void, any[]>(),
+    speak: jest.fn<void, any[]>(),
+    getVoices: jest.fn<{ lang: string }[], any[]>(() => [{ lang: 'en-US' }]),
+    resume: jest.fn<void, any[]>(),
   } as any;
   (global as any).SpeechSynthesisUtterance = class {
     text: string;
@@ -142,7 +145,7 @@ describe('voiceService', () => {
     useVoiceStore.getState().setMode('eleven-default', false);
     (playClonedVoice as jest.Mock).mockResolvedValue({
       audio: new (class extends MockAudio {
-        play = jest.fn().mockRejectedValue({ name: 'NotAllowedError' });
+        play = jest.fn<Promise<unknown>, any[]>().mockRejectedValue({ name: 'NotAllowedError' });
       })(),
       error: { name: 'NotAllowedError' },
     });


### PR DESCRIPTION
## Summary
- add explicit jest mock generics across payment and voice tests
- ensure mocked subscription checkout matches expected return type
- cast local mocks for logged fetch and browser APIs

## Testing
- `npm test` *(fails: server/auth/__tests__/ton.spec.ts, server/replicate/__tests__/replicate.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6d9a43fc83268b6c4b46a820f310