### PR TITLE
refactor: use TonConnectUI singleton

### DIFF
--- a/src/hooks/useTonAuth.ts
+++ b/src/hooks/useTonAuth.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { CHAIN } from "@tonconnect/sdk";
-import { TonConnectUI } from "@tonconnect/ui";
+import { getTonConnectUI } from "@/lib/tonconnect";
 import { setDataKey } from "@/state/keyManager";
 import { db as localDb } from "@/data/db";
 
@@ -18,9 +18,7 @@ function composeMessage(
   ].join("|");
 }
 
-export const tonConnectUI = new TonConnectUI({
-  manifestUrl: `${location.origin}/tonconnect-manifest.json`,
-});
+const tonConnectUI = getTonConnectUI();
 
 export function useTonAuth() {
   const [address, setAddress] = useState<string | null>(null);

--- a/src/integrations/auth.ts
+++ b/src/integrations/auth.ts
@@ -1,4 +1,4 @@
-import { tonConnectUI } from "@/hooks/useTonAuth";
+import { getTonConnectUI } from "@/lib/tonconnect";
 
 export interface TonUser {
   id: string;
@@ -6,6 +6,7 @@ export interface TonUser {
 }
 
 export async function getTonUser(): Promise<TonUser | null> {
+  const tonConnectUI = getTonConnectUI();
   const address = tonConnectUI.wallet?.account.address;
   return address ? { id: address, email: address } : null;
 }

--- a/src/lib/tonconnect.ts
+++ b/src/lib/tonconnect.ts
@@ -1,9 +1,30 @@
 import { TonConnectUI } from "@tonconnect/ui";
 
-const ORIGIN = import.meta.env.VITE_PUBLIC_ORIGIN || window.location.origin;
+declare global {
+  interface Window {
+    __tcui?: TonConnectUI;
+  }
+}
 
-export const tonConnectUI = new TonConnectUI({
-  manifestUrl: `${ORIGIN}/tonconnect-manifest.json`,
-  restoreConnection: true,
-});
+const ORIGIN = import.meta.env.VITE_PUBLIC_ORIGIN || window.location.origin;
+const MANIFEST_URL = `${ORIGIN}/tonconnect-manifest.json`;
+
+export function getTonConnectUI(): TonConnectUI {
+  if (!window.__tcui) {
+    window.__tcui = new TonConnectUI({
+      manifestUrl: MANIFEST_URL,
+      restoreConnection: true,
+    });
+  }
+  return window.__tcui;
+}
+
+export async function connectTonkeeper() {
+  const ui = getTonConnectUI();
+  try {
+    await ui.connectWallet();
+  } catch (e) {
+    console.error("[TON] connect failed:", e);
+  }
+}
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,8 +12,9 @@ import { db } from './data/db';
 import { initializeGamificationStore } from './game/gamification/store';
 import { initializeRoadmapStore } from './state/roadmapStore';
 import { getDataKey } from './state/keyManager';
-import { tonConnectUI } from './lib/tonconnect';
+import { getTonConnectUI } from './lib/tonconnect';
 
+const tonConnectUI = getTonConnectUI();
 export { tonConnectUI as connector };
 
 if ('serviceWorker' in navigator) {

--- a/src/pages/OnboardingFlow.tsx
+++ b/src/pages/OnboardingFlow.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/data/profile";
 import { setMemoryKey } from "@/memory/indexedDbMemory";
 import { deriveDataKey } from "@/state/keyManager";
-import { tonConnectUI } from "@/hooks/useTonAuth";
+import { getTonConnectUI } from "@/lib/tonconnect";
 import { Volume2 } from "lucide-react";
 
 
@@ -160,6 +160,7 @@ export default function OnboardingFlow() {
       try {
         const passcode = window.prompt("Set a passcode to secure your data") || "";
         if (!passcode) return;
+        const tonConnectUI = getTonConnectUI();
         const { signature } = await tonConnectUI.signData({
           type: "text",
           text: "Authorize Aurora key derivation",


### PR DESCRIPTION
## Summary
- add TonConnectUI singleton getter and helper connectTonkeeper
- consume shared TonConnectUI instance across auth hooks and onboarding
- expose singleton in main entry for debugging

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in jose module)*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any in types/three-webgpu.d.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68adc67d0b5c8326b2234a8c9e91c238