### PR TITLE
Use BufferSource directly in SHA-256 digests

### DIFF
--- a/src/state/keyManager.ts
+++ b/src/state/keyManager.ts
@@ -82,7 +82,7 @@ export function clearDataKey() {
 export async function deriveDataKey(signedMessage: string, passcode: string) {
   const messageBytes = decodeSignedMessage(signedMessage);
   const msgHash = new Uint8Array(
-    await crypto.subtle.digest('SHA-256', messageBytes.buffer)
+    await crypto.subtle.digest('SHA-256', messageBytes)
   );
   const enc = new TextEncoder();
   const passBytes = enc.encode(passcode);
@@ -91,7 +91,7 @@ export async function deriveDataKey(signedMessage: string, passcode: string) {
   combined.set(passBytes, msgHash.length);
   const baseKey = await crypto.subtle.importKey('raw', combined, 'PBKDF2', false, ['deriveBits']);
   const salt = new Uint8Array(
-    await crypto.subtle.digest('SHA-256', passBytes.buffer)
+    await crypto.subtle.digest('SHA-256', passBytes)
   );
   const bits = await crypto.subtle.deriveBits(
     {


### PR DESCRIPTION
## Summary
- pass `Uint8Array` objects directly to `crypto.subtle.digest`
- avoid relying on `.buffer` when hashing message and passcode in `deriveDataKey`

## Testing
- `npm run lint` *(fails: Unexpected any ...)*
- `npm test` *(fails: Jest encountered an unexpected token in server tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ac76238a008326bc342e71fd1cafe1