### PR TITLE
chore: update manifest origin and cors

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -18,13 +18,27 @@ async function build() {
     const nftAssets = (await import('./nft/assets')).default;
     await server.register(nftAssets);
   }
+  server.options('/tonconnect-manifest.json', async (_req, reply) => {
+    reply
+      .header('Access-Control-Allow-Origin', '*')
+      .header('Access-Control-Allow-Methods', 'GET,OPTIONS')
+      .header('Access-Control-Allow-Headers', '*')
+      .code(204)
+      .send();
+  });
+
   server.get('/tonconnect-manifest.json', async (req, reply) => {
     try {
       const raw = await fs.readFile(manifestPath, 'utf-8');
       const origin =
-        process.env.VITE_ORIGIN || `${req.protocol}://${req.headers.host}`;
+        process.env.VITE_PUBLIC_ORIGIN ||
+        `${req.protocol}://${req.headers.host}`;
       reply
         .header('Content-Type', 'application/json')
+        .header('Cache-Control', 'no-store')
+        .header('Access-Control-Allow-Origin', '*')
+        .header('Access-Control-Allow-Methods', 'GET,OPTIONS')
+        .header('Access-Control-Allow-Headers', '*')
         .send(raw.replace('%VITE_ORIGIN%', origin));
     } catch (err) {
       server.log.error(err);


### PR DESCRIPTION
## Summary
- read VITE_PUBLIC_ORIGIN when injecting manifest origin
- add CORS headers and preflight handling for `/tonconnect-manifest.json`

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in server/auth and server/replicate tests)*
- `npm run lint` *(fails: 289 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68adb596a8948326a85551955c03ffd6