### PR TITLE
refactor ModalHost to use views registry

### DIFF
--- a/src/components/modals/ModalHost.tsx
+++ b/src/components/modals/ModalHost.tsx
@@ -1,5 +1,3 @@
-import LiveFocusView from "@/components/live/LiveFocusView";
-import HypnoPanel from "@/components/hypno/HypnoPanel";
 import {
   Dialog,
   DialogContent,
@@ -10,13 +8,10 @@ import {
 import { useChatInputFocus } from "@/hooks/useChatInputFocus";
 import { useUIStore } from "@/state/ui";
 import { lazy, Suspense, useEffect, type ReactNode } from "react";
-import AnalyticsModal from "@/components/modals/AnalyticsModal";
-import GoalsModal from "@/components/modals/GoalsModal";
-import SettingsModal from "@/components/modals/SettingsModal";
-import TasksModal from "@/components/modals/TasksModal";
 import { AuroraSphere } from "@/components/avatar/AuroraSphere";
 import { Button } from "@/components/ui/button";
 import { X } from "lucide-react";
+import { views } from "@/views/registry";
 
 const BrainView = views.find((v) => v.id === "brain")!.component;
 const FocusView = views.find((v) => v.id === "focus")!.component;
@@ -31,11 +26,6 @@ const SettingsModal = lazy(() => import("./SettingsModal"));
 const TasksModal = lazy(() => import("./TasksModal"));
 const OnboardingSheet = lazy(() => import("./OnboardingSheet"));
 const ConfirmSheet = lazy(() => import("./ConfirmSheet"));
-
-const BrainView = lazy(() => import("@/views/BrainView"));
-const JournalView = lazy(() => import("@/views/JournalView"));
-const FocusView = lazy(() => import("@/views/FocusView"));
-const VoiceView = lazy(() => import("@/views/VoiceView"));
 
 export default function ModalHost() {
   const { activeModal, closeModal, modalArgs } = useUIStore();


### PR DESCRIPTION
## Summary
- import central `views` registry for modal view lookups
- remove duplicate component imports and lazily load modals

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export' from jose in server tests)*
- `npm run lint` *(fails: numerous lint errors, e.g., no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_68ac933ff1f08326b41ca5079bf056ff