### PR TITLE
chore: use node post-build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "preinstall": "node scripts/check-peer-deps.cjs",
     "dev": "vite",
-    "build": "tsc -p tsconfig.node.json && tsc -p tsconfig.app.json && vite build && mkdir -p dist/public && cp public/tonconnect-manifest.json dist/public/tonconnect-manifest.json",
-    "build:dev": "tsc -p tsconfig.node.json && tsc -p tsconfig.app.json && vite build --mode development && mkdir -p dist/public && cp public/tonconnect-manifest.json dist/public/tonconnect-manifest.json",
+    "build": "tsc -p tsconfig.node.json && tsc -p tsconfig.app.json && vite build && node scripts/post-build.js",
+    "build:dev": "tsc -p tsconfig.node.json && tsc -p tsconfig.app.json && vite build --mode development && node scripts/post-build.js",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "jest",

--- a/scripts/post-build.js
+++ b/scripts/post-build.js
@@ -1,0 +1,4 @@
+import fs from 'fs';
+
+fs.mkdirSync('dist/public', { recursive: true });
+fs.copyFileSync('public/tonconnect-manifest.json', 'dist/public/tonconnect-manifest.json');


### PR DESCRIPTION
## Summary
- replace shell utilities in build scripts with cross-platform node script
- add post-build script to create dist/public and copy tonconnect manifest

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export')*

------
https://chatgpt.com/codex/tasks/task_e_68ac849dab5083269c092538d96257d0