### PR TITLE
fix: cast crypto inputs to BufferSource

### DIFF
--- a/src/memory/brainBackup.ts
+++ b/src/memory/brainBackup.ts
@@ -7,13 +7,18 @@ async function deriveKey(passphrase: string, salt: Uint8Array) {
   const enc = new TextEncoder();
   const keyMaterial = await crypto.subtle.importKey(
     'raw',
-    enc.encode(passphrase),
+    enc.encode(passphrase) as BufferSource,
     'PBKDF2',
     false,
     ['deriveKey']
   );
   return crypto.subtle.deriveKey(
-    { name: 'PBKDF2', salt, iterations: 100000, hash: 'SHA-256' },
+    {
+      name: 'PBKDF2',
+      salt: salt as BufferSource,
+      iterations: 100000,
+      hash: 'SHA-256',
+    },
     keyMaterial,
     { name: 'AES-GCM', length: 256 },
     false,
@@ -29,7 +34,11 @@ export async function exportEncryptedBrain(passphrase: string): Promise<ArrayBuf
   const iv = crypto.getRandomValues(new Uint8Array(12));
   const key = await deriveKey(passphrase, salt);
   const encrypted = new Uint8Array(
-    await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, data)
+    await crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv: iv as BufferSource },
+      key,
+      data as BufferSource,
+    )
   );
   const out = new Uint8Array(salt.length + iv.length + encrypted.length);
   out.set(salt, 0);
@@ -46,7 +55,7 @@ async function writeBrain(bytes: Uint8Array) {
       const root = await (navigator as any).storage.getDirectory();
       const handle = await root.getFileHandle(DB_FILE, { create: true });
       const writable = await handle.createWritable();
-      await writable.write(bytes);
+      await writable.write(bytes as BufferSource);
       await writable.close();
       return;
     } catch {
@@ -85,7 +94,11 @@ export async function importEncryptedBrain(buffer: ArrayBuffer, passphrase: stri
   const data = buf.slice(28);
   const key = await deriveKey(passphrase, salt);
   const decrypted = new Uint8Array(
-    await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, data)
+    await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: iv as BufferSource },
+      key,
+      data as BufferSource,
+    )
   );
   await writeBrain(decrypted);
 }

--- a/src/memory/brainDb.ts
+++ b/src/memory/brainDb.ts
@@ -47,13 +47,18 @@ async function deriveKey(
   const enc = new TextEncoder();
   const keyMaterial = await crypto.subtle.importKey(
     "raw",
-    enc.encode(passphrase),
+    enc.encode(passphrase) as BufferSource,
     "PBKDF2",
     false,
     ["deriveKey"],
   );
   return crypto.subtle.deriveKey(
-    { name: "PBKDF2", salt, iterations: 100000, hash: "SHA-256" },
+    {
+      name: "PBKDF2",
+      salt: salt as BufferSource,
+      iterations: 100000,
+      hash: "SHA-256",
+    },
     keyMaterial,
     { name: "AES-GCM", length: 256 },
     false,
@@ -70,9 +75,9 @@ async function encryptData(
   const key = await deriveKey(passphrase, salt);
   const encrypted = new Uint8Array(
     await crypto.subtle.encrypt(
-      { name: "AES-GCM", iv },
+      { name: "AES-GCM", iv: iv as BufferSource },
       key,
-      data,
+      data as BufferSource,
     ),
   );
   const out = new Uint8Array(salt.length + iv.length + encrypted.length);
@@ -93,9 +98,9 @@ async function decryptData(
   const key = await deriveKey(passphrase, salt);
   const decrypted = new Uint8Array(
     await crypto.subtle.decrypt(
-      { name: "AES-GCM", iv },
+      { name: "AES-GCM", iv: iv as BufferSource },
       key,
-      enc,
+      enc as BufferSource,
     ),
   );
   return decrypted;
@@ -221,7 +226,7 @@ export async function openBrainDb(): Promise<BrainDatabase> {
       if (opfsHandle) {
         try {
           const writable = await opfsHandle.createWritable();
-          await writable.write(data);
+          await writable.write(data as BufferSource);
           await writable.close();
         } catch {
           toast({ title: "Storage error", description: "OPFS write failed" });
@@ -239,7 +244,7 @@ export async function openBrainDb(): Promise<BrainDatabase> {
             const root = await (navigator as any).storage.getDirectory();
             opfsHandle = await root.getFileHandle(DB_FILE, { create: true });
             const writable = await opfsHandle.createWritable();
-            await writable.write(data);
+            await writable.write(data as BufferSource);
             await writable.close();
           } catch {
             toast({ title: "Storage error", description: "OPFS sync failed" });

--- a/src/state/keyManager.ts
+++ b/src/state/keyManager.ts
@@ -82,21 +82,21 @@ export function clearDataKey() {
 export async function deriveDataKey(signedMessage: string, passcode: string) {
   const messageBytes = decodeSignedMessage(signedMessage);
   const msgHash = new Uint8Array(
-    await crypto.subtle.digest('SHA-256', messageBytes)
+    await crypto.subtle.digest('SHA-256', messageBytes as BufferSource)
   );
   const enc = new TextEncoder();
   const passBytes = enc.encode(passcode);
   const combined = new Uint8Array(msgHash.length + passBytes.length);
   combined.set(msgHash);
   combined.set(passBytes, msgHash.length);
-  const baseKey = await crypto.subtle.importKey('raw', combined, 'PBKDF2', false, ['deriveBits']);
+  const baseKey = await crypto.subtle.importKey('raw', combined as BufferSource, 'PBKDF2', false, ['deriveBits']);
   const salt = new Uint8Array(
-    await crypto.subtle.digest('SHA-256', passBytes)
+    await crypto.subtle.digest('SHA-256', passBytes as BufferSource)
   );
   const bits = await crypto.subtle.deriveBits(
     {
       name: 'PBKDF2',
-      salt,
+      salt: salt as BufferSource,
       iterations: 150_000,
       hash: 'SHA-256'
     },


### PR DESCRIPTION
## Summary
- cast salts, ivs, and data to BufferSource before crypto operations
- cast Uint8Array writes to BufferSource for FileSystemWritableFileStream
- ensure key derivation uses BufferSource in key manager

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in server tests)*
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7a1514ec832684ff6e62b6f68287