### PR TITLE
refactor: use native fetch in cid registry

### DIFF
--- a/server/utils/cid-registry.ts
+++ b/server/utils/cid-registry.ts
@@ -1,25 +1,37 @@
 // [AURORA-BEGIN:cid-registry]
-import fetch from 'node-fetch';
 
 const couchUrl = process.env.COUCH_URL || 'http://localhost:5984';
 const dbName = process.env.COUCH_DB_ASSETS || 'assets';
 const dbUrl = `${couchUrl}/${dbName}`;
 
 async function ensureDb() {
-  const res = await fetch(dbUrl, { method: 'HEAD' });
-  if (res.status === 404) {
-    await fetch(dbUrl, { method: 'PUT' });
+  try {
+    const res = await fetch(dbUrl, { method: 'HEAD' });
+    if (res.status === 404) {
+      await fetch(dbUrl, { method: 'PUT' });
+    }
+  } catch (err) {
+    console.error('Failed to ensure CouchDB exists', err);
+    throw err;
   }
 }
-ensureDb();
+
+void ensureDb().catch(console.error);
 
 export type AssetKey = 'auroraid/base' | 'seasonpass/base' | `badge/${string}`;
+
+interface AssetDocument {
+  _id: string;
+  cid: string;
+  updatedAt: string;
+  _rev?: string;
+}
 
 export async function getCidForKey(key: AssetKey): Promise<string | undefined> {
   const res = await fetch(`${dbUrl}/${encodeURIComponent(key)}`);
   if (res.status === 200) {
-    const json: any = await res.json();
-    return json.cid as string;
+    const json: AssetDocument = await res.json();
+    return json.cid;
   }
   return undefined;
 }
@@ -30,7 +42,7 @@ export async function setCidForKey(key: AssetKey, cid: string) {
   const existing = await fetch(docUrl);
   let rev: string | undefined;
   if (existing.status === 200) {
-    const doc: any = await existing.json();
+    const doc: AssetDocument = await existing.json();
     rev = doc._rev;
   }
   await fetch(docUrl, {
@@ -40,12 +52,23 @@ export async function setCidForKey(key: AssetKey, cid: string) {
   });
 }
 
+interface AllDocsRow<T> {
+  id: string;
+  key: string;
+  value: { rev: string };
+  doc?: T;
+}
+
+interface AllDocsResponse<T> {
+  rows: Array<AllDocsRow<T>>;
+}
+
 export async function listAllAssets(): Promise<Array<{ key: string; cid: string; updatedAt: string }>> {
   const res = await fetch(`${dbUrl}/_all_docs?include_docs=true`);
   if (!res.ok) return [];
-  const json: any = await res.json();
+  const json: AllDocsResponse<AssetDocument> = await res.json();
   return json.rows
-    .filter((r: any) => r.doc)
-    .map((r: any) => ({ key: r.doc._id, cid: r.doc.cid, updatedAt: r.doc.updatedAt }));
+    .filter((r): r is AllDocsRow<AssetDocument> & { doc: AssetDocument } => Boolean(r.doc))
+    .map((r) => ({ key: r.doc._id, cid: r.doc.cid, updatedAt: r.doc.updatedAt }));
 }
 // [AURORA-END:cid-registry]


### PR DESCRIPTION
## Summary
- use Node's built-in `fetch` instead of `node-fetch`
- add error handling for CouchDB initialization and invoke with `void ensureDb().catch(console.error)`
- introduce typed interfaces for CouchDB documents and `_all_docs` responses

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export' from jose)*
- `npm run build` *(fails: Cannot find module '@esbuild-plugins/node-globals-polyfill')*

------
https://chatgpt.com/codex/tasks/task_e_68acd6b9d5688326935106be9c310813