### PR TITLE
feat: stub threejs modules for type checking

### DIFF
--- a/types/three-examples.d.ts
+++ b/types/three-examples.d.ts
@@ -1,0 +1,32 @@
+declare module 'three/examples/jsm/controls/OrbitControls.js' {
+  import * as THREE from 'three';
+  export class OrbitControls {
+    constructor(camera: THREE.Camera, domElement: HTMLElement);
+    update(): void;
+    enableDamping: boolean;
+    enablePan: boolean;
+    dispose(): void;
+  }
+}
+declare module 'three/examples/jsm/loaders/RGBELoader.js' {
+  import * as THREE from 'three';
+  export class RGBELoader {
+    load(
+      url: string,
+      onLoad: (t: THREE.DataTexture) => void,
+      onProgress?: () => void,
+      onError?: (err: unknown) => void
+    ): void;
+  }
+}
+declare module 'three/examples/jsm/exporters/GLTFExporter.js' {
+  import type { Scene } from 'three';
+  export class GLTFExporter {
+    parse(
+      input: Scene,
+      onSuccess: (gltf: ArrayBuffer | Record<string, unknown>) => void,
+      onError?: (error: unknown) => void,
+      options?: Record<string, unknown>
+    ): void;
+  }
+}

--- a/types/three-tsl.d.ts
+++ b/types/three-tsl.d.ts
@@ -1,0 +1,13 @@
+declare module 'three/tsl' {
+  export function vec3(...args: any[]): any;
+  export function float(...args: any[]): any;
+  export function uv(): any;
+  export const time: any;
+  export const positionLocal: any;
+  export const normalLocal: any;
+  export function rotate(...args: any[]): any;
+  export function triNoise3D(...args: any[]): any;
+  export const cameraPosition: any;
+  export const positionWorld: any;
+  export const normalWorld: any;
+}

--- a/types/three-webgpu.d.ts
+++ b/types/three-webgpu.d.ts
@@ -1,0 +1,9 @@
+declare module 'three/webgpu' {
+  import * as THREE from 'three';
+  export * from 'three';
+  export class WebGPURenderer extends THREE.WebGLRenderer {
+    init(): void;
+    backend: any;
+  }
+  export class MeshStandardNodeMaterial extends THREE.MeshStandardMaterial {}
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,6 @@ import fs from "fs";
 import type { IncomingMessage, ServerResponse } from "http";
 import { NodeGlobalsPolyfillPlugin } from "@esbuild-plugins/node-globals-polyfill";
 import { NodeModulesPolyfillPlugin } from "@esbuild-plugins/node-modules-polyfill";
-import nodePolyfills from "rollup-plugin-node-polyfills";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -47,7 +46,6 @@ export default defineConfig(({ mode }) => {
     },
     plugins: [
       react(),
-      nodePolyfills() as unknown as Plugin,
       VitePWA({
         registerType: 'autoUpdate',
         manifest: false,
@@ -87,7 +85,7 @@ export default defineConfig(({ mode }) => {
     build: {
       chunkSizeWarningLimit: 6000,
       rollupOptions: {
-        plugins: [nodePolyfills() as unknown as Plugin],
+        plugins: [],
         output: {
           manualChunks(id) {
             if (id.includes('node_modules')) {


### PR DESCRIPTION
## Summary
- add type stubs for three.js WebGPU build
- declare missing TSL helpers used by AuroraSphere
- stub example utilities like OrbitControls, RGBELoader, and GLTFExporter
- drop rollup node polyfills to avoid React build errors

## Testing
- `npx tsc -p tsconfig.app.json`
- `npx tsc -p tsconfig.node.json`
- `NODE_OPTIONS=--max_old_space_size=4096 npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_68ad6ff16b8c8326b2cd5c4a430a6a5c