### PR TITLE
refactor: replace Ton user helper with NEAR wallet

### DIFF
--- a/src/components/VoiceSetup.tsx
+++ b/src/components/VoiceSetup.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
 import { Mic, Square } from "lucide-react";
 import { db } from "@/integrations/db";
-import { getTonUser } from "@/integrations/auth";
+import { getNearUser } from "@/integrations/auth";
 
 export default function VoiceSetup() {
   const {
@@ -46,7 +46,7 @@ export default function VoiceSetup() {
         setMode("cloned");
         setLocale(navigator.language || "en-US");
         try {
-          const auth = await getTonUser();
+          const auth = await getNearUser();
           const uid = auth?.id;
           if (uid) {
             const { data: prof } = await db

--- a/src/components/home/QuickPodsRow.tsx
+++ b/src/components/home/QuickPodsRow.tsx
@@ -9,7 +9,7 @@ import { awardXPRemote } from "@/integrations/db";
 import { award } from "@/game/gamification/award";
 import FocusRunner from "@/nodes/FocusRunner";
 import { useChatInputFocus } from "@/hooks/useChatInputFocus";
-import { getTonUser } from "@/integrations/auth";
+import { getNearUser } from "@/integrations/auth";
 import { uploadToStorage } from "@/integrations/storage";
 
 const pods: { key: string; label: string; icon: LucideIcon }[] = [
@@ -43,7 +43,7 @@ export function QuickPodsRow() {
   };
   const [noteText, setNoteText] = useState("");
   const saveNote = async () => {
-    const user = await getTonUser();
+    const user = await getNearUser();
     if (!user) {
       toast({ title: "Sign in required", description: "Sign in to capture notes." });
       return;
@@ -80,7 +80,7 @@ export function QuickPodsRow() {
   const timerRef = useRef<number | null>(null);
 
   const startRecording = async () => {
-    const authUser = await getTonUser();
+    const authUser = await getNearUser();
     if (!authUser) {
       toast({ title: "Sign in required", description: "Sign in to record voice notes." });
       return;

--- a/src/components/hypno/HypnoPanel.tsx
+++ b/src/components/hypno/HypnoPanel.tsx
@@ -6,7 +6,7 @@ import { REWARDS } from "@/game/QuestEngine";
 import { award } from "@/game/gamification/award";
 import { db } from "@/integrations/db";
 import { logEvent } from "@/integrations/db";
-import { getTonUser } from "@/integrations/auth";
+import { getNearUser } from "@/integrations/auth";
 import { DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 
@@ -33,7 +33,7 @@ export default function HypnoPanel({ onClose }: Props) {
     award({ xp: REWARDS.completeQuest });
 
     // Server: create a session start row (if signed-in)
-    const user = await getTonUser();
+    const user = await getNearUser();
     const uid = user?.id;
     if (uid) {
       try {

--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { awardXPRemote, upsertQuest, logEvent } from "@/integrations/db";
 import { db } from "@/integrations/db";
-import { getTonUser } from "@/integrations/auth";
+import { getNearUser } from "@/integrations/auth";
 import logger from "@/lib/logger";
 
 export type Stats = { hp: number; mp: number; xp: number; level: number; streak: number };
@@ -68,7 +68,7 @@ export const useGameStore = create<GameState>((set, get) => {
   return {
     ...init,
     fetchStats: async () => {
-      const user = await getTonUser();
+      const user = await getNearUser();
       if (!user) return;
       const { data: stats } = await db
         .from("user_stats")

--- a/src/integrations/auth.ts
+++ b/src/integrations/auth.ts
@@ -5,7 +5,7 @@ export interface AuthUser {
   email: string;
 }
 
-export async function getTonUser(): Promise<AuthUser | null> {
+export async function getNearUser(): Promise<AuthUser | null> {
   const wallet = await getWallet();
   const accountId = wallet.getAccountId();
   return accountId ? { id: accountId, email: accountId } : null;

--- a/src/state/quickActions.ts
+++ b/src/state/quickActions.ts
@@ -9,7 +9,7 @@ import {
 import { registerQuickAction } from "@/components/navigation/quickActions";
 import { useUIStore } from "@/state/ui";
 import { db } from "@/integrations/db";
-import { getTonUser } from "@/integrations/auth";
+import { getNearUser } from "@/integrations/auth";
 
 registerQuickAction({
   id: "journal",
@@ -30,7 +30,7 @@ registerQuickAction({
   label: "Tasks",
   icon: ListTodo,
   onClick: async () => {
-    const user = await getTonUser();
+    const user = await getNearUser();
 
     let roadmapId: string | undefined;
 

--- a/src/utils/moments.ts
+++ b/src/utils/moments.ts
@@ -1,10 +1,10 @@
 import { db } from "@/integrations/db";
 import { toast } from "@/hooks/use-toast";
-import { getTonUser } from "@/integrations/auth";
+import { getNearUser } from "@/integrations/auth";
 import { uploadToStorage } from "@/integrations/storage";
 
 export async function addNote() {
-  const user = await getTonUser();
+  const user = await getNearUser();
 
   if (!user) {
     toast({ title: "Sign in required", description: "Sign in to capture notes." });
@@ -29,7 +29,7 @@ export async function addNote() {
 }
 
 export async function startVoiceNote() {
-  const user = await getTonUser();
+  const user = await getNearUser();
   if (!user) {
     toast({ title: "Sign in required", description: "Sign in to record voice notes." });
     return;


### PR DESCRIPTION
## Summary
- replace `getTonUser` with NEAR-based `getNearUser`
- update components and utilities to use `getNearUser`

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, no-empty, react-hooks/rules-of-hooks, and more)*

------
https://chatgpt.com/codex/tasks/task_e_68c6168aa1cc83268c595e86bb256607