### PR TITLE
feat(chat): add waku messaging layer

### DIFF
--- a/src/components/chat/ChatDrawer.tsx
+++ b/src/components/chat/ChatDrawer.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import { cn } from '@/lib/utils';
 import { useOnboardingStore } from '@/state/onboarding';
 import { useChatStore } from '@/state/chat';
+import { useWakuChat } from '@/hooks/useWakuChat';
 import { Button } from '@/components/ui/button';
 import { ChevronUp } from 'lucide-react';
 
@@ -15,8 +16,17 @@ export function ChatDrawer() {
     suggestion,
   } = useOnboardingStore();
   const { messages: chatMessages, sending: chatSending } = useChatStore();
-  const messages = hasRoadmap ? chatMessages : obMessages;
-  const sending = hasRoadmap ? chatSending : obSending;
+  const { messages: wakuMessages, sending: wakuSending, sendMessage } = useWakuChat();
+  const baseMessages = hasRoadmap ? chatMessages : obMessages;
+  const messages = [...baseMessages, ...wakuMessages];
+  const sending = (hasRoadmap ? chatSending : obSending) || wakuSending;
+
+  useEffect(() => {
+    const latest = baseMessages[baseMessages.length - 1];
+    if (latest) {
+      void sendMessage(latest.content, latest.role);
+    }
+  }, [baseMessages, sendMessage]);
 
   const [open, setOpen] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);

--- a/src/hooks/useWakuChat.ts
+++ b/src/hooks/useWakuChat.ts
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  createLightNode,
+  LightNode,
+  Protocols,
+  WakuMessage,
+} from "js-waku";
+
+export type WakuChatMessage = {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  timestamp?: number;
+};
+
+const CHAT_TOPIC = "/aurora-chat/1/plain";
+
+export function useWakuChat() {
+  const [node, setNode] = useState<LightNode | null>(null);
+  const [ready, setReady] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [messages, setMessages] = useState<WakuChatMessage[]>([]);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const n = await createLightNode({
+          defaultBootstrap: true,
+          protocols: [Protocols.LightPush, Protocols.Filter],
+        });
+        await n.start();
+        if (!mounted) {
+          await n.stop();
+          return;
+        }
+        setNode(n);
+        setReady(true);
+        await n.filter.subscribe([CHAT_TOPIC], (msg: WakuMessage) => {
+          if (!msg.payload) return;
+          try {
+            const decoded = new TextDecoder().decode(msg.payload);
+            const parsed = JSON.parse(decoded) as {
+              role: "user" | "assistant";
+              content: string;
+            };
+            setMessages((prev) => [
+              ...prev,
+              {
+                id: crypto.randomUUID(),
+                role: parsed.role,
+                content: parsed.content,
+                timestamp: msg.timestamp,
+              },
+            ]);
+          } catch {
+            const text = new TextDecoder().decode(msg.payload);
+            setMessages((prev) => [
+              ...prev,
+              {
+                id: crypto.randomUUID(),
+                role: "assistant",
+                content: text,
+                timestamp: msg.timestamp,
+              },
+            ]);
+          }
+        });
+      } catch (err) {
+        console.error("Failed to initialize Waku", err);
+      }
+    })();
+    return () => {
+      mounted = false;
+      node?.stop().catch(() => {});
+    };
+  }, []);
+
+  const sendMessage = useCallback(
+    async (content: string, role: "user" | "assistant" = "user") => {
+      if (!node) return;
+      setSending(true);
+      try {
+        const payload = JSON.stringify({ role, content });
+        await node.lightPush.push({
+          contentTopic: CHAT_TOPIC,
+          payload: new TextEncoder().encode(payload),
+        });
+      } finally {
+        setSending(false);
+      }
+    },
+    [node]
+  );
+
+  return { messages, sendMessage, ready, sending };
+}
+
+export default useWakuChat;


### PR DESCRIPTION
## Summary
- add `useWakuChat` hook to connect to js-waku and provide send/receive APIs
- wire `ChatDrawer` to the Waku hook to broadcast and display messages

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in types/*.d.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c617b86ea083269347156517bb1dba