### PR TITLE
feat: initialize TonConnect connector

### DIFF
--- a/public/privacy.html
+++ b/public/privacy.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Privacy Policy</title>
+</head>
+<body>
+  <h1>Privacy Policy</h1>
+  <p>Placeholder privacy policy.</p>
+</body>
+</html>

--- a/public/terms.html
+++ b/public/terms.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Terms of Use</title>
+</head>
+<body>
+  <h1>Terms of Use</h1>
+  <p>Placeholder terms of use.</p>
+</body>
+</html>

--- a/public/tonconnect-manifest.json
+++ b/public/tonconnect-manifest.json
@@ -1,5 +1,7 @@
 {
-  "url": "http://localhost:8080",
-  "name": "Aurora (Dev)",
-  "iconUrl": "/icon.png"
+  "url": "http://localhost:3000",
+  "name": "Mindscape Control Panel",
+  "iconUrl": "http://localhost:3000/icon.png",
+  "termsOfUseUrl": "http://localhost:3000/terms.html",
+  "privacyPolicyUrl": "http://localhost:3000/privacy.html"
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,5 @@
 import './polyfills/randomUUID';
+import { TonConnect } from '@tonconnect/sdk';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import ErrorBoundary from './components/ErrorBoundary';
@@ -12,6 +13,10 @@ import { db } from './data/db';
 import { initializeGamificationStore } from './game/gamification/store';
 import { initializeRoadmapStore } from './state/roadmapStore';
 import { getDataKey } from './state/keyManager';
+
+export const connector = new TonConnect({
+  manifestUrl: `${location.origin}/tonconnect-manifest.json`,
+});
 
 if ('serviceWorker' in navigator) {
   registerSW({ immediate: true });
@@ -29,7 +34,8 @@ async function bootstrap() {
         db.tasks.toArray(),
         db.stats.get('local'),
       ]);
-      initializeRoadmapStore(tasks as any);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        initializeRoadmapStore(tasks as any);
       initializeGamificationStore(stats ?? undefined);
     } catch (err) {
       console.warn('Dexie unavailable', err);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -49,6 +49,7 @@ export default defineConfig(({ mode }) => {
       VitePWA({
         registerType: 'autoUpdate',
         manifest: false,
+        devOptions: { enabled: false },
         workbox: {
           globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
           maximumFileSizeToCacheInBytes: 6 * 1024 * 1024,
@@ -69,16 +70,18 @@ export default defineConfig(({ mode }) => {
     optimizeDeps: {
       include: ["react", "react-dom"],
       exclude: ["@mlc-ai/web-llm"],
-      esbuildOptions: {
-        define: {
-          global: "globalThis",
+        esbuildOptions: {
+          define: {
+            global: "globalThis",
+          },
+          plugins: [
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            NodeGlobalsPolyfillPlugin({ buffer: true, process: true }) as any,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            NodeModulesPolyfillPlugin() as any,
+          ],
         },
-        plugins: [
-          NodeGlobalsPolyfillPlugin({ buffer: true, process: true }) as any,
-          NodeModulesPolyfillPlugin() as any,
-        ],
       },
-    },
     ssr: {
       noExternal: ["@mlc-ai/web-llm"],
     },


### PR DESCRIPTION
## Summary
- expand TonConnect manifest with absolute URLs and policy links
- initialize TonConnect connector at app startup and disable PWA service worker during dev
- add placeholder terms and privacy pages referenced by the manifest

## Testing
- `./node_modules/.bin/eslint public/tonconnect-manifest.json src/main.tsx vite.config.ts`
- `./node_modules/.bin/jest`


------
https://chatgpt.com/codex/tasks/task_e_68ad949d83588326b48aef308617d5cc