### PR TITLE
chore: expand PWA cache size

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -47,7 +47,10 @@ export default defineConfig(({ mode }) => {
       VitePWA({
         registerType: 'autoUpdate',
         manifest: false,
-        workbox: { globPatterns: ['**/*.{js,css,html,ico,png,svg}'] }
+        workbox: {
+          globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
+          maximumFileSizeToCacheInBytes: 6 * 1024 * 1024,
+        }
       }),
       tonConnectManifest(),
     ],


### PR DESCRIPTION
## Summary
- expand VitePWA cache limit to 6MB to handle larger JS bundles

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export' in jose imports)*
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_68ac82984d288326ba875bff3d80e07d