### PR TITLE
feat: set up TonConnect UI

### DIFF
--- a/src/lib/tonconnect.ts
+++ b/src/lib/tonconnect.ts
@@ -1,0 +1,9 @@
+import { TonConnectUI } from "@tonconnect/ui";
+
+const ORIGIN = import.meta.env.VITE_PUBLIC_ORIGIN || window.location.origin;
+
+export const tonConnectUI = new TonConnectUI({
+  manifestUrl: `${ORIGIN}/tonconnect-manifest.json`,
+  restoreConnection: true,
+});
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,4 @@
 import './polyfills/randomUUID';
-import { TonConnect } from '@tonconnect/sdk';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import ErrorBoundary from './components/ErrorBoundary';
@@ -13,10 +12,9 @@ import { db } from './data/db';
 import { initializeGamificationStore } from './game/gamification/store';
 import { initializeRoadmapStore } from './state/roadmapStore';
 import { getDataKey } from './state/keyManager';
+import { tonConnectUI } from './lib/tonconnect';
 
-export const connector = new TonConnect({
-  manifestUrl: `${location.origin}/tonconnect-manifest.json`,
-});
+export { tonConnectUI as connector };
 
 if ('serviceWorker' in navigator) {
   registerSW({ immediate: true });


### PR DESCRIPTION
## Summary
- add TonConnect UI helper with configurable origin
- expose TonConnect UI from entry point

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in server auth tests)*
- `npm run lint` *(fails: 289 problems including `@typescript-eslint/no-explicit-any`)*

------
https://chatgpt.com/codex/tasks/task_e_68adb5940fe08326883772b0db392ef9