### PR TITLE
Lazy-load view components in ModalHost

### DIFF
--- a/src/components/modals/ModalHost.tsx
+++ b/src/components/modals/ModalHost.tsx
@@ -11,7 +11,11 @@ import { lazy, Suspense, useEffect, type ReactNode } from "react";
 import { AuroraSphere } from "@/components/avatar/AuroraSphere";
 import { Button } from "@/components/ui/button";
 import { X } from "lucide-react";
-import { views } from "@/views/registry";
+
+const BrainView = lazy(() => import("@/views/BrainView"));
+const FocusView = lazy(() => import("@/views/FocusView"));
+const JournalView = lazy(() => import("@/views/JournalView"));
+const VoiceView = lazy(() => import("@/views/VoiceView"));
 
 const LiveFocusView = lazy(() => import("@/components/live/LiveFocusView"));
 const HypnoPanel = lazy(() => import("@/components/hypno/HypnoPanel"));


### PR DESCRIPTION
## Summary
- lazily import BrainView, FocusView, JournalView, and VoiceView for modal rendering
- remove unused views registry import from ModalHost

## Testing
- `npm run build` *(fails: "useState" is not exported by "node_modules/react/index.js")*


------
https://chatgpt.com/codex/tasks/task_e_68acd6b63d848326be3544e39a2033f9