### PR TITLE
Use wrapped key encryption for Dexie storage

### DIFF
--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -1,12 +1,13 @@
 import { addRxPlugin, createRxDatabase, type RxCollection, type RxDatabase, type RxJsonSchema } from 'rxdb';
 import { RxDBAttachmentsPlugin } from 'rxdb/plugins/attachments';
-import { RxDBEncryptionPlugin } from 'rxdb/plugins/encryption-crypto-js';
+import { wrappedKeyEncryptionCryptoJsStorage } from 'rxdb/plugins/encryption-crypto-js';
 import { getRxStorageDexie } from 'rxdb/plugins/storage-dexie';
 import type { Observable } from 'rxjs';
 import { getDataKey, waitForDataKey } from './keyManager';
 
 addRxPlugin(RxDBAttachmentsPlugin);
-addRxPlugin(RxDBEncryptionPlugin);
+
+const storage = wrappedKeyEncryptionCryptoJsStorage({ storage: getRxStorageDexie() });
 
 export interface JournalEntry {
   id: string;
@@ -103,7 +104,7 @@ export async function createDatabase(): Promise<RxDatabase<Collections>> {
     const password = btoa(String.fromCharCode(...key));
     dbPromise = createRxDatabase<Collections>({
       name: 'brain',
-      storage: getRxStorageDexie(),
+      storage,
       password,
     }).then(async (db) => {
       await db.addCollections({


### PR DESCRIPTION
## Summary
- remove RxDBEncryptionPlugin and use wrappedKeyEncryptionCryptoJsStorage
- wrap Dexie storage with key encryption and pass to database creation

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in jose ESM modules)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7619b0d8832696a77312cc4a8a88