### PR TITLE
chore: remove duplicate HomeGalaxy declaration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,11 +24,9 @@ import { views } from '@/views/registry';
 import { useRoadmapProgress } from '@/hooks/useRoadmapProgress';
 import LiveShell from '@/routes/live/LiveShell';
 import { TTSPill } from '@/voice/TTSPill';
-import { lazy, Suspense } from 'react';
+import { Suspense } from 'react';
 const queryClient = new QueryClient();
 const HomeGalaxy = views.find((v) => v.id === 'home')!.component;
-
-const HomeGalaxy = lazy(() => import('@/views/HomeGalaxy'));
 
 function RequireRoadmap({ children }: { children: React.ReactNode }) {
   const location = useLocation();


### PR DESCRIPTION
## Summary
- remove duplicate `HomeGalaxy` declaration in App, ensuring single source from views registry

## Testing
- `npm test` *(fails: Jest encountered unexpected token in server/auth/__tests__/ton.spec.ts and server/replicate/__tests__/replicate.spec.ts)*
- `npm run lint` *(fails: 274 errors, 24 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ac933bd4008326a5b3212dea5a9b8b