### PR TITLE
fix: register toast listener only once

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- ensure useToast only registers listener once by using empty effect dependency array

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export' in jose)*
- `npm run lint src/hooks/use-toast.ts` *(fails: 277 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68ace65efe3c83268c2f792cb37f4623