### PR TITLE
feat: add NEAR Lake stream

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -4,6 +4,7 @@ import cookie from '@fastify/cookie';
 
 import authNear from './auth/near';
 import replicate from './replicate';
+import { startLakeStream } from './near/lake';
 
 const server = Fastify({ logger: true });
 
@@ -20,6 +21,7 @@ async function build() {
 const start = async () => {
   try {
     await build();
+    startLakeStream().catch((err) => server.log.error({ err }, 'Lake stream error'));
     const port = Number(process.env.PORT) || 3000;
     await server.listen({ port, host: '0.0.0.0' });
   } catch (err) {

--- a/server/near/lake.ts
+++ b/server/near/lake.ts
@@ -1,0 +1,28 @@
+import { EventEmitter } from 'events';
+import { startStream, types } from 'near-lake-framework';
+
+export const lakeEmitter = new EventEmitter();
+
+export async function startLakeStream(): Promise<void> {
+  const network = process.env.NEAR_NETWORK || 'testnet';
+  const startBlockHeight = Number(process.env.LAKE_START_BLOCK || '0');
+
+  const lakeConfig: types.LakeConfig = {
+    s3BucketName: network === 'mainnet' ? 'near-lake-data-mainnet' : 'near-lake-data-testnet',
+    s3RegionName: 'eu-central-1',
+    startBlockHeight,
+  };
+
+  await startStream(lakeConfig, (streamerMessage) => {
+    for (const shard of streamerMessage.shards) {
+      for (const outcome of shard.receiptExecutionOutcomes) {
+        const { receipt, executionOutcome } = outcome;
+        const receiver = receipt.receiverId || '';
+        const executor = executionOutcome.outcome.executorId || '';
+        if (receiver.includes('aurora') || executor.includes('aurora')) {
+          lakeEmitter.emit('aurora', { receipt, outcome: executionOutcome });
+        }
+      }
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add NEAR Lake streaming module and event emitter for Aurora-related events
- start block stream during server startup

## Testing
- `npm test` *(fails: ReferenceError: crypto is not defined)*
- `npm run lint` *(fails: many Unexpected any, React hooks warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c617c6a2388326bb288b7648f28145