### PR TITLE
Fix key handling in NFT asset upload

### DIFF
--- a/server/nft/assets.ts
+++ b/server/nft/assets.ts
@@ -63,7 +63,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     let key: string | undefined;
     for await (const part of parts) {
       if (part.type === 'file' && part.fieldname === 'file') file = part;
-      if (part.type === 'field' && part.fieldname === 'key') key = part.value;
+      if (part.type === 'field' && part.fieldname === 'key') key = String(part.value);
     }
     if (!file || !key || !isValidKey(key)) {
       return reply.code(400).send({ error: 'invalid_payload' });


### PR DESCRIPTION
## Summary
- Ensure multipart key field is coerced to string before validation

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7607fa70832697e72bfbd52bd15f