### PR TITLE
refactor: remove ts-ignore and type RxDB observables

### DIFF
--- a/src/data/db.ts
+++ b/src/data/db.ts
@@ -3,6 +3,7 @@ import {
   createRxDatabase,
   type RxCollection,
   type RxDatabase,
+  type RxDocument,
   type RxJsonSchema,
 } from "rxdb";
 import { RxDBAttachmentsPlugin } from "rxdb/plugins/attachments";
@@ -298,9 +299,8 @@ export async function removeJournal(id: string) {
   return doc?.remove();
 }
 
-export async function journal$(): Promise<Observable<JournalEntry[]>> {
+export async function journal$(): Promise<Observable<RxDocument<JournalEntry>[]>> {
   const db = await getDatabase();
-  // @ts-ignore - rxdb observable type
   return db.journal.find().$;
 }
 
@@ -326,9 +326,8 @@ export async function removeFocusSession(id: string) {
   return doc?.remove();
 }
 
-export async function focusSessions$(): Promise<Observable<FocusSession[]>> {
+export async function focusSessions$(): Promise<Observable<RxDocument<FocusSession>[]>> {
   const db = await getDatabase();
-  // @ts-ignore
   return db.focus_sessions.find().$;
 }
 
@@ -351,9 +350,8 @@ export async function removeTask(id: string) {
   return doc?.remove();
 }
 
-export async function tasks$(): Promise<Observable<TaskItem[]>> {
+export async function tasks$(): Promise<Observable<RxDocument<TaskItem>[]>> {
   const db = await getDatabase();
-  // @ts-ignore
   return db.simple_tasks.find().$;
 }
 
@@ -376,9 +374,8 @@ export async function removeGoal(id: string) {
   return doc?.remove();
 }
 
-export async function goals$(): Promise<Observable<GoalItem[]>> {
+export async function goals$(): Promise<Observable<RxDocument<GoalItem>[]>> {
   const db = await getDatabase();
-  // @ts-ignore
   return db.goals.find().$;
 }
 

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -1,4 +1,4 @@
-import { addRxPlugin, createRxDatabase, type RxCollection, type RxDatabase, type RxJsonSchema } from 'rxdb';
+import { addRxPlugin, createRxDatabase, type RxCollection, type RxDatabase, type RxDocument, type RxJsonSchema } from 'rxdb';
 import { RxDBAttachmentsPlugin } from 'rxdb/plugins/attachments';
 import { wrappedKeyEncryptionCryptoJsStorage } from 'rxdb/plugins/encryption-crypto-js';
 import { getRxStorageDexie } from 'rxdb/plugins/storage-dexie';
@@ -140,9 +140,8 @@ export async function removeJournal(id: string) {
   return doc?.remove();
 }
 
-export async function journal$(): Promise<Observable<JournalEntry[]>> {
+export async function journal$(): Promise<Observable<RxDocument<JournalEntry>[]>> {
   const db = await createDatabase();
-  // @ts-ignore - rxdb observable type
   return db.journal.find().$;
 }
 
@@ -164,9 +163,8 @@ export async function removeFocusSession(id: string) {
   return doc?.remove();
 }
 
-export async function focusSessions$(): Promise<Observable<FocusSession[]>> {
+export async function focusSessions$(): Promise<Observable<RxDocument<FocusSession>[]>> {
   const db = await createDatabase();
-  // @ts-ignore
   return db.focus_sessions.find().$;
 }
 
@@ -188,9 +186,8 @@ export async function removeTask(id: string) {
   return doc?.remove();
 }
 
-export async function tasks$(): Promise<Observable<Task[]>> {
+export async function tasks$(): Promise<Observable<RxDocument<Task>[]>> {
   const db = await createDatabase();
-  // @ts-ignore
   return db.tasks.find().$;
 }
 
@@ -212,8 +209,7 @@ export async function removeGoal(id: string) {
   return doc?.remove();
 }
 
-export async function goals$(): Promise<Observable<Goal[]>> {
+export async function goals$(): Promise<Observable<RxDocument<Goal>[]>> {
   const db = await createDatabase();
-  // @ts-ignore
   return db.goals.find().$;
 }


### PR DESCRIPTION
## Summary
- type RxDB collection observables in data and state db helpers
- drop `@ts-ignore` in favor of explicit RxDocument observable types

## Testing
- `npx tsc -p tsconfig.app.json` *(fails: Cannot find name 'BrainView' in ModalHost.tsx)*
- `npm test` *(fails: Jest encountered an unexpected token in jose module)*


------
https://chatgpt.com/codex/tasks/task_e_68acd6be9b548326b230c522e1585d4d