### PR TITLE
refactor: broaden view component type

### DIFF
--- a/src/views/registry.tsx
+++ b/src/views/registry.tsx
@@ -10,7 +10,7 @@ export type ViewMeta = {
   label: string;
   path: string;
   icon?: JSX.Element;
-  component: React.LazyExoticComponent<() => JSX.Element>;
+  component: React.LazyExoticComponent<React.ComponentType<any>>;
   hotkey?: string;
 };
 


### PR DESCRIPTION
## Summary
- use `React.ComponentType` for view registry component type so entries can expose any component signature

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in jose ESM)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6db3adc88326ac2bb4c6c19046be