### PR TITLE
Polyfill Node APIs for browser builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,8 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.2",
+    "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
+    "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
     "@eslint/js": "^9.32.0",
     "@playwright/test": "^1.54.2",
     "@storybook/addon-essentials": "^8.6.14",
@@ -127,6 +129,7 @@
     "jest": "^30.0.5",
     "jest-environment-jsdom": "^30.0.5",
     "postcss": "^8.5.6",
+    "rollup-plugin-node-polyfills": "^0.2.1",
     "rxdb": "^16.17.2",
     "rxjs": "^7.8.2",
     "storybook": "^8.6.14",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,9 @@ import path from "path";
 import { VitePWA } from "vite-plugin-pwa";
 import fs from "fs";
 import type { IncomingMessage, ServerResponse } from "http";
+import { NodeGlobalsPolyfillPlugin } from "@esbuild-plugins/node-globals-polyfill";
+import { NodeModulesPolyfillPlugin } from "@esbuild-plugins/node-modules-polyfill";
+import nodePolyfills from "rollup-plugin-node-polyfills";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -44,6 +47,7 @@ export default defineConfig(({ mode }) => {
     },
     plugins: [
       react(),
+      nodePolyfills() as unknown as Plugin,
       VitePWA({
         registerType: 'autoUpdate',
         manifest: false,
@@ -62,9 +66,24 @@ export default defineConfig(({ mode }) => {
     },
     define: {
       'process.env.VITE_API_BASE_URL': JSON.stringify(env.VITE_API_BASE_URL),
+      global: "globalThis",
     },
     optimizeDeps: {
       exclude: ["@mlc-ai/web-llm"],
+      esbuildOptions: {
+        define: {
+          global: "globalThis",
+        },
+        plugins: [
+          NodeGlobalsPolyfillPlugin({ buffer: true, process: true }) as any,
+          NodeModulesPolyfillPlugin() as any,
+        ],
+      },
+    },
+    build: {
+      rollupOptions: {
+        plugins: [nodePolyfills() as unknown as Plugin],
+      },
     },
     ssr: {
       noExternal: ["@mlc-ai/web-llm"],


### PR DESCRIPTION
## Summary
- add node polyfill dev dependencies
- configure Vite to inject polyfills for Buffer, process, and other Node built-ins used by `secrets.js-grempe` and `sql.js`

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in server/auth/__tests__/ton.spec.ts)*
- `npm run build` *(fails: workbox couldn't find precaching/runtime caching config)*

------
https://chatgpt.com/codex/tasks/task_e_68ac84a7ae6083269249e783b438394b