### PR TITLE
chore: prebundle react deps

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -69,6 +69,7 @@ export default defineConfig(({ mode }) => {
       global: "globalThis",
     },
     optimizeDeps: {
+      include: ["react", "react-dom"],
       exclude: ["@mlc-ai/web-llm"],
       esbuildOptions: {
         define: {


### PR DESCRIPTION
## Summary
- ensure react and react-dom are deduped and pre-bundled in Vite config

## Testing
- `npm ls react react-dom --depth=0`
- `npm install`
- `NODE_OPTIONS=--max_old_space_size=4096 npm run build:dev` *(fails: Couldn't find configuration for either precaching or runtime caching)*

------
https://chatgpt.com/codex/tasks/task_e_68ace66225ec8326a7fd44e9c1480be5