### PR TITLE
refactor: type buffer as ArrayBufferLike

### DIFF
--- a/src/memory/brainDb.ts
+++ b/src/memory/brainDb.ts
@@ -190,11 +190,13 @@ export async function openBrainDb(): Promise<BrainDatabase> {
     if (opfsHandle) {
       try {
         const file = await opfsHandle.getFile();
-        let buffer = new Uint8Array(await file.arrayBuffer());
+        let buffer: Uint8Array<ArrayBufferLike> = new Uint8Array(
+          await file.arrayBuffer(),
+        );
         const { passphrase } = getEncryptionSettings();
         if (passphrase && buffer.byteLength) {
           try {
-            buffer = (await decryptData(buffer, passphrase)) as Uint8Array;
+            buffer = await decryptData(buffer, passphrase);
           } catch {}
         }
         db = buffer.byteLength


### PR DESCRIPTION
## Summary
- type OPFS file buffer against `ArrayBufferLike`
- directly assign decrypted data without cast

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export')*
- `npm run lint` *(fails: Unexpected any, no-empty)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7c9d51008326bb54ec3695f38707