### PR TITLE
Handle toast id in retry updates

### DIFF
--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -13,7 +13,7 @@ export async function retryWithBackoff<T>(
     try {
       const result = await fn();
       if (t && attempt > 0) {
-        t.update({ description: 'Success' });
+        t.update({ id: t.id, description: 'Success' });
         setTimeout(() => t?.dismiss(), 2000);
       }
       return result;
@@ -23,7 +23,7 @@ export async function retryWithBackoff<T>(
       }
       attempt++;
       if (attempt > maxRetries) {
-        t.update({ description: 'Failed', variant: 'destructive' });
+        t.update({ id: t.id, description: 'Failed', variant: 'destructive' });
         setTimeout(() => t?.dismiss(), 2000);
         throw err;
       }


### PR DESCRIPTION
## Summary
- include toast id when updating retry success and failure toasts

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export')*
- `npm run lint` *(fails: 314 problems, 290 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6dacd5d88326b1e408824cf79373