### PR TITLE
Avoid top-level await in memory store for wider compatibility

### DIFF
--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -1,4 +1,8 @@
-import { IndexedDbMemory, type MemoryBucket, type MemoryEntry } from './indexedDbMemory';
+import {
+  IndexedDbMemory,
+  type MemoryBucket,
+  type MemoryEntry,
+} from './indexedDbMemory';
 import { OpfsMemory } from './opfsStore';
 
 async function createStore() {
@@ -16,7 +20,11 @@ async function createStore() {
   return new IndexedDbMemory();
 }
 
-export const memoryStore = await createStore();
+const memoryStorePromise = createStore();
+
+export async function getMemoryStore() {
+  return memoryStorePromise;
+}
 
 export interface MemoryRecord {
   id: number;
@@ -24,12 +32,20 @@ export interface MemoryRecord {
   metadata: Record<string, any>;
 }
 
-export async function saveMemory(text: string, metadata: Record<string, any> = {}): Promise<void> {
-  await memoryStore.add('semantic', metadata.role ?? 'user', text, metadata);
+export async function saveMemory(
+  text: string,
+  metadata: Record<string, any> = {},
+): Promise<void> {
+  const store = await memoryStorePromise;
+  await store.add('semantic', metadata.role ?? 'user', text, metadata);
 }
 
-export async function queryMemory(query: string, k = 5): Promise<MemoryRecord[]> {
-  const results = await memoryStore.search(query, k);
+export async function queryMemory(
+  query: string,
+  k = 5,
+): Promise<MemoryRecord[]> {
+  const store = await memoryStorePromise;
+  const results = await store.search(query, k);
   return results.map((m, i) => ({ id: i, text: m.content, metadata: m }));
 }
 

--- a/src/memory/sync.ts
+++ b/src/memory/sync.ts
@@ -61,10 +61,11 @@ function merge(
 }
 
 export async function sync(adapter: SyncAdapter) {
-  const [{ memoryStore }, { default: logger }] = await Promise.all([
+  const [{ getMemoryStore }, { default: logger }] = await Promise.all([
     import('./store'),
     import('@/lib/logger'),
   ]);
+  const memoryStore = await getMemoryStore();
   const remote = await adapter.pull();
   const local = memoryStore.exportAll();
   const merged = merge(local, remote);


### PR DESCRIPTION
## Summary
- initialize memory store lazily without top-level await
- adjust sync logic to await the new store getter

## Testing
- `npm run build:dev` *(fails: workbox asset size exceeds default limit)*
- `npm test` *(fails: jest cannot parse ESM modules from jose)*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and other existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7f128744832698ffb203609c8c72