### PR TITLE
docs: replace TON references with NEAR

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,7 @@ ELEVENLABS_API_KEY=your_elevenlabs_api_key
 VITE_ELEVENLABS_DEFAULT_VOICE_ID=21m00Tcm4TlvDq8ikWAM
 ELEVENLABS_DEFAULT_VOICE_ID=21m00Tcm4TlvDq8ikWAM
 VITE_PUBLIC_ORIGIN=
+VITE_NEAR_NETWORK_ID=testnet
+VITE_NEAR_NODE_URL=https://rpc.testnet.near.org
+VITE_NEAR_WALLET_URL=https://wallet.testnet.near.org
+VITE_NEAR_HELPER_URL=https://helper.testnet.near.org

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,4 +4,4 @@ Key guides and references:
 
 - [Data Backup](./backup.md)
 - [Offline Mode](./offline-mode.md)
-- TON wallet authentication requires connecting to the TON testnet.
+- [NEAR Wallet Setup](./near-wallet.md)

--- a/docs/near-wallet.md
+++ b/docs/near-wallet.md
@@ -1,0 +1,12 @@
+# NEAR Wallet Setup
+
+To authenticate with a NEAR wallet in development, set the following environment variables in your `.env` file:
+
+```
+VITE_NEAR_NETWORK_ID=testnet
+VITE_NEAR_NODE_URL=https://rpc.testnet.near.org
+VITE_NEAR_WALLET_URL=https://wallet.testnet.near.org
+VITE_NEAR_HELPER_URL=https://helper.testnet.near.org
+```
+
+These defaults connect to the NEAR testnet. Use mainnet endpoints if you deploy to production.

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -44,7 +44,7 @@ const copy = {
   },
   faq: [
     { q: "Is it free?", a: "Yes, start free. Upgrade options may come later." },
-    { q: "Do I need a credit card?", a: "No. Just connect your TON wallet to sign in." },
+    { q: "Do I need a credit card?", a: "No. Just connect your NEAR wallet to sign in." },
     { q: "Will it work on mobile?", a: "Yes. It's built mobile-first and safe-area aware." }
   ],
   footer: {


### PR DESCRIPTION
## Summary
- document NEAR wallet setup and env vars
- add NEAR env defaults in `.env.example`
- update landing page copy to mention NEAR wallet

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68c6169b412c83269fa7e775fabe7af8