### PR TITLE
fix: use absolute URLs in TonConnect manifest

### DIFF
--- a/public/tonconnect-manifest.json
+++ b/public/tonconnect-manifest.json
@@ -1,5 +1,5 @@
 {
-  "url": "http://localhost:8080",
+  "url": "http://localhost:3000",
   "name": "Aurora (Dev)",
-  "iconUrl": "/icon.png"
+  "iconUrl": "http://localhost:3000/icon.png"
 }


### PR DESCRIPTION
## Summary
- point TonConnect manifest `url` and `iconUrl` to `http://localhost:3000` so the extension can fetch assets

## Testing
- `./node_modules/.bin/eslint public/tonconnect-manifest.json`
- `./node_modules/.bin/jest`


------
https://chatgpt.com/codex/tasks/task_e_68ad949d83588326b48aef308617d5cc