### PR TITLE
refactor: remove disableNormalPass from identity scene

### DIFF
--- a/src/three/ComposedIdentityScene.tsx
+++ b/src/three/ComposedIdentityScene.tsx
@@ -31,7 +31,7 @@ export function ComposedIdentityScene({ xp, streak, mood }: ComposedIdentityScen
       <Canvas className="absolute inset-0" camera={{ position: [0, 0, 4], fov: 60 }}>
         <ambientLight intensity={0.4} />
         <HoloBrain seed={seed} color={color} pulse={pulse} particles={particles} />
-        <EffectComposer disableNormalPass>
+        <EffectComposer enableNormalPass={false}>
           <Bloom luminanceThreshold={0.2} intensity={0.8} />
           <FXAA />
         </EffectComposer>


### PR DESCRIPTION
## Summary
- replace deprecated `disableNormalPass` with `enableNormalPass={false}` in `ComposedIdentityScene`

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export' in server/auth/__tests__/ton.spec.ts and server/replicate/__tests__/replicate.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6da559848326bdf55d4f614dd5dc