### PR TITLE
refactor: switch auth hooks to NEAR

### DIFF
--- a/app/studio/nft/page.tsx
+++ b/app/studio/nft/page.tsx
@@ -6,7 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { useToast } from '@/components/ui/use-toast';
-import { useTonAuth } from '@/hooks/useTonAuth';
+import { useNearAuth } from '@/hooks/useNearAuth';
 
 const adminWallets = (process.env.NEXT_PUBLIC_ADMIN_WALLETS || process.env.ADMIN_WALLETS || '')
   .split(',')
@@ -55,7 +55,7 @@ function AssetCard({ label, assetKey, cid, onFile, onSvg }: AssetCardProps) {
 }
 
 export default function NFTAssetStudioPage() {
-  const { address, login } = useTonAuth();
+  const { address, login } = useNearAuth();
   const { toast } = useToast();
   const [assets, setAssets] = useState<Asset[]>([]);
   const [authorized, setAuthorized] = useState(false);

--- a/app/view/identity/page.tsx
+++ b/app/view/identity/page.tsx
@@ -5,10 +5,10 @@
 import { useEffect, useState } from "react";
 import ComposedIdentityScene from "@/components/identity/ComposedIdentityScene";
 import { db } from "@/integrations/db";
-import { useTonSession } from "@/hooks/useTonSession";
+import { useNearSession } from "@/hooks/useNearSession";
 
 export default function IdentityPage() {
-  const { user } = useTonSession();
+  const { user } = useNearSession();
   const [stats, setStats] = useState<any | null>(null);
 
   useEffect(() => {

--- a/src/components/StoreCreation.test.tsx
+++ b/src/components/StoreCreation.test.tsx
@@ -10,8 +10,8 @@ jest.mock('@/agent/stores-agent', () => ({
   mintStoreNFT: jest.fn(),
 }));
 
-jest.mock('@/hooks/useTonSession', () => ({
-  useTonSession: () => ({ user: { id: 'user-1' } }),
+jest.mock('@/hooks/useNearSession', () => ({
+  useNearSession: () => ({ user: { id: 'user-1' } }),
 }));
 
 describe('StoreCreation', () => {

--- a/src/components/StoreCreation.tsx
+++ b/src/components/StoreCreation.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { useTonSession } from "@/hooks/useTonSession";
+import { useNearSession } from "@/hooks/useNearSession";
 import { mintStoreNFT, type StoreRecord } from "@/agent/stores-agent";
 
 export default function StoreCreation() {
@@ -9,7 +9,7 @@ export default function StoreCreation() {
   const [creating, setCreating] = useState(false);
   const [store, setStore] = useState<StoreRecord | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const { user } = useTonSession();
+  const { user } = useNearSession();
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/components/auth/AuthMenu.tsx
+++ b/src/components/auth/AuthMenu.tsx
@@ -1,10 +1,10 @@
 
 import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import { useTonAuth } from "@/hooks/useTonAuth";
+import { useNearAuth } from "@/hooks/useNearAuth";
 
 export function AuthMenu() {
-  const { address, logout } = useTonAuth();
+  const { address, logout } = useNearAuth();
 
   if (!address) {
     return (

--- a/src/components/control/RoadmapForm.tsx
+++ b/src/components/control/RoadmapForm.tsx
@@ -2,12 +2,12 @@ import { useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
-import { useTonSession } from "@/hooks/useTonSession";
+import { useNearSession } from "@/hooks/useNearSession";
 import { db } from "@/integrations/db";
 import { toast } from "@/hooks/use-toast";
 
 export default function RoadmapForm({ onCreated }: { onCreated?: (id: string) => void }) {
-  const { user } = useTonSession();
+  const { user } = useNearSession();
   const [title, setTitle] = useState("");
   const [color, setColor] = useState("");
   const [description, setDescription] = useState("");

--- a/src/components/control/RoadmapsManager.tsx
+++ b/src/components/control/RoadmapsManager.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import RoadmapForm from "./RoadmapForm";
 import RoadmapsList, { RoadmapItem } from "./RoadmapsList";
 import TasksManager from "./TasksManager";
-import { useTonSession } from "@/hooks/useTonSession";
+import { useNearSession } from "@/hooks/useNearSession";
 import { db } from "@/integrations/db";
 import { toast } from "@/hooks/use-toast";
 import { Button } from "@/components/ui/button";
@@ -15,7 +15,7 @@ import { setActiveRoadmap, fetchNextTask } from "@/modules/roadmaps";
 import { useChatInputFocus } from "@/hooks/useChatInputFocus";
  
 export default function RoadmapsManager() {
-  const { user } = useTonSession();
+  const { user } = useNearSession();
   const [items, setItems] = useState<RoadmapItem[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [showAll, setShowAll] = useState(false);

--- a/src/components/control/TasksManager.tsx
+++ b/src/components/control/TasksManager.tsx
@@ -3,7 +3,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { useTonSession } from "@/hooks/useTonSession";
+import { useNearSession } from "@/hooks/useNearSession";
 import { db } from "@/integrations/db";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { toast } from "@/hooks/use-toast";
@@ -22,7 +22,7 @@ export type Task = {
 };
 
 export default function TasksManager({ roadmapId }: { roadmapId: string }) {
-  const { user } = useTonSession();
+  const { user } = useNearSession();
   if (!requirePro()) {
     return (
       <div className="p-4 text-center space-y-2">

--- a/src/components/goals/GoalForm.tsx
+++ b/src/components/goals/GoalForm.tsx
@@ -3,10 +3,10 @@ import { useState } from "react";
 import { db } from "@/integrations/db";
 import { Button } from "@/components/ui/button";
 import { toast } from "@/hooks/use-toast";
-import { useTonSession } from "@/hooks/useTonSession";
+import { useNearSession } from "@/hooks/useNearSession";
 
 export default function GoalForm() {
-  const { user } = useTonSession();
+  const { user } = useNearSession();
   const [title, setTitle] = useState("");
   const [why, setWhy] = useState("");
   const [nextAction, setNextAction] = useState("");

--- a/src/components/goals/GoalsList.tsx
+++ b/src/components/goals/GoalsList.tsx
@@ -2,7 +2,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { db } from "@/integrations/db";
 import { Button } from "@/components/ui/button";
-import { useTonSession } from "@/hooks/useTonSession";
+import { useNearSession } from "@/hooks/useNearSession";
 import { toast } from "@/hooks/use-toast";
 
 type Goal = {
@@ -24,7 +24,7 @@ async function fetchGoals() {
 }
 
 export default function GoalsList() {
-  const { user } = useTonSession();
+  const { user } = useNearSession();
   const qc = useQueryClient();
 
   const { data, isLoading, error } = useQuery({

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -3,10 +3,10 @@ import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { SoundControl } from "@/components/sounds/SoundControl";
 import { AuthMenu } from "@/components/auth/AuthMenu";
-import { useTonSession } from "@/hooks/useTonSession";
+import { useNearSession } from "@/hooks/useNearSession";
 
 export default function AppHeader() {
-  const { user, initializing } = useTonSession();
+  const { user, initializing } = useNearSession();
   const navigate = useNavigate();
   const [online, setOnline] = useState(true);
   const headerRef = useRef<HTMLElement>(null);

--- a/src/components/live/CurrentFocusCard.tsx
+++ b/src/components/live/CurrentFocusCard.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { toast } from "@/hooks/use-toast";
 import { db } from "@/integrations/db";
-import { useTonSession } from "@/hooks/useTonSession";
+import { useNearSession } from "@/hooks/useNearSession";
 import { awardXPRemote } from "@/integrations/db";
 import { award } from "@/game/gamification/award";
 import { useState } from "react";
@@ -34,7 +34,7 @@ export function CurrentFocusCard({
   progressPercent?: number;
   onAdvance: () => void;
 }) {
-  const { user } = useTonSession();
+  const { user } = useNearSession();
   const [busy, setBusy] = useState(false);
 
   const markDoneAndAdvance = async () => {

--- a/src/components/live/DailyKickoff.tsx
+++ b/src/components/live/DailyKickoff.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { useTonSession } from "@/hooks/useTonSession";
+import { useNearSession } from "@/hooks/useNearSession";
 import { db } from "@/integrations/db";
 import { MoodCheck } from "./MoodCheck";
 
@@ -13,7 +13,7 @@ interface Props {
 type Task = { id: string; title: string };
 
 export default function DailyKickoff({ visible, onComplete }: Props) {
-  const { user } = useTonSession();
+  const { user } = useNearSession();
   const [tasks, setTasks] = useState<Task[]>([]);
   const [selected, setSelected] = useState<string | undefined>(undefined);
 

--- a/src/components/live/HeroCard.tsx
+++ b/src/components/live/HeroCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { Flame } from "lucide-react";
-import { useTonSession } from "@/hooks/useTonSession";
+import { useNearSession } from "@/hooks/useNearSession";
 import { db } from "@/integrations/db";
 
 interface HeroCardProps {
@@ -8,7 +8,7 @@ interface HeroCardProps {
 }
 
 export default function HeroCard({ taskTitle }: HeroCardProps) {
-  const { user } = useTonSession();
+  const { user } = useNearSession();
   const [xp, setXp] = useState(0);
   const [mood, setMood] = useState<string | null>(null);
 

--- a/src/components/live/LiveFocusView.tsx
+++ b/src/components/live/LiveFocusView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useTonSession } from '@/hooks/useTonSession';
+import { useNearSession } from '@/hooks/useNearSession';
 import { db } from '@/integrations/db';
 import { toast } from '@/hooks/use-toast';
 import { Button } from '@/components/ui/button';
@@ -18,7 +18,7 @@ type Roadmap = {
 
 
 export default function LiveFocusView() {
-  const { user, initializing } = useTonSession();
+  const { user, initializing } = useNearSession();
   const [activeRoadmap, setActiveRoadmap] = useState<Roadmap | null>(null);
   const [roadmaps, setRoadmaps] = useState<Roadmap[]>([]);
   const [task, setTask] = useState<Task | null>(null);

--- a/src/components/live/StreakBadge.tsx
+++ b/src/components/live/StreakBadge.tsx
@@ -1,10 +1,10 @@
 import { Flame } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import { useTonSession } from "@/hooks/useTonSession";
+import { useNearSession } from "@/hooks/useNearSession";
 import { db } from "@/integrations/db";
 
 export function StreakBadge() {
-  const { user } = useTonSession();
+  const { user } = useNearSession();
   const [streak, setStreak] = useState<number>(0);
   const [spark, setSpark] = useState(false);
   const prev = useRef(0);

--- a/src/components/live/XPBar.tsx
+++ b/src/components/live/XPBar.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useTonSession } from "@/hooks/useTonSession";
+import { useNearSession } from "@/hooks/useNearSession";
 import { db } from "@/integrations/db";
 import { Progress } from "@/components/ui/progress";
 
 export function XPBar() {
-  const { user } = useTonSession();
+  const { user } = useNearSession();
   const [total, setTotal] = useState<number>(0);
   const [spark, setSpark] = useState(false);
   const prevLevel = useRef(1);

--- a/src/components/modals/TasksModal.tsx
+++ b/src/components/modals/TasksModal.tsx
@@ -2,12 +2,12 @@ import { useEffect, useState } from "react";
 import { DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import TasksManager from "@/components/control/TasksManager";
 import { useUIStore } from "@/state/ui";
-import { useTonSession } from "@/hooks/useTonSession";
+import { useNearSession } from "@/hooks/useNearSession";
 import { db } from "@/integrations/db";
 
 export default function TasksModal() {
   const tasksRoadmapId = useUIStore((s) => s.tasksRoadmapId);
-  const { user } = useTonSession();
+  const { user } = useNearSession();
   const [defaultId, setDefaultId] = useState<string | null>(null);
 
   useEffect(() => {

--- a/src/components/share/ShareCard.tsx
+++ b/src/components/share/ShareCard.tsx
@@ -1,6 +1,6 @@
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { useTonSession } from "@/hooks/useTonSession";
+import { useNearSession } from "@/hooks/useNearSession";
 import { useEffect, useMemo, useRef, useState } from "react";
 import * as htmlToImage from "html-to-image";
 import { toast } from "@/hooks/use-toast";
@@ -15,7 +15,7 @@ interface Props {
 }
 
 export default function ShareCard({ open, onOpenChange, progressPercent }: Props) {
-  const { user } = useTonSession();
+  const { user } = useNearSession();
   const focusChatInput = useChatInputFocus();
   const nodeRef = useRef<HTMLDivElement | null>(null);
   const [imgUrl, setImgUrl] = useState<string | null>(null);

--- a/src/hooks/useBackgroundAudio.tsx
+++ b/src/hooks/useBackgroundAudio.tsx
@@ -1,7 +1,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { db } from "@/integrations/db";
-import { useTonSession } from "@/hooks/useTonSession";
+import { useNearSession } from "@/hooks/useNearSession";
 import { toast } from "@/hooks/use-toast";
 import logger from "@/lib/logger";
 
@@ -22,7 +22,7 @@ type Sound = {
 };
 
 export function useBackgroundAudio() {
-  const { user } = useTonSession();
+  const { user } = useNearSession();
   const audioRef = useRef<HTMLAudioElement | null>(null);
 
   const [loading, setLoading] = useState(true);

--- a/src/hooks/useNearAuth.ts
+++ b/src/hooks/useNearAuth.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { getWallet } from "@/lib/near";
 
-export function useTonAuth() {
+export function useNearAuth() {
   const [address, setAddress] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 

--- a/src/hooks/useNearSession.ts
+++ b/src/hooks/useNearSession.ts
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
-import { useTonAuth } from "./useTonAuth";
+import { useNearAuth } from "./useNearAuth";
 
-export function useTonSession() {
-  const { address, logout } = useTonAuth();
+export function useNearSession() {
+  const { address, logout } = useNearAuth();
   const [initializing, setInitializing] = useState(true);
 
   useEffect(() => {

--- a/src/hooks/useWeeklyBrainBackup.ts
+++ b/src/hooks/useWeeklyBrainBackup.ts
@@ -1,11 +1,11 @@
 import { useEffect } from 'react';
 import { useLocalStorage } from './useLocalStorage';
-import { useTonSession } from './useTonSession';
+import { useNearSession } from './useNearSession';
 import { uploadToStorage } from '@/integrations/storage';
 import { exportEncryptedBrain } from '@/memory/brainBackup';
 
 export default function useWeeklyBrainBackup() {
-  const { user } = useTonSession();
+  const { user } = useNearSession();
   const [enabled] = useLocalStorage<boolean>('brain.backup.enabled', false);
   const [passphrase] = useLocalStorage<string>('brain.backup.passphrase', '');
 

--- a/src/hooks/useWeeklyReview.ts
+++ b/src/hooks/useWeeklyReview.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { db } from "@/integrations/db";
-import { useTonSession } from "./useTonSession";
+import { useNearSession } from "./useNearSession";
 
 /**
  * Weekly review hook
@@ -8,7 +8,7 @@ import { useTonSession } from "./useTonSession";
  * - Stores the next sprint id for quick access
  */
 export default function useWeeklyReview(missionId: string | null) {
-  const { user } = useTonSession();
+  const { user } = useNearSession();
 
   useEffect(() => {
     if (!user || !missionId) return;

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -2,10 +2,10 @@ import { useEffect } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { useTonAuth } from "@/hooks/useTonAuth";
+import { useNearAuth } from "@/hooks/useNearAuth";
 
 const AuthPage = () => {
-  const { address, login, loading } = useTonAuth();
+  const { address, login, loading } = useNearAuth();
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -24,13 +24,13 @@ const AuthPage = () => {
       <Card className="w-full max-w-sm p-6 space-y-4">
         <div className="space-y-1">
           <h1 className="text-xl font-semibold">Connect Wallet</h1>
-          <p className="text-sm text-muted-foreground">Use your TON wallet to sign in.</p>
+          <p className="text-sm text-muted-foreground">Use your NEAR wallet to sign in.</p>
         </div>
         <div className="flex justify-center">
           {loading ? (
             <p className="text-sm text-muted-foreground">Connecting...</p>
           ) : (
-            <Button onClick={connect}>Connect TON Wallet</Button>
+            <Button onClick={connect}>Connect NEAR Wallet</Button>
           )}
         </div>
         <div className="text-xs">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -12,7 +12,7 @@ import GameHome from '@/game/path/GameHome';
 import ArchivePanel from '@/components/archive/ArchivePanel';
 import { PanelHeaderUnified } from '@/components/layout/PanelHeaderUnified';
 import DailyKickoff from '@/components/live/DailyKickoff';
-import { useTonSession } from '@/hooks/useTonSession';
+import { useNearSession } from '@/hooks/useNearSession';
 import LandingPage from './LandingPage';
 import { type PathNode } from '@/game/path/path.data';
 import FastTravel from '@/components/overlays/FastTravel';
@@ -398,7 +398,7 @@ const Index = () => {
     gotoPanel,
   } = useSwipeNavigation();
   const [showKickoff, setShowKickoff] = useState(false);
-  const { user, initializing } = useTonSession();
+  const { user, initializing } = useNearSession();
 
   const completeQuest = useGameStore((s) => s.completeQuest);
   const resetDaily = useGameStore((s) => s.resetDaily);

--- a/src/pages/OnboardingFlow.tsx
+++ b/src/pages/OnboardingFlow.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { db } from "@/integrations/db";
-import { useTonSession } from "@/hooks/useTonSession";
+import { useNearSession } from "@/hooks/useNearSession";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Progress } from "@/components/ui/progress";
@@ -110,7 +110,7 @@ const getNextState = (
 type Phase = "start" | "question" | "summary";
 
 export default function OnboardingFlow() {
-  const { user } = useTonSession();
+  const { user } = useNearSession();
   const navigate = useNavigate();
 
   // SINGLE instance

--- a/src/routes/AppShell.tsx
+++ b/src/routes/AppShell.tsx
@@ -11,7 +11,7 @@ import { bus } from "@/utils/bus";
 import { useViewNav } from "@/state/view";
 import { useXPChime } from "@/hooks/useXPChime";
 import { useSwipeNav } from "@/hooks/useSwipeNav";
-import { useTonSession } from "@/hooks/useTonSession";
+import { useNearSession } from "@/hooks/useNearSession";
 import useDailyCheckIn from "@/hooks/useDailyCheckIn";
 import useWeeklyBrainBackup from "@/hooks/useWeeklyBrainBackup";
 import { useKeyboardOffset } from "@/hooks/useKeyboardOffset";
@@ -19,7 +19,7 @@ import AppHeader from "@/components/layout/AppHeader";
 import { useUIStore } from "@/state/ui";
 
 export default function AppShell() {
-  const { user, initializing } = useTonSession();
+  const { user, initializing } = useNearSession();
   const loc = useLocation();
   const open = useViewNav();
 

--- a/src/views/MasterPlanView.tsx
+++ b/src/views/MasterPlanView.tsx
@@ -9,7 +9,7 @@ import { useChatInputFocus } from "@/hooks/useChatInputFocus";
 import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { db } from "@/integrations/db";
-import { useTonSession } from "@/hooks/useTonSession";
+import { useNearSession } from "@/hooks/useNearSession";
 import { toast } from "@/hooks/use-toast";
 import { usePlanUpdater } from "@/hooks/usePlanUpdater";
 import { UserProfile } from "@/data/profile";
@@ -34,7 +34,7 @@ interface DBHabit {
 
 export default function MasterPlanView() {
   const focusChatInput = useChatInputFocus();
-  const { user } = useTonSession();
+  const { user } = useNearSession();
   const [dbPlan, setDbPlan] = useState<MasterPlan | null>(null);
   const { plan: plan, update } = usePlanUpdater(dbPlan as any);
   const [profile, setProfile] = useState<UserProfile>({ history: [] });

--- a/src/views/PlanView.tsx
+++ b/src/views/PlanView.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { db } from "@/integrations/db";
-import { useTonSession } from "@/hooks/useTonSession";
+import { useNearSession } from "@/hooks/useNearSession";
 import useWeeklyReview from "@/hooks/useWeeklyReview";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
@@ -11,7 +11,7 @@ interface Sprint { id: string; title: string; start_date: string | null; end_dat
 interface Task { id: string; title: string; sprint_id: string }
 
 export default function PlanView() {
-  const { user } = useTonSession();
+  const { user } = useNearSession();
   const [params] = useSearchParams();
   const missionId = params.get("mission_id");
 

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { useTonSession } from "@/hooks/useTonSession";
+import { useNearSession } from "@/hooks/useNearSession";
 import { toast } from "@/hooks/use-toast";
 import { exportProfile, deleteProfile } from "@/lib/storage";
 import {
@@ -25,7 +25,7 @@ import DeviceManagerPanel from "@/components/settings/DeviceManagerPanel";
 
 
 export default function SettingsView() {
-  const { user, logout } = useTonSession();
+  const { user, logout } = useNearSession();
 
   const signOut = async () => {
     try {

--- a/src/views/__tests__/MasterPlanView.test.tsx
+++ b/src/views/__tests__/MasterPlanView.test.tsx
@@ -25,8 +25,8 @@ const mockPlan = {
   plan_versions: [],
 };
 
-jest.mock('@/hooks/useTonSession', () => ({
-  useTonSession: () => ({ user: { id: '1' } }),
+jest.mock('@/hooks/useNearSession', () => ({
+  useNearSession: () => ({ user: { id: '1' } }),
 }));
 
 jest.mock('@/hooks/usePlanUpdater', () => ({


### PR DESCRIPTION
## Summary
- replace TonConnect auth with NEAR wallet auth via `useNearAuth`
- expose `{id, email}` using new `useNearSession`
- update components and auth page to consume new NEAR hooks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6038679188326a3ca2a9c68e5428a