### PR TITLE
fix: cast HoloBrain material ref

### DIFF
--- a/src/three/HoloBrain.tsx
+++ b/src/three/HoloBrain.tsx
@@ -1,5 +1,5 @@
 // [AURORA-BEGIN:three-holobrain]
-import { useMemo, useRef } from 'react';
+import { useMemo, useRef, type Ref } from 'react';
 import * as THREE from 'three';
 import { extend, useFrame, type ReactThreeFiber } from '@react-three/fiber';
 import { shaderMaterial } from '@react-three/drei';
@@ -116,7 +116,9 @@ export function HoloBrain({
   return (
     <group ref={group} {...props}>
       <mesh geometry={geometry}>
-        <fresnelMaterial ref={material} />
+        <fresnelMaterial
+          ref={material as unknown as Ref<THREE.ShaderMaterial>}
+        />
       </mesh>
       <points geometry={particleGeometry}>
         <pointsMaterial size={0.02} color={color} transparent opacity={0.6} />


### PR DESCRIPTION
## Summary
- cast HoloBrain Fresnel material ref to ShaderMaterial

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export' in jose ESM module)*
- `npm run lint` *(fails: 314 problems (290 errors, 24 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68ac6dab2ae8832698107673f8b2596d