### PR TITLE
feat(three): enhance fresnel material typing

### DIFF
--- a/src/three/HoloBrain.tsx
+++ b/src/three/HoloBrain.tsx
@@ -1,5 +1,5 @@
 // [AURORA-BEGIN:three-holobrain]
-import { useMemo, useRef, type Ref } from 'react';
+import { useMemo, useRef } from 'react';
 import * as THREE from 'three';
 import { extend, useFrame, type ReactThreeFiber } from '@react-three/fiber';
 import { shaderMaterial } from '@react-three/drei';
@@ -42,7 +42,11 @@ declare global {
   namespace JSX {
     interface IntrinsicElements {
       fresnelMaterial: ReactThreeFiber.Object3DNode<
-        typeof FresnelMaterial,
+        THREE.ShaderMaterial & {
+          time: number;
+          pulse: number;
+          color: THREE.Color;
+        },
         typeof FresnelMaterial
       >;
     }
@@ -116,9 +120,7 @@ export function HoloBrain({
   return (
     <group ref={group} {...props}>
       <mesh geometry={geometry}>
-        <fresnelMaterial
-          ref={material as unknown as Ref<THREE.ShaderMaterial>}
-        />
+        <fresnelMaterial ref={material} />
       </mesh>
       <points geometry={particleGeometry}>
         <pointsMaterial size={0.02} color={color} transparent opacity={0.6} />


### PR DESCRIPTION
## Summary
- add fresnelMaterial to JSX intrinsic elements with full shader material type
- remove unnecessary ref cast in HoloBrain component

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export')*
- `npm run lint` *(fails: 281 errors, e.g. Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68ac76248390832688df4713ad223c3d