### PR TITLE
Store goal and sprint identifiers when creating tasks

### DIFF
--- a/src/state/roadmapStore.ts
+++ b/src/state/roadmapStore.ts
@@ -201,6 +201,8 @@ export async function createTask(
   const dbTask: DBTask = {
     id: task.id,
     roadmap_id: goalId,
+    goal_id: goalId,
+    sprint_id: sprintId,
     title: task.title,
     description: task.notes ?? null,
     status: task.status,


### PR DESCRIPTION
## Summary
- attach `goal_id` and `sprint_id` to `dbTask` in `createTask` for proper metadata

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in server auth/replicate tests)*
- `npm run lint` *(fails: multiple lint errors, e.g., Unexpected any in app/view/identity/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6da2e8c48326987518b8f779f979