### PR TITLE
refactor: remove custom speech recognition

### DIFF
--- a/src/voice/voiceio.ts
+++ b/src/voice/voiceio.ts
@@ -3,20 +3,9 @@ import { voiceService } from '@/voice/voiceService';
 import { bus } from '@/utils/bus';
 
 declare global {
-  interface SpeechRecognition {
-    lang: string;
-    interimResults: boolean;
-    maxAlternatives: number;
-    onresult: ((event: any) => void) | null;
-    onerror: ((event: any) => void) | null;
-    onend: (() => void) | null;
-    start(): void;
-    stop(): void;
-  }
-
   interface Window {
-    SpeechRecognition?: new () => SpeechRecognition;
-    webkitSpeechRecognition?: new () => SpeechRecognition;
+    SpeechRecognition?: typeof SpeechRecognition;
+    webkitSpeechRecognition?: typeof SpeechRecognition;
   }
 }
 


### PR DESCRIPTION
## Summary
- remove custom SpeechRecognition interface and rely on global types

## Testing
- `npm test` (fails: SyntaxError: Unexpected token 'export')
- `npm run lint` (fails: 303 problems)

------
https://chatgpt.com/codex/tasks/task_e_68ac7627e8808326b9da2d1770733114