### PR TITLE
test: cast mock audio to HTMLAudioElement

### DIFF
--- a/src/voice/__tests__/voiceService.test.ts
+++ b/src/voice/__tests__/voiceService.test.ts
@@ -153,7 +153,7 @@ describe('voiceService', () => {
     playClonedVoiceMock.mockResolvedValue({
       audio: new (class extends MockAudio {
         play = jest.fn<() => Promise<void>>().mockRejectedValue({ name: 'NotAllowedError' });
-      })(),
+      })() as unknown as HTMLAudioElement,
       error: { name: 'NotAllowedError' },
     });
 
@@ -169,7 +169,7 @@ describe('voiceService', () => {
     useVoiceStore.getState().setVoiceId('abc');
     guardMock.mockResolvedValue('free');
     playClonedVoiceMock.mockResolvedValue({
-      audio: new MockAudio(),
+      audio: new MockAudio() as unknown as HTMLAudioElement,
       error: null,
     });
 


### PR DESCRIPTION
## Summary
- Cast mocked audio instances to `HTMLAudioElement` in voice service tests

## Testing
- `npm test src/voice/__tests__/voiceService.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ac7c9e01e883269bb313b0ea705cba