### PR TITLE
refactor: replace ton auth with near

### DIFF
--- a/server/auth/near.ts
+++ b/server/auth/near.ts
@@ -1,0 +1,7 @@
+import type { FastifyPluginAsync } from 'fastify';
+
+const plugin: FastifyPluginAsync = async (fastify) => {
+  fastify.get('/auth/near/ping', async () => ({ ok: true }));
+};
+
+export default plugin;

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,50 +1,20 @@
 // [AURORA-BEGIN:server-entry]
 import Fastify from 'fastify';
 import cookie from '@fastify/cookie';
-import fs from 'node:fs/promises';
-import path from 'node:path';
 
-import authTon from './auth/ton';
+import authNear from './auth/near';
 import replicate from './replicate';
 
 const server = Fastify({ logger: true });
-const manifestPath = path.resolve(process.cwd(), 'public/tonconnect-manifest.json');
 
 async function build() {
   await server.register(cookie);
-  await server.register(authTon);
+  await server.register(authNear);
   await server.register(replicate);
   if (process.env.ENABLE_NFT_ASSETS !== 'false') {
     const nftAssets = (await import('./nft/assets')).default;
     await server.register(nftAssets);
   }
-  server.options('/tonconnect-manifest.json', async (_req, reply) => {
-    reply
-      .header('Access-Control-Allow-Origin', '*')
-      .header('Access-Control-Allow-Methods', 'GET,OPTIONS')
-      .header('Access-Control-Allow-Headers', '*')
-      .code(204)
-      .send();
-  });
-
-  server.get('/tonconnect-manifest.json', async (req, reply) => {
-    try {
-      const raw = await fs.readFile(manifestPath, 'utf-8');
-      const origin =
-        process.env.VITE_PUBLIC_ORIGIN ||
-        `${req.protocol}://${req.headers.host}`;
-      reply
-        .header('Content-Type', 'application/json')
-        .header('Cache-Control', 'no-store')
-        .header('Access-Control-Allow-Origin', '*')
-        .header('Access-Control-Allow-Methods', 'GET,OPTIONS')
-        .header('Access-Control-Allow-Headers', '*')
-        .send(raw.replace('%VITE_ORIGIN%', origin));
-    } catch (err) {
-      server.log.error(err);
-      reply.code(404).send({ error: 'tonconnect-manifest.json not found' });
-    }
-  });
 }
 
 const start = async () => {


### PR DESCRIPTION
## Summary
- replace TON authentication setup with NEAR plugin
- drop TonConnect manifest endpoints from server startup
- add basic NEAR auth plugin stub

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export' in jose)*

------
https://chatgpt.com/codex/tasks/task_e_68c4fc57bac48326b91bdf0ca3550da3