### PR TITLE
test: refine jest mocks in subscription test

### DIFF
--- a/src/modules/payments/__tests__/subscription.test.ts
+++ b/src/modules/payments/__tests__/subscription.test.ts
@@ -1,7 +1,7 @@
 import { jest } from '@jest/globals';
 
 // Mock loggedFetch to avoid real network calls and side effects
-const mockLoggedFetch = jest.fn<Promise<Response>, any[]>();
+const mockLoggedFetch = jest.fn<(...args: any[]) => Promise<Response>>();
 jest.mock('@/lib/loggedFetch', () => ({ loggedFetch: mockLoggedFetch }));
 
 let getSubscription: any;
@@ -30,7 +30,7 @@ beforeEach(() => {
   mockLoggedFetch.mockReset();
   // minimal localStorage stub
   (global as any).localStorage = {
-    getItem: jest.fn<string | null, any[]>(() => null),
+    getItem: jest.fn<() => string | null>(() => null),
   };
 });
 


### PR DESCRIPTION
## Summary
- adjust mockLoggedFetch type to use a generic function signature
- update localStorage.getItem mock to use jest.fn without args

## Testing
- `npm test -- src/modules/payments/__tests__/subscription.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ac761740488326b1d13f8643c67497