### PR TITLE
fix: merge duplicate build config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -80,17 +80,13 @@ export default defineConfig(({ mode }) => {
         ],
       },
     },
-    build: {
-      rollupOptions: {
-        plugins: [nodePolyfills() as unknown as Plugin],
-      },
-    },
     ssr: {
       noExternal: ["@mlc-ai/web-llm"],
     },
     build: {
       chunkSizeWarningLimit: 6000,
       rollupOptions: {
+        plugins: [nodePolyfills() as unknown as Plugin],
         output: {
           manualChunks(id) {
             if (id.includes('node_modules')) {


### PR DESCRIPTION
## Summary
- merge duplicate `build` sections in `vite.config.ts` and include polyfill plugin with manual chunking

## Testing
- `npm test` *(fails: SyntaxError in jest for jose ESM modules)*
- `npm run lint` *(fails: multiple eslint errors including unexpected any and empty block)*
- `npm run build:dev` *(fails: TS2307 cannot find module '@esbuild-plugins/node-globals-polyfill')*

------
https://chatgpt.com/codex/tasks/task_e_68ac8a61e8548326b2fb03dd966b62db