### PR TITLE
Use NEAR key to derive onboarding encryption key

### DIFF
--- a/src/pages/OnboardingFlow.tsx
+++ b/src/pages/OnboardingFlow.tsx
@@ -18,6 +18,7 @@ import {
 import { setMemoryKey } from "@/memory/indexedDbMemory";
 import { deriveDataKey } from "@/state/keyManager";
 import { Volume2 } from "lucide-react";
+import { keyStores } from "near-api-js";
 
 
 type Msg = { role: "assistant" | "user"; content: string };
@@ -159,9 +160,17 @@ export default function OnboardingFlow() {
       try {
         const passcode = window.prompt("Set a passcode to secure your data") || "";
         if (!passcode) return;
-        const random = crypto.getRandomValues(new Uint8Array(64));
-        const signature = Array.from(random).map((b) => b.toString(16).padStart(2, "0")).join("");
-        const keyBytes = await deriveDataKey(signature, passcode);
+
+        const keyStore = new keyStores.BrowserLocalStorageKeyStore();
+        const networkId = import.meta.env.VITE_NEAR_NETWORK_ID as string;
+        const keyPair = await keyStore.getKey(networkId, user.id);
+        if (!keyPair) throw new Error("No local key found");
+        const message = new TextEncoder().encode("aurora-derive-key");
+        const { signature } = keyPair.sign(message);
+        const signatureHex = Array.from(signature)
+          .map((b) => b.toString(16).padStart(2, "0"))
+          .join("");
+        const keyBytes = await deriveDataKey(signatureHex, passcode);
         const keyHex = Array.from(keyBytes)
           .map((b) => b.toString(16).padStart(2, "0"))
           .join("");


### PR DESCRIPTION
## Summary
- Sign a fixed message with the NEAR account's local key and use that signature for encryption key derivation

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_68c60a2d36048326a642d3ff50d50f4a