### PR TITLE
fix: move eslint disable comment in RoadmapsManager

### DIFF
--- a/src/components/control/RoadmapsManager.tsx
+++ b/src/components/control/RoadmapsManager.tsx
@@ -52,7 +52,8 @@ export default function RoadmapsManager() {
     if (active) setSelectedId(active.id); else setSelectedId(list[0]?.id ?? null);
   };
 
-  useEffect(()=> { fetchRoadmaps(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [user]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => { fetchRoadmaps(); }, [user]);
 
   const setActive = async (roadmapId: string) => {
       if (!user) { toast({ title: "Sign in required", description: "Sign in to manage roadmaps." }); return; }


### PR DESCRIPTION
## Summary
- move `react-hooks/exhaustive-deps` disable comment to the line before `useEffect`

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in jose package)*
- `npm run lint` *(fails: 277 problems including no-explicit-any and no-empty)*

------
https://chatgpt.com/codex/tasks/task_e_68ace6612224832696138b573f99f38d