### PR TITLE
refactor: switch to TonConnectUI

### DIFF
--- a/src/hooks/useTonAuth.ts
+++ b/src/hooks/useTonAuth.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { CHAIN } from "@tonconnect/sdk";
-import { connector } from "@/main";
+import { TonConnectUI } from "@tonconnect/ui";
 import { setDataKey } from "@/state/keyManager";
 import { db as localDb } from "@/data/db";
 
@@ -18,13 +18,17 @@ function composeMessage(
   ].join("|");
 }
 
+export const tonConnectUI = new TonConnectUI({
+  manifestUrl: `${location.origin}/tonconnect-manifest.json`,
+});
+
 export function useTonAuth() {
   const [address, setAddress] = useState<string | null>(null);
   const refreshTimer = useRef<ReturnType<typeof setInterval> | null>(null);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    const unsubscribe = connector.onStatusChange((wallet) => {
+    const unsubscribe = tonConnectUI.onStatusChange((wallet) => {
       setAddress(wallet?.account.address ?? null);
     });
     return unsubscribe;
@@ -34,12 +38,12 @@ export function useTonAuth() {
     const res = await fetch("/auth/ton/start", { method: "POST" });
     const { challenge } = await res.json();
     const message = composeMessage(challenge, scopes);
-    const { signature } = await connector.signData({
+    const { signature } = await tonConnectUI.signData({
       type: "text",
       text: message,
       network: CHAIN.TESTNET,
     });
-    const publicKey = connector.wallet?.account.publicKey;
+    const publicKey = tonConnectUI.wallet?.account.publicKey;
     if (!publicKey) throw new Error("missing_public_key");
     const hexSignature = Buffer.from(signature, "base64").toString("hex");
     await fetch("/auth/ton/verify", {
@@ -52,26 +56,22 @@ export function useTonAuth() {
         scopes,
       }),
     });
-    const addr = connector.wallet?.account.address;
+    const addr = tonConnectUI.wallet?.account.address;
     setAddress(addr || null);
   };
 
   const login = async (scopes: string[] = []) => {
     setLoading(true);
     try {
-      if (!connector.wallet) {
+      if (!tonConnectUI.wallet) {
         try {
-          const link = connector.connect({
-            universalLink: "https://app.tonkeeper.com/ton-connect",
-            bridgeUrl: "https://bridge.tonapi.io/bridge",
-          });
-          window.open(link, "_blank");
+          await tonConnectUI.connectWallet();
         } catch (err) {
           console.error("Wallet connection failed", err);
           throw err;
         }
       }
-      if (connector.wallet?.account.chain !== CHAIN.TESTNET) {
+      if (tonConnectUI.wallet?.account.chain !== CHAIN.TESTNET) {
         console.warn("Wallet is not on TON testnet");
         throw new Error("Only TON testnet is supported");
       }
@@ -103,7 +103,7 @@ export function useTonAuth() {
       await fetch("/auth/logout", { method: "POST" });
     } finally {
       if (refreshTimer.current) clearInterval(refreshTimer.current);
-      await connector.disconnect();
+      await tonConnectUI.disconnect();
       setAddress(null);
     }
   };

--- a/src/integrations/auth.ts
+++ b/src/integrations/auth.ts
@@ -1,4 +1,4 @@
-import { connector } from "@/hooks/useTonAuth";
+import { tonConnectUI } from "@/hooks/useTonAuth";
 
 export interface TonUser {
   id: string;
@@ -6,6 +6,6 @@ export interface TonUser {
 }
 
 export async function getTonUser(): Promise<TonUser | null> {
-  const address = connector.wallet?.account.address;
+  const address = tonConnectUI.wallet?.account.address;
   return address ? { id: address, email: address } : null;
 }

--- a/src/pages/OnboardingFlow.tsx
+++ b/src/pages/OnboardingFlow.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/data/profile";
 import { setMemoryKey } from "@/memory/indexedDbMemory";
 import { deriveDataKey } from "@/state/keyManager";
-import { connector } from "@/hooks/useTonAuth";
+import { tonConnectUI } from "@/hooks/useTonAuth";
 import { Volume2 } from "lucide-react";
 
 
@@ -160,7 +160,7 @@ export default function OnboardingFlow() {
       try {
         const passcode = window.prompt("Set a passcode to secure your data") || "";
         if (!passcode) return;
-        const { signature } = await connector.signData({
+        const { signature } = await tonConnectUI.signData({
           type: "text",
           text: "Authorize Aurora key derivation",
         });


### PR DESCRIPTION
## Summary
- use TonConnectUI instance for auth flows and wallet operations
- update integrations and onboarding to sign and access wallet via TonConnectUI

## Testing
- `npm run lint` (fails: Unexpected any types)
- `npm test` (fails: Jest encountered an unexpected token)

------
https://chatgpt.com/codex/tasks/task_e_68adb594966c832687e546dc7b885b1b