### PR TITLE
feat: stub threejs modules for type checking

### DIFF
--- a/types/three-examples.d.ts
+++ b/types/three-examples.d.ts
@@ -1,0 +1,32 @@
+declare module 'three/examples/jsm/controls/OrbitControls.js' {
+  import * as THREE from 'three';
+  export class OrbitControls {
+    constructor(camera: THREE.Camera, domElement: HTMLElement);
+    update(): void;
+    enableDamping: boolean;
+    enablePan: boolean;
+    dispose(): void;
+  }
+}
+declare module 'three/examples/jsm/loaders/RGBELoader.js' {
+  import * as THREE from 'three';
+  export class RGBELoader {
+    load(
+      url: string,
+      onLoad: (t: THREE.DataTexture) => void,
+      onProgress?: () => void,
+      onError?: (err: unknown) => void
+    ): void;
+  }
+}
+declare module 'three/examples/jsm/exporters/GLTFExporter.js' {
+  import type { Scene } from 'three';
+  export class GLTFExporter {
+    parse(
+      input: Scene,
+      onSuccess: (gltf: ArrayBuffer | Record<string, unknown>) => void,
+      onError?: (error: unknown) => void,
+      options?: Record<string, unknown>
+    ): void;
+  }
+}

--- a/types/three-tsl.d.ts
+++ b/types/three-tsl.d.ts
@@ -1,0 +1,13 @@
+declare module 'three/tsl' {
+  export function vec3(...args: any[]): any;
+  export function float(...args: any[]): any;
+  export function uv(): any;
+  export const time: any;
+  export const positionLocal: any;
+  export const normalLocal: any;
+  export function rotate(...args: any[]): any;
+  export function triNoise3D(...args: any[]): any;
+  export const cameraPosition: any;
+  export const positionWorld: any;
+  export const normalWorld: any;
+}

--- a/types/three-webgpu.d.ts
+++ b/types/three-webgpu.d.ts
@@ -1,0 +1,9 @@
+declare module 'three/webgpu' {
+  import * as THREE from 'three';
+  export * from 'three';
+  export class WebGPURenderer extends THREE.WebGLRenderer {
+    init(): void;
+    backend: any;
+  }
+  export class MeshStandardNodeMaterial extends THREE.MeshStandardMaterial {}
+}


### PR DESCRIPTION
## Summary
- add type stubs for three.js WebGPU build
- declare missing TSL helpers used by AuroraSphere
- stub example utilities like OrbitControls, RGBELoader, and GLTFExporter

## Testing
- `npx tsc -p tsconfig.app.json`
- `npx tsc -p tsconfig.node.json`
- `npm run build:dev` *(fails: FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6ff16b8c8326b2cd5c4a430a6a5c