### PR TITLE
feat: add Web Speech API type extensions

### DIFF
--- a/src/types/web-speech.d.ts
+++ b/src/types/web-speech.d.ts
@@ -1,0 +1,12 @@
+export {};
+
+declare global {
+  interface SpeechRecognition {
+    lang: string;
+    maxAlternatives: number;
+    interimResults: boolean;
+    onerror: ((event: any) => void) | null;
+  }
+}
+
+export type WebSpeechRecognition = SpeechRecognition;

--- a/src/voice/voiceio.ts
+++ b/src/voice/voiceio.ts
@@ -1,6 +1,7 @@
 import { useVoiceStore } from '@/state/voice';
 import { voiceService } from '@/voice/voiceService';
 import { bus } from '@/utils/bus';
+import type { WebSpeechRecognition } from '@/types/web-speech';
 
 declare global {
   interface Window {
@@ -17,7 +18,7 @@ export type VoiceCallbacks = {
 };
 
 export class VoiceIO {
-  private recognition: SpeechRecognition | null = null;
+  private recognition: WebSpeechRecognition | null = null;
   private callbacks: VoiceCallbacks;
 
   constructor(callbacks: VoiceCallbacks = {}) {
@@ -36,7 +37,7 @@ export class VoiceIO {
       this.callbacks.onError?.(new Error('Web Speech API not available'));
       return;
     }
-    this.recognition = new SR();
+    this.recognition = new SR() as WebSpeechRecognition;
     const { locale } = useVoiceStore.getState();
     this.recognition.lang = locale;
     this.recognition.interimResults = true;


### PR DESCRIPTION
## Summary
- add ambient Web Speech API definitions with language and error support
- use `WebSpeechRecognition` typing in voice IO implementation

## Testing
- `npm test` (fails: Jest encountered an unexpected token)
- `npm run lint` (fails: @typescript-eslint/no-explicit-any)


------
https://chatgpt.com/codex/tasks/task_e_68ac7a171eb483268a9849e15d98d2ca